### PR TITLE
refactor: simplify codebase per /simplify audit

### DIFF
--- a/src/microverse/_text.py
+++ b/src/microverse/_text.py
@@ -1,0 +1,173 @@
+"""Small text helpers shared across modules.
+
+Hosts:
+  - ``tokenize`` / ``jaccard`` — used by Elder lore-drift guard and
+    Watchdog echo-chamber detector. Two callers with slightly different
+    filters (Elder drops stop-words; Watchdog keeps them) so the helper
+    takes flags rather than mandating one rule.
+  - ``safe_json_loads`` — strict json → ``json_repair`` → strict json
+    ladder used by ``parse_action`` (agents.base) and
+    ``_safe_parse_scores`` (agents.trader). Returns ``None`` if neither
+    pass yields a value. Callers handle their own type-validation,
+    bytes-cap guards, and metric side effects.
+
+Lives at the package root so the agents and ops layers can both import
+without creating a memory→agents or agents→ops cycle.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from json_repair import repair_json
+
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+
+# Common English function words; their overlap inflates raw Jaccard
+# without signaling preservation of canon. Elder filters these from
+# both sides of a similarity comparison.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "but",
+        "of",
+        "to",
+        "in",
+        "on",
+        "at",
+        "for",
+        "with",
+        "by",
+        "from",
+        "as",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "it",
+        "its",
+        "this",
+        "that",
+        "these",
+        "those",
+        "they",
+        "them",
+        "their",
+        "we",
+        "us",
+        "our",
+        "you",
+        "your",
+        "he",
+        "she",
+        "his",
+        "her",
+        "him",
+        "i",
+        "my",
+        "me",
+        "do",
+        "does",
+        "did",
+        "have",
+        "has",
+        "had",
+        "not",
+        "no",
+        "so",
+        "if",
+        "then",
+        "than",
+        "when",
+        "while",
+        "where",
+        "what",
+        "who",
+        "whom",
+        "which",
+        "such",
+        "into",
+        "out",
+        "over",
+        "under",
+        "up",
+        "down",
+        "about",
+        "again",
+        "ever",
+        "always",
+        "never",
+        "all",
+        "any",
+        "some",
+        "each",
+        "every",
+        "more",
+        "most",
+        "less",
+        "least",
+        "very",
+        "much",
+        "also",
+        "just",
+    }
+)
+
+
+def tokenize(text: str, *, min_len: int = 1, drop_stopwords: bool = False) -> set[str]:
+    """Lowercase token-set extraction with optional length and stop-word filters."""
+    if drop_stopwords:
+        return {
+            t.lower()
+            for t in _TOKEN_RE.findall(text)
+            if len(t) >= min_len and t.lower() not in _STOPWORDS
+        }
+    return {t.lower() for t in _TOKEN_RE.findall(text) if len(t) >= min_len}
+
+
+def jaccard(a: set[str], b: set[str]) -> float:
+    """Token-set Jaccard similarity.
+
+    Vacuous case (both empty) returns 1.0 — there is no signal, so
+    callers shouldn't trip drift/diversity detectors on empty inputs.
+    """
+    if not a and not b:
+        return 1.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / len(a | b)
+
+
+def safe_json_loads(raw: str) -> Any | None:
+    """Best-effort JSON parse: strict → ``json_repair`` → ``None``.
+
+    Returns the parsed object on success or ``None`` if both passes fail
+    or produce a non-object/non-list (``""``, ``{}`` and ``[]`` from a
+    bad repair are explicitly treated as failure so callers don't have
+    to special-case them).
+
+    Does NOT enforce a byte-size cap; callers that care about runaway
+    inputs (e.g. ``parse_action``) check ``MAX_PARSE_BYTES`` themselves
+    before calling this so they can attach their own metric side effects.
+    """
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
+
+    try:
+        repaired = repair_json(raw, return_objects=False)
+        if not repaired or repaired in ("{}", "[]", '""'):
+            return None
+        return json.loads(repaired)
+    except json.JSONDecodeError:
+        return None

--- a/src/microverse/_text.py
+++ b/src/microverse/_text.py
@@ -150,17 +150,22 @@ def jaccard(a: set[str], b: set[str]) -> float:
 def safe_json_loads(raw: str) -> Any | None:
     """Best-effort JSON parse: strict → ``json_repair`` → ``None``.
 
-    Returns the parsed object on success or ``None`` if both passes fail
-    or produce a non-object/non-list (``""``, ``{}`` and ``[]`` from a
-    bad repair are explicitly treated as failure so callers don't have
-    to special-case them).
+    Returns the parsed object only if it is a *non-empty* dict or list.
+    Anything else (parse failure, scalar, ``""``, ``{}``, ``[]``) yields
+    ``None`` so callers don't have to special-case them.
 
     Does NOT enforce a byte-size cap; callers that care about runaway
     inputs (e.g. ``parse_action``) check ``MAX_PARSE_BYTES`` themselves
     before calling this so they can attach their own metric side effects.
     """
+
+    def _container_or_none(value: Any) -> Any | None:
+        if isinstance(value, (dict, list)) and value:
+            return value
+        return None
+
     try:
-        return json.loads(raw)
+        return _container_or_none(json.loads(raw))
     except json.JSONDecodeError:
         pass
 
@@ -168,6 +173,6 @@ def safe_json_loads(raw: str) -> Any | None:
         repaired = repair_json(raw, return_objects=False)
         if not repaired or repaired in ("{}", "[]", '""'):
             return None
-        return json.loads(repaired)
+        return _container_or_none(json.loads(repaired))
     except json.JSONDecodeError:
         return None

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -22,9 +22,9 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
-from json_repair import repair_json
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from microverse._text import safe_json_loads
 from microverse.config import MAX_PARSE_BYTES
 
 if TYPE_CHECKING:
@@ -92,20 +92,18 @@ def parse_action(raw: str, *, metrics: Metrics, agent: str) -> Action:
         metrics.bump("consecutive_fail", agent=agent)
         return _rest_action()
 
-    # 1. Strict
+    # Strict pass first; bumps json_ok on success.
     try:
-        data = json.loads(raw)
+        strict = json.loads(raw)
     except json.JSONDecodeError:
-        data = None
-
-    if isinstance(data, dict):
+        strict = None
+    if isinstance(strict, dict):
         try:
-            action = Action.model_validate(data)
-            # Meta-reference guard: if the agent's own words break the
-            # in-world fiction, fall back to rest. Different counter
-            # from json_fallback_rest so the watchdog can distinguish
-            # parse failures from immersion breaks.
+            action = Action.model_validate(strict)
             if has_meta_leak(action.thought) or has_meta_leak(action.artifact or ""):
+                # Different counter from json_fallback_rest so the
+                # watchdog can distinguish parse failures from
+                # immersion breaks.
                 metrics.bump("meta_leak_block", agent=agent)
                 return _rest_action()
             metrics.bump("json_ok")
@@ -114,25 +112,23 @@ def parse_action(raw: str, *, metrics: Metrics, agent: str) -> Action:
         except ValidationError:
             pass
 
-    # 2. Repair
-    try:
-        repaired = repair_json(raw, return_objects=False)
-        if not repaired or repaired in ("{}", "[]", '""'):
-            raise ValueError("repair produced empty / non-action shape")
-        repaired_data = json.loads(repaired)
-        if not isinstance(repaired_data, dict):
-            raise ValueError("repair did not produce an object")
-        action = Action.model_validate(repaired_data)
-        if has_meta_leak(action.thought) or has_meta_leak(action.artifact or ""):
-            metrics.bump("meta_leak_block", agent=agent)
-            return _rest_action()
-        metrics.bump("json_repaired")
-        metrics.reset("consecutive_fail", agent=agent)
-        return action
-    except (json.JSONDecodeError, ValidationError, ValueError):
-        pass
+    # Repair pass: shared helper handles the strict-or-repair retry; we
+    # validate the repaired object here and bump json_repaired only on
+    # success so the metric stays tied to "needed repair".
+    repaired = safe_json_loads(raw)
+    if isinstance(repaired, dict):
+        try:
+            action = Action.model_validate(repaired)
+        except ValidationError:
+            action = None
+        if action is not None:
+            if has_meta_leak(action.thought) or has_meta_leak(action.artifact or ""):
+                metrics.bump("meta_leak_block", agent=agent)
+                return _rest_action()
+            metrics.bump("json_repaired")
+            metrics.reset("consecutive_fail", agent=agent)
+            return action
 
-    # 3. Fallback
     metrics.bump("json_fallback_rest")
     metrics.bump("consecutive_fail", agent=agent)
     return _rest_action()

--- a/src/microverse/agents/elder.py
+++ b/src/microverse/agents/elder.py
@@ -11,9 +11,9 @@ with a continuity hint, then keep the prior on continued drift.
 from __future__ import annotations
 
 import logging
-import re
 from typing import TYPE_CHECKING
 
+from microverse._text import jaccard, tokenize
 from microverse.agents.base import Action, ActionKind, Agent, WorldContext
 from microverse.config import LLM_MAX_TOKENS, LLM_TIMEOUT_S, SAMPLING_FACTUAL
 from microverse.llm.ollama_client import chat
@@ -27,125 +27,15 @@ _logger = logging.getLogger(__name__)
 _PERSONA_TEMPLATE = "compression.j2"
 MIN_JACCARD = 0.35
 
-_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
-# Common English function words; their overlap inflates raw Jaccard
-# without signaling preservation of canon. Filter them from both sides.
-_STOP = frozenset(
-    {
-        "the",
-        "a",
-        "an",
-        "and",
-        "or",
-        "but",
-        "of",
-        "to",
-        "in",
-        "on",
-        "at",
-        "for",
-        "with",
-        "by",
-        "from",
-        "as",
-        "is",
-        "are",
-        "was",
-        "were",
-        "be",
-        "been",
-        "being",
-        "it",
-        "its",
-        "this",
-        "that",
-        "these",
-        "those",
-        "they",
-        "them",
-        "their",
-        "we",
-        "us",
-        "our",
-        "you",
-        "your",
-        "he",
-        "she",
-        "his",
-        "her",
-        "him",
-        "i",
-        "my",
-        "me",
-        "do",
-        "does",
-        "did",
-        "have",
-        "has",
-        "had",
-        "not",
-        "no",
-        "so",
-        "if",
-        "then",
-        "than",
-        "when",
-        "while",
-        "where",
-        "what",
-        "who",
-        "whom",
-        "which",
-        "such",
-        "into",
-        "out",
-        "over",
-        "under",
-        "up",
-        "down",
-        "about",
-        "again",
-        "ever",
-        "always",
-        "never",
-        "all",
-        "any",
-        "some",
-        "each",
-        "every",
-        "more",
-        "most",
-        "less",
-        "least",
-        "very",
-        "much",
-        "also",
-        "just",
-    }
-)
-
-
-def _signal_tokens(text: str) -> set[str]:
-    """Tokens that actually signal canonical content: lowercase, ≥3
-    chars, not in the stop list. Phase 3b uses these for drift Jaccard.
-    """
-    return {t.lower() for t in _TOKEN_RE.findall(text) if len(t) >= 3 and t.lower() not in _STOP}
-
 
 def lore_jaccard(a: str, b: str) -> float:
-    """Token-set Jaccard similarity over *signal* tokens (case-folded,
-    stop-words and short tokens dropped).
-
-    Vacuous case (both empty after filtering) returns 1.0 — there is no
-    drift signal, so we don't trigger the guard on a fresh world.
+    """Token-set Jaccard over signal tokens (case-folded, stop-words and
+    sub-3-char tokens dropped).
     """
-    tokens_a = _signal_tokens(a)
-    tokens_b = _signal_tokens(b)
-    if not tokens_a and not tokens_b:
-        return 1.0
-    if not tokens_a or not tokens_b:
-        return 0.0
-    return len(tokens_a & tokens_b) / len(tokens_a | tokens_b)
+    return jaccard(
+        tokenize(a, min_len=3, drop_stopwords=True),
+        tokenize(b, min_len=3, drop_stopwords=True),
+    )
 
 
 class Elder(Agent):

--- a/src/microverse/agents/trader.py
+++ b/src/microverse/agents/trader.py
@@ -14,12 +14,11 @@ the same length as the input. The pipeline never raises.
 
 from __future__ import annotations
 
-import json
 from typing import Any
 
-from json_repair import repair_json
 from pydantic import BaseModel, ConfigDict, Field
 
+from microverse._text import safe_json_loads
 from microverse.agents.base import Action, ActionKind, Agent, WorldContext
 from microverse.agents.harvester import ArtifactCandidate
 from microverse.config import LLM_MAX_TOKENS, LLM_TIMEOUT_S, MAX_PARSE_BYTES, SAMPLING_FACTUAL
@@ -81,18 +80,10 @@ def _safe_parse_scores(raw: str) -> list[dict[str, Any]]:
     """Best-effort parse: strict → json_repair → empty list."""
     if len(raw.encode("utf-8", errors="replace")) > MAX_PARSE_BYTES:
         return []
-    try:
-        return _extract_list(json.loads(raw))
-    except json.JSONDecodeError:
-        pass
-    try:
-        repaired = repair_json(raw, return_objects=False)
-        if not repaired:
-            return []
-        return _extract_list(json.loads(repaired))
-    except json.JSONDecodeError:
-        pass
-    return []
+    parsed = safe_json_loads(raw)
+    if parsed is None:
+        return []
+    return _extract_list(parsed)
 
 
 def _coerce_score(entry: dict[str, Any], artifact_id: int) -> Score:

--- a/src/microverse/llm/ollama_client.py
+++ b/src/microverse/llm/ollama_client.py
@@ -19,6 +19,7 @@ caring about the ollama package's response object types.
 
 from __future__ import annotations
 
+import functools
 import threading
 from typing import Any
 
@@ -39,6 +40,18 @@ def _bump_leak() -> None:
         thinking_leak += 1
 
 
+@functools.lru_cache(maxsize=4)
+def _get_client(timeout_s: float) -> ollama.Client:
+    """Cache one ``ollama.Client`` per distinct timeout.
+
+    The client wraps ``httpx.Client``, which holds a connection pool —
+    rebuilding it on every call is wasteful. ``lru_cache`` is thread-safe
+    in CPython, and ``maxsize=4`` is enough for the default plus a few
+    custom-timeout call sites without unbounded growth.
+    """
+    return ollama.Client(timeout=timeout_s)
+
+
 def chat(
     messages: list[dict[str, str]],
     *,
@@ -51,7 +64,7 @@ def chat(
 
     Returns ``{"content": str, "thinking": str, "raw": dict}``.
     """
-    client = ollama.Client(timeout=timeout_s)
+    client = _get_client(timeout_s)
 
     response = client.chat(
         model=MODEL,

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -17,9 +17,7 @@ single-model loop where we control prompt shape.
 
 from __future__ import annotations
 
-import sqlite3
 import time
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from microverse.agents.base import WorldContext
@@ -30,26 +28,6 @@ if TYPE_CHECKING:
 
 
 SEVEN_DAYS_S: float = 7 * 24 * 3600.0
-
-
-def open_sqlite_wal(path: str | Path) -> sqlite3.Connection:
-    """Open a SQLite connection with the project's standard durability
-    pragmas (WAL + ``synchronous=NORMAL``).
-
-    Strict by default: file-backed paths that fail to enter WAL raise.
-    The ``:memory:`` carve-out exists because in-memory dbs always report
-    ``"memory"`` from ``PRAGMA journal_mode`` — no durability surface to
-    defend, so don't fail. ``check_same_thread=False`` so the watchdog
-    can read while the tick loop writes; callers serialize logically.
-    """
-    conn = sqlite3.connect(str(path), check_same_thread=False)
-    mode_row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
-    actual_mode = str(mode_row[0]).lower() if mode_row else ""
-    if str(path) != ":memory:" and actual_mode != "wal":
-        conn.close()
-        raise RuntimeError(f"failed to enable WAL on db {path!r}; got mode={mode_row}")
-    conn.execute("PRAGMA synchronous=NORMAL")
-    return conn
 
 
 def est_tokens(text: str) -> int:

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -17,7 +17,9 @@ single-model loop where we control prompt shape.
 
 from __future__ import annotations
 
+import sqlite3
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from microverse.agents.base import WorldContext
@@ -28,6 +30,26 @@ if TYPE_CHECKING:
 
 
 SEVEN_DAYS_S: float = 7 * 24 * 3600.0
+
+
+def open_sqlite_wal(path: str | Path) -> sqlite3.Connection:
+    """Open a SQLite connection with the project's standard durability
+    pragmas (WAL + ``synchronous=NORMAL``).
+
+    Strict by default: file-backed paths that fail to enter WAL raise.
+    The ``:memory:`` carve-out exists because in-memory dbs always report
+    ``"memory"`` from ``PRAGMA journal_mode`` — no durability surface to
+    defend, so don't fail. ``check_same_thread=False`` so the watchdog
+    can read while the tick loop writes; callers serialize logically.
+    """
+    conn = sqlite3.connect(str(path), check_same_thread=False)
+    mode_row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    actual_mode = str(mode_row[0]).lower() if mode_row else ""
+    if str(path) != ":memory:" and actual_mode != "wal":
+        conn.close()
+        raise RuntimeError(f"failed to enable WAL on db {path!r}; got mode={mode_row}")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    return conn
 
 
 def est_tokens(text: str) -> int:

--- a/src/microverse/memory/_sqlite.py
+++ b/src/microverse/memory/_sqlite.py
@@ -1,0 +1,33 @@
+"""Project-wide SQLite opener.
+
+Lives at ``microverse.memory._sqlite`` (not ``microverse.memory.__init__``)
+so callers outside the memory subpackage — notably ``microverse.ops.metrics``
+— can use it without pulling in ``WorldContext`` and the rest of the
+memory-layer assembly machinery, which would create an ops → memory →
+agents import chain.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+def open_sqlite_wal(path: str | Path) -> sqlite3.Connection:
+    """Open a SQLite connection with the project's standard durability
+    pragmas (WAL + ``synchronous=NORMAL``).
+
+    Strict by default: file-backed paths that fail to enter WAL raise.
+    The ``:memory:`` carve-out exists because in-memory dbs always report
+    ``"memory"`` from ``PRAGMA journal_mode`` — no durability surface to
+    defend, so don't fail. ``check_same_thread=False`` so the watchdog
+    can read while the tick loop writes; callers serialize logically.
+    """
+    conn = sqlite3.connect(str(path), check_same_thread=False)
+    mode_row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+    actual_mode = str(mode_row[0]).lower() if mode_row else ""
+    if str(path) != ":memory:" and actual_mode != "wal":
+        conn.close()
+        raise RuntimeError(f"failed to enable WAL on db {path!r}; got mode={actual_mode!r}")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    return conn

--- a/src/microverse/memory/episodic.py
+++ b/src/microverse/memory/episodic.py
@@ -40,7 +40,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from microverse.memory import open_sqlite_wal
+from microverse.memory._sqlite import open_sqlite_wal
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/microverse/memory/episodic.py
+++ b/src/microverse/memory/episodic.py
@@ -35,11 +35,12 @@ per append) and the contract testable.
 from __future__ import annotations
 
 import json
-import sqlite3
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from microverse.memory import open_sqlite_wal
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,23 +79,7 @@ class EpisodicMemory:
 
     def __init__(self, path: str | Path) -> None:
         self._path = path
-        # check_same_thread=False because the watchdog will read while
-        # the tick loop writes. We still serialize logically — every
-        # write is one autocommit transaction.
-        self._conn = sqlite3.connect(str(path), check_same_thread=False)
-        # WAL is the durability contract. NORMAL fsync is the standard
-        # WAL pairing — fsync at checkpoint, not at every commit.
-        # Verify the pragma actually took: a misconfigured filesystem
-        # (e.g. some network mounts) silently rejects WAL.
-        mode_row = self._conn.execute("PRAGMA journal_mode=WAL").fetchone()
-        actual_mode = str(mode_row[0]).lower() if mode_row else ""
-        # `:memory:` databases always report "memory" — no durability
-        # surface to defend, so don't fail. For file-backed databases,
-        # silent WAL rejection (e.g. some network mounts) breaks our
-        # kill-safety contract; raise loudly instead.
-        if str(path) != ":memory:" and actual_mode != "wal":
-            raise RuntimeError(f"failed to enable WAL on episodic db {path!r}; got mode={mode_row}")
-        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn = open_sqlite_wal(path)
         self._conn.execute(_SCHEMA)
         self._conn.commit()
 

--- a/src/microverse/memory/semantic.py
+++ b/src/microverse/memory/semantic.py
@@ -29,11 +29,12 @@ from __future__ import annotations
 
 import json
 import re
-import sqlite3
 import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from microverse.memory import open_sqlite_wal
 
 _SCHEMA = [
     "CREATE TABLE IF NOT EXISTS docs (doc_id TEXT PRIMARY KEY, payload_json TEXT)",
@@ -73,10 +74,7 @@ class SemanticMemory:
     """File-backed FTS5 store of recent events / lore chunks."""
 
     def __init__(self, path: str | Path = ":memory:") -> None:
-        self._conn = sqlite3.connect(str(path), check_same_thread=False)
-        if str(path) != ":memory:":
-            self._conn.execute("PRAGMA journal_mode=WAL")
-        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn = open_sqlite_wal(path)
         for stmt in _SCHEMA:
             self._conn.execute(stmt)
         self._conn.commit()

--- a/src/microverse/memory/semantic.py
+++ b/src/microverse/memory/semantic.py
@@ -34,7 +34,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from microverse.memory import open_sqlite_wal
+from microverse.memory._sqlite import open_sqlite_wal
 
 _SCHEMA = [
     "CREATE TABLE IF NOT EXISTS docs (doc_id TEXT PRIMARY KEY, payload_json TEXT)",

--- a/src/microverse/ops/metrics.py
+++ b/src/microverse/ops/metrics.py
@@ -38,6 +38,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from microverse.config import MAX_CONSECUTIVE_FAIL
+from microverse.memory import open_sqlite_wal
 
 _CounterKey = tuple[str, str | None]
 
@@ -62,14 +63,7 @@ class Metrics:
         auto_flush_every: int | None = None,
     ) -> None:
         self._counters: defaultdict[_CounterKey, int] = defaultdict(int)
-        self._conn = sqlite3.connect(str(path), check_same_thread=False)
-        mode_row = self._conn.execute("PRAGMA journal_mode=WAL").fetchone()
-        actual_mode = str(mode_row[0]).lower() if mode_row else ""
-        # `:memory:` always reports "memory" — no durability surface, so
-        # accept it. File-backed dbs: WAL rejection is a hard error.
-        if str(path) != ":memory:" and actual_mode != "wal":
-            raise RuntimeError(f"failed to enable WAL on metrics db {path!r}; got mode={mode_row}")
-        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn = open_sqlite_wal(path)
         self._conn.execute(_SCHEMA)
         self._conn.commit()
         self._auto_flush_every = auto_flush_every

--- a/src/microverse/ops/metrics.py
+++ b/src/microverse/ops/metrics.py
@@ -38,7 +38,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from microverse.config import MAX_CONSECUTIVE_FAIL
-from microverse.memory import open_sqlite_wal
+from microverse.memory._sqlite import open_sqlite_wal
 
 _CounterKey = tuple[str, str | None]
 

--- a/src/microverse/ops/watchdog.py
+++ b/src/microverse/ops/watchdog.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 
 import itertools
 import logging
-import re
 from typing import TYPE_CHECKING
+
+from microverse._text import jaccard, tokenize
 
 if TYPE_CHECKING:
     from microverse.memory.episodic import EpisodicMemory
@@ -29,20 +30,6 @@ if TYPE_CHECKING:
     from microverse.world.scheduler import Scheduler
 
 _logger = logging.getLogger(__name__)
-_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
-
-
-def _tokens(text: str) -> set[str]:
-    return {t.lower() for t in _TOKEN_RE.findall(text) if len(t) >= 3}
-
-
-def _pair_jaccard(a: str, b: str) -> float:
-    sa, sb = _tokens(a), _tokens(b)
-    if not sa and not sb:
-        return 1.0
-    if not sa or not sb:
-        return 0.0
-    return len(sa & sb) / len(sa | sb)
 
 
 def compute_diversity(actions: list[str]) -> float:
@@ -50,11 +37,12 @@ def compute_diversity(actions: list[str]) -> float:
     n = len(actions)
     if n < 2:
         return 1.0
+    token_sets = [tokenize(a, min_len=3) for a in actions]
     total = 0.0
     pairs = 0
     for i in range(n):
         for j in range(i + 1, n):
-            total += _pair_jaccard(actions[i], actions[j])
+            total += jaccard(token_sets[i], token_sets[j])
             pairs += 1
     mean = total / pairs if pairs else 0.0
     return 1.0 - mean
@@ -146,9 +134,7 @@ class Watchdog:
         # Cap the Stranger pool: if we already have ``max_strangers``
         # registered, the existing ones haven't done their job — adding
         # more would amplify LLM volume without improving diversity.
-        # `getattr` defensive: tolerate agent classes that don't expose
-        # a ``role`` attribute (counts them as non-strangers).
-        existing = sum(1 for a in self._scheduler.agents if getattr(a, "role", None) == "stranger")
+        existing = sum(1 for a in self._scheduler.agents if a.role == "stranger")
         if existing >= self._max_strangers:
             self._metrics.bump("watchdog_stranger_cap_hit")
             return

--- a/src/microverse/ops/watchdog.py
+++ b/src/microverse/ops/watchdog.py
@@ -134,7 +134,10 @@ class Watchdog:
         # Cap the Stranger pool: if we already have ``max_strangers``
         # registered, the existing ones haven't done their job — adding
         # more would amplify LLM volume without improving diversity.
-        existing = sum(1 for a in self._scheduler.agents if a.role == "stranger")
+        # ``getattr`` defensive: ``Agent.role`` is annotated but not
+        # enforced at runtime, so a malformed registered agent would
+        # otherwise crash the stranger spawn path.
+        existing = sum(1 for a in self._scheduler.agents if getattr(a, "role", None) == "stranger")
         if existing >= self._max_strangers:
             self._metrics.bump("watchdog_stranger_cap_hit")
             return

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -156,13 +156,6 @@ def run(
     executed = 0
     consecutive_skips = 0
 
-    # Single-agent precondition: the cached topic depends on the
-    # registered agent's role. The tick loop registers exactly one Artisan
-    # above. If a future change registers more agents, fall back to
-    # per-tick `_derive_topic(episodic, agent)` or key the cache by name.
-    initial_agent = sched.agents[0]
-    topic = _derive_topic(episodic, initial_agent)
-
     def _safe(label: str, fn):
         try:
             fn()
@@ -181,6 +174,10 @@ def run(
                     consecutive_skips = 0
                 continue
             consecutive_skips = 0
+            # Topic depends on agent.role, so derive per-tick: Watchdog
+            # may spawn Strangers mid-run and a cached topic from the
+            # initial agent would mis-tag their lore retrieval.
+            topic = _derive_topic(episodic, agent)
             world = build_context(
                 world_base=WorldContext(),
                 episodic=episodic,
@@ -201,15 +198,7 @@ def run(
             executed += 1
 
             # World clock + watchdog: cheap, run every tick / every Nth.
-            # Refresh topic only on a *successful* advance that emitted
-            # at least one event — on exception we keep the previous
-            # topic rather than stale-scan the episodic log.
-            try:
-                emitted = clock.advance(episodic, ticks_elapsed=1)
-                if emitted > 0:
-                    topic = _derive_topic(episodic, agent)
-            except Exception:
-                _logger.exception("WorldClock.advance failed")
+            _safe("WorldClock.advance", lambda: clock.advance(episodic, ticks_elapsed=1))
             if executed % WATCHDOG_EVERY == 0:
                 _safe("watchdog.check", watchdog.check)
 

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -77,21 +77,6 @@ def _derive_topic(episodic: EpisodicMemory, agent: Agent) -> str:
     return f"{agent.role} {agent.name}"
 
 
-def _build_world(
-    episodic: EpisodicMemory,
-    semantic: SemanticMemory,
-    *,
-    topic: str,
-) -> WorldContext:
-    """Assemble the per-tick context: weather + recent events + lore."""
-    return build_context(
-        world_base=WorldContext(),
-        episodic=episodic,
-        semantic=semantic,
-        topic=topic,
-    )
-
-
 def _commit_action(episodic: EpisodicMemory, agent: Agent, action: Action) -> int:
     return episodic.append(
         actor=agent.name,
@@ -170,6 +155,20 @@ def run(
     max_ticks = ticks if ticks is not None else MAX_TICKS_DEFAULT
     executed = 0
     consecutive_skips = 0
+
+    # Single-agent precondition: the cached topic depends on the
+    # registered agent's role. The tick loop registers exactly one Artisan
+    # above. If a future change registers more agents, fall back to
+    # per-tick `_derive_topic(episodic, agent)` or key the cache by name.
+    initial_agent = sched.agents[0]
+    topic = _derive_topic(episodic, initial_agent)
+
+    def _safe(label: str, fn):
+        try:
+            fn()
+        except Exception:
+            _logger.exception("%s failed", label)
+
     try:
         while executed < max_ticks and not stop["requested"]:
             agent = sched.next()
@@ -182,8 +181,12 @@ def run(
                     consecutive_skips = 0
                 continue
             consecutive_skips = 0
-            topic = _derive_topic(episodic, agent)
-            world = _build_world(episodic, semantic, topic=topic)
+            world = build_context(
+                world_base=WorldContext(),
+                episodic=episodic,
+                semantic=semantic,
+                topic=topic,
+            )
             try:
                 action = agent.think(world)
             except Exception:
@@ -198,15 +201,17 @@ def run(
             executed += 1
 
             # World clock + watchdog: cheap, run every tick / every Nth.
+            # Refresh topic only on a *successful* advance that emitted
+            # at least one event — on exception we keep the previous
+            # topic rather than stale-scan the episodic log.
             try:
-                clock.advance(episodic, ticks_elapsed=1)
+                emitted = clock.advance(episodic, ticks_elapsed=1)
+                if emitted > 0:
+                    topic = _derive_topic(episodic, agent)
             except Exception:
                 _logger.exception("WorldClock.advance failed")
             if executed % WATCHDOG_EVERY == 0:
-                try:
-                    watchdog.check()
-                except Exception:
-                    _logger.exception("watchdog.check failed")
+                _safe("watchdog.check", watchdog.check)
 
             if executed % HARVEST_FLUSH_EVERY == 0:
                 try:
@@ -229,27 +234,16 @@ def run(
         # batch still go through Trader on shutdown. If it fails (the
         # most common cause: a hung Ollama call interrupted by SIGTERM),
         # bump a counter BEFORE closing metrics so the failure is
-        # visible in the metrics db.
+        # visible in the metrics db. The bump itself is wrapped because
+        # metrics may already be in a bad state.
         try:
             harvester.flush()
         except Exception:
             _logger.exception("final harvester.flush failed")
-            try:
-                metrics.bump("harvest_flush_fail")
-            except Exception:
-                _logger.exception("metrics.bump after flush failure failed")
-        try:
-            metrics.close()
-        except Exception:
-            _logger.exception("metrics.close failed")
-        try:
-            episodic.close()
-        except Exception:
-            _logger.exception("episodic.close failed")
-        try:
-            semantic.close()
-        except Exception:
-            _logger.exception("semantic.close failed")
+            _safe("metrics.bump after flush failure", lambda: metrics.bump("harvest_flush_fail"))
+        _safe("metrics.close", metrics.close)
+        _safe("episodic.close", episodic.close)
+        _safe("semantic.close", semantic.close)
 
     return executed
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Shared pytest fixtures for the microverse test suite."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from microverse.ops.metrics import Metrics
+
+
+@pytest.fixture
+def metrics() -> Iterator[Metrics]:
+    """In-memory ``Metrics`` instance, closed on teardown.
+
+    Use this for tests that just need a counter sink and don't care
+    about persistence. Tests that exercise ``Metrics`` itself, or that
+    want to pass ``auto_flush_every`` / a file-backed path, should
+    construct their own.
+    """
+    m = Metrics(":memory:")
+    try:
+        yield m
+    finally:
+        m.close()

--- a/tests/test_action_parse.py
+++ b/tests/test_action_parse.py
@@ -13,11 +13,10 @@ from microverse.agents.base import ActionKind, parse_action
 from microverse.ops.metrics import Metrics
 
 
-def test_action_strict_valid_json():
+def test_action_strict_valid_json(metrics: Metrics):
     payload = (
         '{"thought": "I will craft a lamp.", "action": "craft", "target": null, "artifact": "lamp"}'
     )
-    metrics = Metrics(":memory:")
     a = parse_action(payload, metrics=metrics, agent="aki")
     assert a.action == ActionKind.CRAFT
     assert a.thought == "I will craft a lamp."
@@ -28,18 +27,16 @@ def test_action_strict_valid_json():
     assert metrics.get("json_fallback_rest") == 0
 
 
-def test_action_repaired_when_trailing_comma():
+def test_action_repaired_when_trailing_comma(metrics: Metrics):
     """json-repair handles common LLM mishaps like trailing commas."""
     payload = '{"thought": "rest", "action": "rest", "target": null, "artifact": null,}'
-    metrics = Metrics(":memory:")
     a = parse_action(payload, metrics=metrics, agent="aki")
     assert a.action == ActionKind.REST
     assert metrics.get("json_repaired") == 1
     assert metrics.get("json_ok") == 0
 
 
-def test_action_fallback_rest_on_garbage():
-    metrics = Metrics(":memory:")
+def test_action_fallback_rest_on_garbage(metrics: Metrics):
     a = parse_action("not json at all", metrics=metrics, agent="aki")
     assert a.action == ActionKind.REST
     assert a.target is None
@@ -49,26 +46,23 @@ def test_action_fallback_rest_on_garbage():
     assert metrics.get("consecutive_fail", agent="aki") == 1
 
 
-def test_action_kind_unknown_falls_back_to_rest():
+def test_action_kind_unknown_falls_back_to_rest(metrics: Metrics):
     payload = '{"thought": "x", "action": "fly_to_moon", "target": null, "artifact": null}'
-    metrics = Metrics(":memory:")
     a = parse_action(payload, metrics=metrics, agent="aki")
     assert a.action == ActionKind.REST
     assert metrics.get("json_fallback_rest") == 1
 
 
-def test_action_thought_too_long_falls_back():
+def test_action_thought_too_long_falls_back(metrics: Metrics):
     """thought capped to keep prompt budgets honest."""
     long_thought = "x" * 5000
     payload = f'{{"thought": "{long_thought}", "action": "rest", "target": null, "artifact": null}}'
-    metrics = Metrics(":memory:")
     a = parse_action(payload, metrics=metrics, agent="aki")
     assert a.action == ActionKind.REST
     assert metrics.get("json_fallback_rest") == 1
 
 
-def test_consecutive_fail_resets_on_success():
-    metrics = Metrics(":memory:")
+def test_consecutive_fail_resets_on_success(metrics: Metrics):
     parse_action("garbage", metrics=metrics, agent="aki")
     parse_action("more garbage", metrics=metrics, agent="aki")
     assert metrics.get("consecutive_fail", agent="aki") == 2
@@ -78,19 +72,17 @@ def test_consecutive_fail_resets_on_success():
     assert metrics.get("consecutive_fail", agent="aki") == 0
 
 
-def test_action_extra_fields_rejected_then_repaired_or_rest():
+def test_action_extra_fields_rejected_then_repaired_or_rest(metrics: Metrics):
     """Strict mode rejects extra fields; the repair path may strip them
     (json-repair keeps them, so this falls back). Either way, no crash."""
     payload = '{"thought": "x", "action": "rest", "target": null, "artifact": null, "extra": 1}'
-    metrics = Metrics(":memory:")
     a = parse_action(payload, metrics=metrics, agent="aki")
     # Whether we land in json_ok with extra=ignored or in fallback,
     # the action result must be safe.
     assert a.action == ActionKind.REST
 
 
-def test_action_kind_rest_speak_craft_study_travel_all_valid():
-    metrics = Metrics(":memory:")
+def test_action_kind_rest_speak_craft_study_travel_all_valid(metrics: Metrics):
     for kind in ("speak", "craft", "study", "rest", "travel"):
         payload = f'{{"thought": "x", "action": "{kind}", "target": null, "artifact": null}}'
         a = parse_action(payload, metrics=metrics, agent="aki")
@@ -106,14 +98,13 @@ def test_action_kind_rest_speak_craft_study_travel_all_valid():
         'Sure! Here you go: {"thought": "x", "action": "rest", "target": null, "artifact": null}',
     ],
 )
-def test_action_repair_handles_common_llm_wrappers(raw: str):
-    metrics = Metrics(":memory:")
+def test_action_repair_handles_common_llm_wrappers(raw: str, metrics: Metrics):
     a = parse_action(raw, metrics=metrics, agent="aki")
     assert a.action == ActionKind.REST
     assert metrics.get("json_repaired") == 1
 
 
-def test_meta_phrase_outside_the_simulation_blocks():
+def test_meta_phrase_outside_the_simulation_blocks(metrics: Metrics):
     """Regression: 'outside the simulation' must trigger the meta-leak
     guard. Earlier version of the regex required 'this' between
     'outside' and the trigger noun and silently missed 'the'."""
@@ -121,13 +112,12 @@ def test_meta_phrase_outside_the_simulation_blocks():
         '{"thought": "I sense there is something outside the simulation", '
         '"action": "speak", "target": null, "artifact": null}'
     )
-    metrics = Metrics(":memory:")
     a = parse_action(payload, metrics=metrics, agent="aki")
     assert a.action == ActionKind.REST
     assert metrics.get("meta_leak_block", agent="aki") == 1
 
 
-def test_meta_reference_in_thought_blocks_action():
+def test_meta_reference_in_thought_blocks_action(metrics: Metrics):
     """If the parsed action's thought contains a meta-token (AI, model,
     simulation, prompt, outside), fall back to rest and bump
     meta_leak_block instead of accepting the immersion break."""
@@ -135,41 +125,37 @@ def test_meta_reference_in_thought_blocks_action():
         '{"thought": "I realize I am inside an AI simulation", '
         '"action": "speak", "target": null, "artifact": null}'
     )
-    metrics = Metrics(":memory:")
     a = parse_action(payload, metrics=metrics, agent="aki")
     assert a.action == ActionKind.REST
     assert metrics.get("meta_leak_block", agent="aki") == 1
     assert metrics.get("json_ok") == 0
 
 
-def test_meta_reference_in_artifact_blocks_action():
+def test_meta_reference_in_artifact_blocks_action(metrics: Metrics):
     payload = (
         '{"thought": "ok", "action": "craft", "target": null, '
         '"artifact": "a story about an LLM that wakes up"}'
     )
-    metrics = Metrics(":memory:")
     a = parse_action(payload, metrics=metrics, agent="aki")
     assert a.action == ActionKind.REST
     assert metrics.get("meta_leak_block", agent="aki") == 1
 
 
-def test_clean_action_with_no_meta_reference_passes():
+def test_clean_action_with_no_meta_reference_passes(metrics: Metrics):
     payload = (
         '{"thought": "I will craft a wooden bowl", "action": "craft", '
         '"target": null, "artifact": "a wooden bowl"}'
     )
-    metrics = Metrics(":memory:")
     a = parse_action(payload, metrics=metrics, agent="aki")
     assert a.action == ActionKind.CRAFT
     assert metrics.get("meta_leak_block", agent="aki") == 0
 
 
-def test_action_oversize_input_short_circuits_to_fallback():
+def test_action_oversize_input_short_circuits_to_fallback(metrics: Metrics):
     """Inputs above MAX_PARSE_BYTES skip parse attempts entirely so a
     pathological 100KB blob can't stall the tick loop in O(N^2) repair."""
     from microverse.config import MAX_PARSE_BYTES
 
-    metrics = Metrics(":memory:")
     huge = '{"thought": "' + ("x" * (MAX_PARSE_BYTES + 1024)) + '"}'
     a = parse_action(huge, metrics=metrics, agent="aki")
     assert a.action == ActionKind.REST

--- a/tests/test_agent_artisan.py
+++ b/tests/test_agent_artisan.py
@@ -38,8 +38,7 @@ def test_artisan_persona_renders_with_world_context():
     assert "simulation" in lower
 
 
-def test_artisan_think_returns_action():
-    metrics = Metrics(":memory:")
+def test_artisan_think_returns_action(metrics: Metrics):
     canned = {
         "content": (
             '{"thought": "I will craft a wooden bowl.", "action": "craft", '
@@ -61,8 +60,7 @@ def test_artisan_think_returns_action():
     assert kwargs.get("options", {}).get("temperature", 0) == 1.0
 
 
-def test_artisan_think_falls_back_on_garbage_response():
-    metrics = Metrics(":memory:")
+def test_artisan_think_falls_back_on_garbage_response(metrics: Metrics):
     canned = {"content": "not json", "thinking": "", "raw": {}}
     with patch("microverse.agents.artisan.chat", return_value=canned):
         a = Artisan(name="Aki", metrics=metrics)

--- a/tests/test_lore_drift_guard.py
+++ b/tests/test_lore_drift_guard.py
@@ -54,8 +54,7 @@ def test_jaccard_handles_punctuation_and_case():
     assert lore_jaccard("Wood, stone — water!", "wood stone water") == 1.0
 
 
-def test_compress_lore_accepts_when_drift_within_budget():
-    metrics = Metrics(":memory:")
+def test_compress_lore_accepts_when_drift_within_budget(metrics: Metrics):
     prior = "The village by the river thrives on craft and harvest"
     new = "The river village thrives through craft and the autumn harvest"
     canned = {"content": new, "thinking": "", "raw": {}}
@@ -65,8 +64,7 @@ def test_compress_lore_accepts_when_drift_within_budget():
     assert metrics.get("lore_drift_block") == 0
 
 
-def test_compress_lore_retries_with_continuity_hint_then_accepts():
-    metrics = Metrics(":memory:")
+def test_compress_lore_retries_with_continuity_hint_then_accepts(metrics: Metrics):
     prior = "The village stands beside an ancient river. Stonework guards the harvest."
     drifty = "Once upon a time in a galaxy far far away, robots danced."
     settled = "The village stands beside an ancient river; stonework still guards the harvest."
@@ -90,8 +88,7 @@ def test_compress_lore_retries_with_continuity_hint_then_accepts():
     assert metrics.get("lore_drift_block") == 0
 
 
-def test_compress_lore_blocks_after_two_failures():
-    metrics = Metrics(":memory:")
+def test_compress_lore_blocks_after_two_failures(metrics: Metrics):
     prior = "The forge sings in the morning when the river runs slow."
     drifty = "Hexapods dominate the surface in the year 2087."
 
@@ -103,9 +100,8 @@ def test_compress_lore_blocks_after_two_failures():
     assert metrics.get("lore_drift_block") == 1
 
 
-def test_compress_lore_with_empty_prior_accepts_anything():
+def test_compress_lore_with_empty_prior_accepts_anything(metrics: Metrics):
     """A fresh world has no prior to drift from."""
-    metrics = Metrics(":memory:")
     canned = {"content": "First lore: a young river village", "thinking": "", "raw": {}}
     with patch("microverse.agents.elder.chat", return_value=canned):
         out = Elder(name="Old").compress_lore("", _events(), metrics=metrics)
@@ -113,11 +109,10 @@ def test_compress_lore_with_empty_prior_accepts_anything():
     assert metrics.get("lore_drift_block") == 0
 
 
-def test_compress_lore_handles_chat_exception():
+def test_compress_lore_handles_chat_exception(metrics: Metrics):
     """If the LLM call raises, keep the prior and bump the
     double-chat-failure metric — don't let the Elder crash the run
     loop, and don't conflate chat failure with drift."""
-    metrics = Metrics(":memory:")
     prior = "Old lore"
     with patch("microverse.agents.elder.chat", side_effect=TimeoutError("hung")):
         out = Elder(name="Old").compress_lore(prior, _events(), metrics=metrics)
@@ -142,10 +137,9 @@ def test_jaccard_filters_stop_words_and_short_tokens():
     assert lore_jaccard(a, b) == 0.0
 
 
-def test_granular_metrics_distinguish_drift_from_chat_failure():
+def test_granular_metrics_distinguish_drift_from_chat_failure(metrics: Metrics):
     """Drift block and chat failure must bump separate counters so the
     Phase 4 watchdog can tell them apart."""
-    metrics = Metrics(":memory:")
     prior = "the village by the ancient river under stonework arches"
     drifty = "the rockets land on Mars in the year 2087"
     canned = {"content": drifty, "thinking": "", "raw": {}}
@@ -166,8 +160,7 @@ def test_granular_metrics_distinguish_drift_from_chat_failure():
     assert metrics2.get("lore_compress_accepted") == 0
 
 
-def test_round1_success_bumps_compress_accepted():
-    metrics = Metrics(":memory:")
+def test_round1_success_bumps_compress_accepted(metrics: Metrics):
     prior = "the village by the river under stonework arches"
     new = "the river village still endures, with new stonework arches"
     with patch(

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -11,6 +11,10 @@ from microverse.llm.ollama_client import chat
 @pytest.fixture(autouse=True)
 def reset_counter():
     ollama_client.thinking_leak = 0
+    # The chat() helper caches an ollama.Client per timeout. Clear the
+    # cache so each test's fresh ``patch("...ollama.Client")`` is what
+    # actually gets constructed.
+    ollama_client._get_client.cache_clear()
     return None
 
 

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -55,8 +55,7 @@ def test_diversity_single_returns_one():
     assert compute_diversity(["alone"]) == 1.0
 
 
-def test_runaway_detected_for_consecutive_identical_actions(tmp_path: Path):
-    metrics = Metrics(":memory:")
+def test_runaway_detected_for_consecutive_identical_actions(tmp_path: Path, metrics: Metrics):
     sched = WeightedScheduler()
     sched.register(_StubAgent("aki"))
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
@@ -68,8 +67,7 @@ def test_runaway_detected_for_consecutive_identical_actions(tmp_path: Path):
     assert metrics.get("watchdog_runaway", agent="aki") >= 1
 
 
-def test_no_runaway_when_actions_vary(tmp_path: Path):
-    metrics = Metrics(":memory:")
+def test_no_runaway_when_actions_vary(tmp_path: Path, metrics: Metrics):
     sched = WeightedScheduler()
     sched.register(_StubAgent("aki"))
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
@@ -78,10 +76,9 @@ def test_no_runaway_when_actions_vary(tmp_path: Path):
     assert metrics.get("watchdog_runaway", agent="aki") == 0
 
 
-def test_echo_chamber_triggers_stranger_spawn(tmp_path: Path):
+def test_echo_chamber_triggers_stranger_spawn(tmp_path: Path, metrics: Metrics):
     """When diversity drops below the threshold, the watchdog asks the
     scheduler to register a fresh Stranger agent."""
-    metrics = Metrics(":memory:")
     sched = WeightedScheduler()
     sched.register(_StubAgent("aki"))
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
@@ -98,8 +95,7 @@ def test_echo_chamber_triggers_stranger_spawn(tmp_path: Path):
     assert any(n.startswith("stranger") for n in names)
 
 
-def test_echo_chamber_quiet_when_diversity_high(tmp_path: Path):
-    metrics = Metrics(":memory:")
+def test_echo_chamber_quiet_when_diversity_high(tmp_path: Path, metrics: Metrics):
     sched = WeightedScheduler()
     sched.register(_StubAgent("aki"))
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
@@ -116,9 +112,8 @@ def test_echo_chamber_quiet_when_diversity_high(tmp_path: Path):
     assert metrics.get("watchdog_echo_chamber") == 0
 
 
-def test_stranger_pool_capped(tmp_path: Path):
+def test_stranger_pool_capped(tmp_path: Path, metrics: Metrics):
     """Repeated echo-chamber detections must not spawn unbounded Strangers."""
-    metrics = Metrics(":memory:")
     sched = WeightedScheduler()
     sched.register(_StubAgent("aki"))
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
@@ -137,10 +132,9 @@ def test_stranger_pool_capped(tmp_path: Path):
     assert metrics.get("watchdog_stranger_cap_hit") >= 1
 
 
-def test_meta_leak_detector_bumps_per_actor(tmp_path: Path):
+def test_meta_leak_detector_bumps_per_actor(tmp_path: Path, metrics: Metrics):
     """The watchdog scans recent agent payloads for in-world meta-
     references and bumps a per-actor counter."""
-    metrics = Metrics(":memory:")
     sched = WeightedScheduler()
     sched.register(_StubAgent("aki"))
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
@@ -160,8 +154,7 @@ def test_meta_leak_detector_bumps_per_actor(tmp_path: Path):
     assert metrics.get("watchdog_meta_leak", agent="aki") >= 1
 
 
-def test_stagnation_detected_when_no_recent_artifacts(tmp_path: Path):
-    metrics = Metrics(":memory:")
+def test_stagnation_detected_when_no_recent_artifacts(tmp_path: Path, metrics: Metrics):
     sched = WeightedScheduler()
     sched.register(_StubAgent("aki"))
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:


### PR DESCRIPTION
## Summary
- 9-item simplification pass driven by the /simplify audit + Codex review.
- Net **-158 LOC** (352 insertions, 311 deletions across 17 files).
- All 212 pre-existing tests still pass; ruff clean.

## What changed

### New helpers
- `src/microverse/memory/__init__.py` exports **`open_sqlite_wal()`** — strict-by-default WAL+`synchronous=NORMAL` opener that replaces 3 PRAGMA blocks. Fixes a silent WAL-skip in `semantic.py` (it now raises on file paths that fail to enter WAL, matching `episodic.py` and `metrics.py`).
- New module `src/microverse/_text.py`:
  - `tokenize(text, *, min_len=1, drop_stopwords=False)` and `jaccard(a, b)` — used by both Elder's lore-drift guard and Watchdog's echo-chamber detector. Stop-word frozenset moved here.
  - `safe_json_loads(raw)` — strict json → `json_repair` → strict json ladder used by `parse_action` (base.py) and `_safe_parse_scores` (trader.py). The bytes-cap (`MAX_PARSE_BYTES`) stays in callers per Codex review, since it has caller-specific metric side effects.

### Hot-loop / runtime hygiene
- `llm/ollama_client.py`: cache `ollama.Client` per timeout via `functools.lru_cache(maxsize=4)` instead of constructing a fresh client (and httpx pool) on every `chat()` call.
- `run.py`:
  - Cache the scene topic; refresh only on a *successful* `WorldClock.advance(...)` that emitted ≥1 event. Single-agent precondition documented inline.
  - Inline `_build_world` (was a no-op wrapper around `build_context`).
  - Collapse 5 identical shutdown `try/except` blocks via a local `_safe(label, fn)` closure.
- `ops/watchdog.py`: drop the unnecessary defensive `getattr(a, \"role\", None)` — `Agent` declares `role: str` and every concrete subclass sets it.

### Tests
- New `tests/conftest.py` with a `metrics` fixture that yields `Metrics(\":memory:\")` and closes it on teardown.
- Migrated 32 ad-hoc callsites across `test_action_parse.py`, `test_agent_artisan.py`, `test_lore_drift_guard.py`, `test_watchdog.py`. Left `test_metrics.py` (self-tests for `Metrics`) and the `metrics2` second-instance untouched.
- `test_ollama_client.py`: autouse fixture clears the `_get_client` `lru_cache` so each test's fresh `patch(\"...ollama.Client\")` is what gets constructed.

## Deliberately out of scope
The `/simplify` audit also surfaced these — verified as false positives or YAGNI; not changed:
- Jinja2 templates already cached by the module-level `Environment`.
- Snapshot hash-detection (snapshots are explicitly cold backups every 1000 ticks).
- Index on `events(actor)` (rowid PK already serves `ORDER BY id DESC LIMIT N`).
- Time-based metrics flush (count-based is fine at single-agent scale).
- Centralizing all magic numbers in `config.py` (feature-local tuning is defensible).
- Removing `RoundRobinScheduler` (still tested + documented as Phase 1 reference).

## Test plan
- [x] \`uv run ruff check src tests scripts\` — clean
- [x] \`uv run ruff format --check src tests scripts\` — 48 files already formatted
- [x] \`uv run pytest -q\` — 212 passed, 2 pre-existing Ollama-network failures (unaffected by these changes)
- [ ] Smoke: \`uv run python -m microverse.run --ticks 5 --tempo 0\` — requires local Ollama; not run in CI