### PR TITLE
fix(trader): use array JSON Schema so harvest stops rejecting all

### DIFF
--- a/src/microverse/agents/trader.py
+++ b/src/microverse/agents/trader.py
@@ -40,6 +40,23 @@ class Score(BaseModel):
 
 _PREFERRED_LIST_KEYS = ("scores", "rankings", "items", "artifacts", "results")
 
+# Ollama JSON Schema. Forces an array root so gemma4:e4b cannot collapse
+# to a single object the way it does under format="json". Empirically
+# verified against gemma4:e4b under think=False; re-check on Ollama
+# upgrades (cf. ollama/ollama#15260 for known regressions in this area).
+_RANK_SCHEMA: dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "artifact_id": {"type": "integer"},
+            "score": {"type": "number"},
+            "rationale": {"type": "string"},
+        },
+        "required": ["artifact_id", "score"],
+    },
+}
+
 
 def _list_looks_like_scores(value: object) -> TypeGuard[list[dict[str, Any]]]:
     """Quick shape check: list of dicts each having an ``artifact_id``."""
@@ -128,7 +145,7 @@ class Trader(Agent):
         result = chat(
             messages=[{"role": "user", "content": prompt}],
             think=False,
-            format="json",
+            format=_RANK_SCHEMA,
             options={**self.sampling, "num_predict": LLM_MAX_TOKENS},
             timeout_s=LLM_TIMEOUT_S,
         )

--- a/src/microverse/agents/trader.py
+++ b/src/microverse/agents/trader.py
@@ -49,9 +49,12 @@ _RANK_SCHEMA: dict[str, Any] = {
     "items": {
         "type": "object",
         "properties": {
-            "artifact_id": {"type": "integer"},
-            "score": {"type": "number"},
-            "rationale": {"type": "string"},
+            # Bounds mirror the ``Score`` Pydantic model (ge=0 / 0.0-1.0 /
+            # max_length=300) so the model is steered toward valid output
+            # rather than relying on ``_coerce_score`` to clamp after.
+            "artifact_id": {"type": "integer", "minimum": 0},
+            "score": {"type": "number", "minimum": 0, "maximum": 1},
+            "rationale": {"type": "string", "maxLength": 300},
         },
         "required": ["artifact_id", "score"],
     },

--- a/src/microverse/agents/trader.py
+++ b/src/microverse/agents/trader.py
@@ -73,6 +73,10 @@ def _extract_list(data: Any) -> list[dict[str, Any]]:
         candidates = [v for v in data.values() if _list_looks_like_scores(v)]
         if len(candidates) == 1:
             return [d for d in candidates[0] if isinstance(d, dict)]
+        # 3. Single Score-shaped object at root: wrap so the caller still
+        # gets one score (gemma4 sometimes emits this under format="json").
+        if "artifact_id" in data:
+            return [data]
     return []
 
 

--- a/src/microverse/llm/ollama_client.py
+++ b/src/microverse/llm/ollama_client.py
@@ -125,7 +125,7 @@ def chat(
     messages: list[dict[str, str]],
     *,
     think: bool = False,
-    format: str | None = None,
+    format: str | dict[str, Any] | None = None,
     options: dict[str, Any] | None = None,
     timeout_s: float = LLM_TIMEOUT_S,
 ) -> dict[str, Any]:

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from microverse.agents.harvester import ArtifactCandidate
-from microverse.agents.trader import Score, Trader
+from microverse.agents.trader import Score, Trader, _extract_list
 
 
 def _candidates() -> list[ArtifactCandidate]:
@@ -192,3 +192,48 @@ def test_rank_falls_back_to_unique_score_shaped_list():
     with patch("microverse.agents.trader.chat", return_value=canned):
         scores = Trader(name="Bo").rank(_candidates())
     assert [round(s.score, 1) for s in scores] == [0.6, 0.7, 0.8]
+
+
+def test_extract_list_wraps_single_root_object_with_artifact_id():
+    """When format=json makes a model emit one object instead of a list,
+    the parser must wrap it as ``[dict]`` so the caller still sees a
+    score for that artifact_id (rather than getting an empty list and
+    defaulting every candidate to 0.0)."""
+    assert _extract_list({"artifact_id": 0, "score": 0.7, "rationale": "x"}) == [
+        {"artifact_id": 0, "score": 0.7, "rationale": "x"}
+    ]
+
+
+def test_extract_list_does_not_wrap_unrelated_root_dict():
+    """A dict without ``artifact_id`` is not a Score — must not wrap."""
+    assert _extract_list({"summary": "ok", "count": 3}) == []
+
+
+def test_rank_handles_single_root_object_response():
+    """End-to-end: a single-object root response yields a score for that
+    artifact_id and the documented 0.0 default for the rest."""
+    canned = {
+        "content": '{"artifact_id": 0, "score": 0.7, "rationale": "x"}',
+        "thinking": "",
+        "raw": {},
+    }
+    with patch("microverse.agents.trader.chat", return_value=canned):
+        scores = Trader(name="Bo").rank(_candidates())
+    assert scores[0].score == 0.7
+    assert scores[1].score == 0.0
+    assert scores[2].score == 0.0
+
+
+def test_rank_drops_root_dict_missing_required_score_field():
+    """artifact_id present but score missing — the wrap still happens,
+    but ``_coerce_score``'s default-0.0 path keeps the entry safe rather
+    than producing a partial/corrupt score."""
+    canned = {
+        "content": '{"artifact_id": 1, "rationale": "x"}',
+        "thinking": "",
+        "raw": {},
+    }
+    with patch("microverse.agents.trader.chat", return_value=canned):
+        scores = Trader(name="Bo").rank(_candidates())
+    assert scores[1].score == 0.0
+    assert scores[1].rationale == "x"

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -209,6 +209,22 @@ def test_extract_list_does_not_wrap_unrelated_root_dict():
     assert _extract_list({"summary": "ok", "count": 3}) == []
 
 
+def test_extract_list_prefers_wrapped_list_over_root_wrap():
+    """Branch ordering regression guard: when a root dict has *both* a
+    known wrapping key (``scores``) and a top-level ``artifact_id``, the
+    wrapped list must win — wrapping the root would silently drop the
+    real per-candidate scores."""
+    payload = {
+        "artifact_id": 99,
+        "scores": [
+            {"artifact_id": 0, "score": 0.4, "rationale": "x"},
+            {"artifact_id": 1, "score": 0.7, "rationale": "y"},
+        ],
+    }
+    out = _extract_list(payload)
+    assert [d["artifact_id"] for d in out] == [0, 1]
+
+
 def test_rank_handles_single_root_object_response():
     """End-to-end: a single-object root response yields a score for that
     artifact_id and the documented 0.0 default for the rest."""
@@ -239,6 +255,11 @@ def test_rank_passes_array_json_schema_as_format():
     assert {"artifact_id", "score"}.issubset(items["required"])
     assert items["properties"]["artifact_id"]["type"] == "integer"
     assert items["properties"]["score"]["type"] == "number"
+    # Bounds must mirror the Pydantic Score model.
+    assert items["properties"]["score"]["minimum"] == 0
+    assert items["properties"]["score"]["maximum"] == 1
+    assert items["properties"]["artifact_id"]["minimum"] == 0
+    assert items["properties"]["rationale"]["maxLength"] == 300
 
 
 def test_rank_drops_root_dict_missing_required_score_field():

--- a/tests/test_trader.py
+++ b/tests/test_trader.py
@@ -55,9 +55,9 @@ def test_rank_returns_one_score_per_candidate_in_index_order():
     assert len(scores) == 3
     assert [s.artifact_id for s in scores] == [0, 1, 2]
     assert [round(s.score, 1) for s in scores] == [0.9, 0.3, 0.7]
-    # Sanity: factual sampling + JSON format requested.
+    # Sanity: factual sampling + array-shaped JSON Schema requested.
     kwargs = mock_chat.call_args.kwargs
-    assert kwargs.get("format") == "json"
+    assert isinstance(kwargs.get("format"), dict)
     assert kwargs.get("options", {}).get("temperature", 1.0) == 0.6
 
 
@@ -222,6 +222,23 @@ def test_rank_handles_single_root_object_response():
     assert scores[0].score == 0.7
     assert scores[1].score == 0.0
     assert scores[2].score == 0.0
+
+
+def test_rank_passes_array_json_schema_as_format():
+    """Layer B: instead of ``format="json"`` (which lets gemma4 collapse
+    to a single object), the Trader must pass an Ollama JSON Schema
+    constraining the response to an array of Score-shaped objects."""
+    canned = {"content": "[]", "thinking": "", "raw": {}}
+    with patch("microverse.agents.trader.chat", return_value=canned) as mock_chat:
+        Trader(name="Bo").rank(_candidates())
+    fmt = mock_chat.call_args.kwargs["format"]
+    assert isinstance(fmt, dict), f"expected schema dict, got {type(fmt).__name__}"
+    assert fmt["type"] == "array"
+    items = fmt["items"]
+    assert items["type"] == "object"
+    assert {"artifact_id", "score"}.issubset(items["required"])
+    assert items["properties"]["artifact_id"]["type"] == "integer"
+    assert items["properties"]["score"]["type"] == "number"
 
 
 def test_rank_drops_root_dict_missing_required_score_field():


### PR DESCRIPTION
## Summary

Trader scoring stopped working under live Ollama: every harvested artifact was rejected with `score: 0.0`. Root cause: `format="json"` made `gemma4:e4b` collapse to a single root object instead of the prompt's array, the parser returned `[]`, every candidate defaulted to 0.0, and the all-tied-zeros path rejected everything. This PR switches the Trader to a JSON Schema constraining the array root and hardens the parser as defense-in-depth.

## Background / Motivation

Surfaced during a 5-minute live soak after merging #12. With 9 ticks and 8 buffered candidates, the harvest manifest showed `accepted: false` and `score: 0.0` for every entry. Standalone repro against `gemma4:e4b` confirmed: `format="json"` returns one well-formed object (`{"artifact_id": 0, ...}`) and stops; `format=""` returns the full 9-element array. The harvest pipeline was effectively dead under realistic conditions.

The CLAUDE.md status notes a 24-hour soak as still-pending operator validation; that soak would have produced an empty `harvest/inbox/` for the entire run.

## Breaking Changes

None. `microverse.llm.ollama_client.chat()`'s `format` parameter widened from `str | None` to `str | dict[str, Any] | None`; existing callers pass `"json"` / `None` and are unaffected. Internal-only API.

## Changes Made

- `src/microverse/agents/trader.py`
  - New `_RANK_SCHEMA` (array of `{artifact_id, score, rationale}`) passed as `format=` instead of `"json"`.
  - `_extract_list` now wraps a single root dict carrying `artifact_id` as `[dict]`.
- `src/microverse/llm/ollama_client.py:128` — widen `format` annotation to `str | dict[str, Any] | None`.
- `tests/test_trader.py` — five new tests (parser wrap, two negative guards, end-to-end single-object response, schema-shape assertion); one existing assertion updated (`format == "json"` → `isinstance(format, dict)`).

## Dependencies

No new dependencies. Underlying `ollama` SDK already accepts `dict` for `format`.

## Test Methodologies and Results

Local quality gate (CLAUDE.md required suite):

```
uv run ruff check                          # All checks passed!
uv run ruff format --check                 # 49 files already formatted
uv run mypy src/microverse                 # no issues found in 26 files
uv run pip-audit                           # No known vulnerabilities found
uv run pytest -q -m 'not integration'      # 229 passed, 2 deselected (+5 new)
uv build                                   # built sdist + wheel
```

Live verification soak (operator-run, requires `ollama serve` + `gemma4:e4b`):

```
rm -rf data harvest && mkdir -p data harvest
timeout --signal=INT --kill-after=30s 300s \
  uv run python -m microverse.run --seed 42 > microverse.log 2>&1
cat harvest/manifest.jsonl
ls harvest/inbox/2026-05-04/
```

Results (same seed, same model as the failing baseline):

| Metric | Before | After |
|---|---:|---:|
| Candidates considered | 8 | 8 |
| Accepted | 0 | 4 |
| Distinct scores | 1 (`0.0`) | 6 (`0.6`–`0.85`) |
| Files in `harvest/inbox/` | 0 | 4 |

Manifest after fix:
```
{"accepted":true,"score":0.75,...a-small-intricately-carved-wooden-bird...}
{"accepted":true,"score":0.85,...a-set-of-three-small-inlaid-wooden-bird-feeders...}
{"accepted":false,"score":0.65,...}
{"accepted":true,"score":0.8, ...a-set-of-small-delicately-carved-wooden-birds...}
{"accepted":false,"score":0.7,...}
{"accepted":true,"score":0.75,...a-set-of-tiny-delicately-carved-wooden-birds...}
{"accepted":false,"score":0.7,...}
{"accepted":false,"score":0.6,...}
```

Hard pass criterion (≥1 entry with `accepted: true` and `score > 0`): met.

## Design & Reasoning Notes

Two layers, both small and orthogonal:

- **Layer A (parser, defense).** `_extract_list` already handled bare arrays and several wrapped-list shapes; it returned `[]` only for "single dict at root with `artifact_id`". Wrapping it as `[dict]` keeps the parser honest against future format regressions. Negative tests lock the guard so an unrelated dict (no `artifact_id`) does *not* wrap.
- **Layer B (call site, root cause).** Switching from `format="json"` to a JSON Schema with `"type": "array"` is the actual fix — the model is constrained at decode time and cannot collapse to a single object. The schema requires `artifact_id` and `score`; `rationale` is optional.

Alternative considered: drop `format=` entirely and rely on the prompt + `json_repair`. Rejected because the schema gives a stronger guarantee at zero implementation cost (the SDK already supports it).

The wrap and the schema do *not* overlap functionally — Layer A only fires if Layer B's schema is silently ignored by some future Ollama version. They are deliberately complementary.

## Impact / Risk Assessment

**Affected.** Trader scoring path only. Artisan/Elder are unchanged.

**Risk.** Ollama issue [#15260](https://github.com/ollama/ollama/issues/15260) reports cases where `think=False` + dict-format silently ignores the schema. Verified non-reproducing on the local runtime against `gemma4:e4b` (returns the 9-element array as expected). A code comment in `trader.py` flags the assumption and asks for a re-check on Ollama upgrades. If a future Ollama silently regresses, the parser's Layer A wrap keeps at least one candidate scored — degraded, not dead.

**Rollback.** Single-commit revert (`git revert`); no data migration.

## Documentation

No documentation updates. CLAUDE.md, README.md, and AGENTS.md describe the harvester/trader contract at a level that is unchanged by this PR. The Trader is still constructed-but-not-scheduled and still ranks at flush.

## Review Focus

- `[IMPORTANT]` `src/microverse/agents/trader.py:47-66` — `_RANK_SCHEMA` shape and the comment explaining the empirical Ollama assumption.
- `[IMPORTANT]` `src/microverse/agents/trader.py:81-87` — new wrap branch in `_extract_list`. Confirm the order (after the unique-list branch) is correct so an existing wrapped-list response still wins over a malformed single-object root.
- `[MINOR]` `tests/test_trader.py` — five new tests; verify the negative guards (`test_extract_list_does_not_wrap_unrelated_root_dict`, `test_rank_drops_root_dict_missing_required_score_field`) actually exercise their intended paths.

## Post-Merge Recommendations

1. **Run the long-deferred 24-hour soak** with this fix in place. The harvest pipeline now produces output, so a soak finally has something to validate end-to-end (snapshots ≈ every 9h at observed cadence, watchdog ≈ every 14 min).
2. **Track `LLM_MAX_TOKENS=1024` truncation as a follow-up.** During the empirical schema check the 9-candidate response truncated mid-stream; the parser still recovered N entries while the rest defaulted to 0.0. Larger flush buffers will lose tail scores. Not a regression vs today (today nothing scores), so deferred — but worth a small PR after this lands.