### PR TITLE
fix: bound deadlock-break + drop Artisan rest-bias from persona

### DIFF
--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -48,3 +48,12 @@ SAMPLING_FACTUAL: dict[str, float | int] = {
 
 # Default tick budget for a non-infinite microverse.run.
 MAX_TICKS_DEFAULT: int = 1_000_000
+
+# Circuit breaker on the deadlock-break path in run.py. Each invocation
+# without an intervening successful think() increments a counter; once
+# it reaches this value the loop exits with a deadlock_break_exit metric
+# bump rather than spinning forever. A 17.9h soak with intermittent
+# Ollama failures generated 6372 timeout bumps because no such bound
+# existed. 10 keeps a brief outage recoverable while bounding the worst
+# case to ~30-60 wasted think() calls before exit.
+MAX_CONSECUTIVE_DEADLOCK_BREAKS: int = 10

--- a/src/microverse/prompts/persona_artisan.j2
+++ b/src/microverse/prompts/persona_artisan.j2
@@ -32,6 +32,5 @@ Decide ONE action. Output STRICT JSON with exactly these keys:
 Hard rules:
 - Never refer to a simulation, AI, model, prompt, or "the outside".
 - Never include any text outside the JSON object.
-- If unsure, choose "rest".
 
 Output only the JSON object. No preamble. No code fences.

--- a/src/microverse/prompts/persona_stranger.j2
+++ b/src/microverse/prompts/persona_stranger.j2
@@ -34,6 +34,5 @@ Hard rules:
   techniques, different stories. Don't merely echo the lore above.
 - Never refer to a simulation, AI, model, prompt, or "the outside".
 - Never include any text outside the JSON object.
-- If unsure, "rest".
 
 Output only the JSON object. No preamble. No code fences.

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -43,6 +43,7 @@ from microverse.agents.artisan import Artisan
 from microverse.agents.base import Action, Agent, WorldContext
 from microverse.agents.harvester import ArtifactCandidate, Harvester
 from microverse.agents.trader import Trader
+from microverse import config
 from microverse.config import MAX_TICKS_DEFAULT
 from microverse.memory import build_context
 from microverse.memory.episodic import EpisodicMemory
@@ -169,6 +170,9 @@ def run(
     max_ticks = ticks if ticks is not None else MAX_TICKS_DEFAULT
     executed = 0
     consecutive_skips = 0
+    # Bounded by config.MAX_CONSECUTIVE_DEADLOCK_BREAKS — see run.py:230
+    # for the exit path. Reset on any successful think() at line 222.
+    deadlock_breaks_since_success = 0
 
     def _safe(label: str, fn: Callable[[], object]) -> None:
         try:
@@ -193,6 +197,18 @@ def run(
                         for a in sched.agents:
                             if metrics.should_pause(a.name):
                                 metrics.reset("consecutive_fail", agent=a.name)
+                        deadlock_breaks_since_success += 1
+                        if (
+                            deadlock_breaks_since_success
+                            >= config.MAX_CONSECUTIVE_DEADLOCK_BREAKS
+                        ):
+                            metrics.bump("deadlock_break_exit")
+                            _logger.error(
+                                "all agents stuck after %d consecutive "
+                                "deadlock-breaks — exiting",
+                                deadlock_breaks_since_success,
+                            )
+                            break
                     consecutive_skips = 0
                 continue
             consecutive_skips = 0
@@ -215,6 +231,7 @@ def run(
                 time.sleep(min(max(tempo or 1.0, 1.0), 5.0))
                 continue
             metrics.reset("consecutive_fail", agent=agent.name)
+            deadlock_breaks_since_success = 0
             _commit_action(episodic, agent, action)
             _maybe_harvest(harvester, agent, action)
             executed += 1

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -39,11 +39,11 @@ import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
+from microverse import config
 from microverse.agents.artisan import Artisan
 from microverse.agents.base import Action, Agent, WorldContext
 from microverse.agents.harvester import ArtifactCandidate, Harvester
 from microverse.agents.trader import Trader
-from microverse import config
 from microverse.config import MAX_TICKS_DEFAULT
 from microverse.memory import build_context
 from microverse.memory.episodic import EpisodicMemory
@@ -198,14 +198,10 @@ def run(
                             if metrics.should_pause(a.name):
                                 metrics.reset("consecutive_fail", agent=a.name)
                         deadlock_breaks_since_success += 1
-                        if (
-                            deadlock_breaks_since_success
-                            >= config.MAX_CONSECUTIVE_DEADLOCK_BREAKS
-                        ):
+                        if deadlock_breaks_since_success >= config.MAX_CONSECUTIVE_DEADLOCK_BREAKS:
                             metrics.bump("deadlock_break_exit")
                             _logger.error(
-                                "all agents stuck after %d consecutive "
-                                "deadlock-breaks — exiting",
+                                "all agents stuck after %d consecutive deadlock-breaks — exiting",
                                 deadlock_breaks_since_success,
                             )
                             break

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -44,7 +44,6 @@ from microverse.agents.artisan import Artisan
 from microverse.agents.base import Action, Agent, WorldContext
 from microverse.agents.harvester import ArtifactCandidate, Harvester
 from microverse.agents.trader import Trader
-from microverse.config import MAX_TICKS_DEFAULT
 from microverse.memory import build_context
 from microverse.memory.episodic import EpisodicMemory
 from microverse.memory.semantic import SemanticMemory
@@ -167,11 +166,12 @@ def run(
     signal.signal(signal.SIGINT, _on_signal)
     signal.signal(signal.SIGTERM, _on_signal)
 
-    max_ticks = ticks if ticks is not None else MAX_TICKS_DEFAULT
+    max_ticks = ticks if ticks is not None else config.MAX_TICKS_DEFAULT
     executed = 0
     consecutive_skips = 0
-    # Bounded by config.MAX_CONSECUTIVE_DEADLOCK_BREAKS — see run.py:230
-    # for the exit path. Reset on any successful think() at line 222.
+    # Bounded by config.MAX_CONSECUTIVE_DEADLOCK_BREAKS; the exit path
+    # below bumps deadlock_break_exit and breaks the loop. Reset to 0
+    # in the success branch right after metrics.reset(consecutive_fail).
     deadlock_breaks_since_success = 0
 
     def _safe(label: str, fn: Callable[[], object]) -> None:

--- a/tests/test_persona_artisan_prompt.py
+++ b/tests/test_persona_artisan_prompt.py
@@ -1,0 +1,22 @@
+"""Persona-prompt content guards for Artisan.
+
+The 17.9h soak showed Aki collapsing into a permanent rest-loop within
+the first hour. The prompt template explicitly told the model "If
+unsure, choose 'rest'", which combined with newest-first episodic
+context produced a self-reinforcing fixed point. These tests pin the
+prompt content so the trap can't silently come back.
+"""
+
+from __future__ import annotations
+
+from microverse.agents.base import WorldContext
+from microverse.prompts import render
+
+
+def test_artisan_prompt_does_not_default_to_rest():
+    rendered = render("persona_artisan.j2", world=WorldContext(), name="Aki")
+    # The literal escape hatch must be gone.
+    assert "If unsure, choose" not in rendered
+    # And no stray 'rest' suggestion in the Hard rules section.
+    hard_rules = rendered.split("Hard rules:")[-1]
+    assert '"rest"' not in hard_rules

--- a/tests/test_persona_artisan_prompt.py
+++ b/tests/test_persona_artisan_prompt.py
@@ -17,6 +17,11 @@ def test_artisan_prompt_does_not_default_to_rest():
     rendered = render("persona_artisan.j2", world=WorldContext(), name="Aki")
     # The literal escape hatch must be gone.
     assert "If unsure, choose" not in rendered
-    # And no stray 'rest' suggestion in the Hard rules section.
-    hard_rules = rendered.split("Hard rules:")[-1]
-    assert '"rest"' not in hard_rules
+    # And no stray rest suggestion in the Hard rules section. We assert
+    # the section anchor exists first so a template restructure can't
+    # silently turn this guard into a no-op, and we use a partition so
+    # a missing anchor would raise rather than yield the whole prompt.
+    # Lower-cased substring catches both quoted and unquoted forms.
+    assert "Hard rules:" in rendered
+    hard_rules = rendered.split("Hard rules:", 1)[1]
+    assert "rest" not in hard_rules.lower()

--- a/tests/test_persona_stranger_prompt.py
+++ b/tests/test_persona_stranger_prompt.py
@@ -1,0 +1,25 @@
+"""Persona-prompt content guards for Stranger.
+
+The Watchdog's echo-chamber rehab path can register a Stranger mid-run,
+so the same rest-bias trap that hit Artisan in the 17.9h soak could
+reappear via Stranger if the persona keeps an explicit rest default.
+Pin the prompt content so the trap can't sneak back in through this
+agent.
+"""
+
+from __future__ import annotations
+
+from microverse.agents.base import WorldContext
+from microverse.prompts import render
+
+
+def test_stranger_prompt_does_not_default_to_rest():
+    rendered = render("persona_stranger.j2", world=WorldContext(), name="Mira")
+    # The literal escape hatch must be gone.
+    assert "If unsure, choose" not in rendered
+    assert 'If unsure, "rest"' not in rendered
+    # And no stray rest suggestion in the Hard rules section
+    # (case-insensitive, catches quoted and unquoted forms).
+    assert "Hard rules:" in rendered
+    hard_rules = rendered.split("Hard rules:", 1)[1]
+    assert "rest" not in hard_rules.lower()

--- a/tests/test_run_smoke.py
+++ b/tests/test_run_smoke.py
@@ -191,6 +191,47 @@ def test_deadlock_break_only_fires_when_all_agents_paused():
     assert _all_agents_paused(m, agents) is True
 
 
+def test_run_exits_after_consecutive_deadlock_breaks(tmp_path: Path):
+    """A 17.9-hour soak ran for hours with cumulative llm_timeout=6372:
+    Ollama was intermittently unhealthy, every 3 fails paused the only
+    agent, the deadlock-break path reset and re-tried, and the loop
+    spun forever. Bound that loop. After ``MAX_CONSECUTIVE_DEADLOCK_BREAKS``
+    consecutive deadlock-break invocations *without an intervening
+    successful tick*, exit cleanly with a fatal-metric bump."""
+    import sqlite3
+
+    from microverse import config
+
+    def boom(**_kwargs: object) -> dict[str, object]:
+        raise TimeoutError("simulated ollama outage")
+
+    data_dir = tmp_path / "data"
+    harvest_dir = tmp_path / "harvest"
+
+    with (
+        patch("microverse.run.time.sleep", side_effect=lambda *_a, **_k: None),
+        patch("microverse.agents.artisan.chat", side_effect=boom),
+        patch.object(config, "MAX_CONSECUTIVE_DEADLOCK_BREAKS", 2),
+    ):
+        executed = run(
+            ticks=10_000,
+            seed=0,
+            tempo=0,
+            data_dir=data_dir,
+            harvest_dir=harvest_dir,
+        )
+
+    # Loop exited without committing anything (every think() raised).
+    assert executed == 0
+
+    # The fatal metric was bumped exactly once on exit.
+    with sqlite3.connect(str(data_dir / "metrics.sqlite")) as conn:
+        rows = conn.execute(
+            "SELECT MAX(value) FROM metrics WHERE name='deadlock_break_exit'"
+        ).fetchall()
+    assert rows == [(1,)], f"expected deadlock_break_exit=1, got {rows}"
+
+
 def test_run_recovers_from_all_paused_via_consecutive_fail_reset(tmp_path: Path):
     """Three consecutive parse failures pause the only agent. The tick
     loop must auto-rehab via reset(consecutive_fail) so the run can


### PR DESCRIPTION
## Summary

Two cooperating bugs surfaced in a 17.9-hour soak: `run.py`'s deadlock-break path reset `consecutive_fail` forever with no terminal condition, and the Artisan persona had an explicit `If unsure, choose "rest"` line that, combined with newest-first episodic context, locked the LLM into a permanent rest-loop within the first hour. This PR adds a circuit breaker on the deadlock-break and removes the rest-bias line from the prompt.

## Background / Motivation

A 17.9h soak (cut short by an unrelated system restart, but the data survived intact via WAL) returned:

- 1178 ticks, of which only **55 were craft and 1112 were rest** — Aki produced zero artifacts after id=71.
- `llm_timeout` cumulative **6372** vs `json_ok` **1167**, but final `consecutive_fail = 1`. Failures were intermittent; the loop just never stopped retrying.
- Sample rest payload: *"The drawing feels nearly complete… forcing more now would detract from the intended feeling."* — a coherent in-character LLM decision, not a parse fallback.

Codex and a manual review of the source agreed on two interacting root causes:

1. **`run.py:190-196` deadlock-break is unbounded.** With the single-agent setup (Aki only), the cycle is: 3 fails → pause → 3 skips → break → reset → repeat. Forever.
2. **`persona_artisan.j2:35` says `If unsure, choose "rest"`.** Combined with `episodic.since()` returning newest-first (`episodic.py:122-140`), once a couple of rest events land they sit at the top of "Recent things you witnessed" and self-reinforce.

`build_context()` itself is fine (~4 ms on the live DB) — the bottleneck was at the model.

## Breaking Changes

None. New config constant + one removed prompt line. Existing tests still pass; the new metric `deadlock_break_exit` is additive and only ever bumps in the failure path.

## Changes Made

- `src/microverse/config.py` — new `MAX_CONSECUTIVE_DEADLOCK_BREAKS: int = 10` with rationale.
- `src/microverse/run.py` — track consecutive deadlock-break invocations without an intervening successful think(); when threshold reached, bump `deadlock_break_exit` and break the loop. The `finally` block still runs final harvester flush + closes. Switched to `from microverse import config` so tests can `patch.object(config, ...)` without rebinding a local import.
- `src/microverse/prompts/persona_artisan.j2` — removed the `If unsure, choose "rest"` Hard-rule line. Other rules (no meta-leaks, JSON-only) untouched.
- `tests/test_run_smoke.py` — new behavioral test injecting an always-raising `chat()`, asserting the loop exits at threshold with `deadlock_break_exit == 1` and `executed == 0`.
- `tests/test_persona_artisan_prompt.py` — pins the rendered persona so the rest-default cannot silently return.

## Dependencies

None.

## Test Methodologies and Results

Local quality gate (CLAUDE.md required suite):

```
uv run ruff check                          # All checks passed!
uv run ruff format --check                 # 50 files already formatted
uv run mypy src/microverse                 # no issues found in 26 files
uv run pip-audit                           # No known vulnerabilities found
uv run pytest -q -m 'not integration'      # 233 passed, 2 deselected (+2 new)
uv build                                   # built sdist + wheel
```

Live verification (operator-run, requires Ollama + `gemma4:e4b`). Two checkpoints:
1. **45-min wiring re-soak.** Pass criteria: at least 50% of Aki's actions are `craft`; `deadlock_break_exit == 0`; harvest manifest non-empty with >0 accepted artifacts and 0 zero-scored entries (PR #15 + #16 fixes still hold).
2. **24-hour soak.** Pass criteria: 2 snapshots fire (~hours 9.7 and 19.4), craft rate stays well above rest rate, kill-drill watermark contiguous.

## Design & Reasoning Notes

- **Circuit breaker, not fail-fast.** Codex initially recommended fatal-on-first-deadlock-break. That's too aggressive for a 24h operator run — a brief Ollama hiccup at hour 22 would lose the day. The counter pattern lets the system ride through transient blips while bounding the worst case to ~30-60 wasted think() calls before exit. Default threshold 10 picked to balance recoverability vs spin-bound.
- **Threshold lives in `config.py`.** Operator-tunable without code edits; testable via `patch.object(config, ...)`.
- **`from microverse import config` import.** Required for the test pattern to work (a `from x import CONST` would create a local binding that monkeypatch can't reach). Slightly less idiomatic than the existing `from microverse.config import MAX_TICKS_DEFAULT` style but the testing benefit outweighs the inconsistency.
- **Why drop the line, not reword.** "If unsure, choose <action>" is a fixed-point trap regardless of the action — any default that also appears in the action set will be reinforced via context once it lands. The right answer is no default at all; let the LLM stay in the action it can best justify.

## Impact / Risk Assessment

**Affected.** Tick loop and Artisan persona only. Trader/Elder/Watchdog unchanged.

**Risk: deadlock-break too aggressive.** If Ollama has a 10-minute outage and the threshold trips, a long-running operator soak exits and needs a manual restart. Mitigation: threshold is config-tunable; the metric `deadlock_break_exit` makes this state visible in the metrics DB so operators can see why a run ended.

**Risk: removed line affects creative output quality.** Without the "if unsure → rest" escape hatch, the LLM might produce lower-quality crafts when uncertain. Mitigation: the Trader's percentile cutoff already filters low-quality output at harvest time. The 2.5h baseline soak (which never hit the rest-trap) showed clean output without this line being load-bearing.

**Rollback.** Single-commit revert of the `run.py` change is safe (just removes the exit guard). The prompt revert is also a one-line restore.

## Documentation

No documentation updates beyond the inline rationale comments. CLAUDE.md and README describe the deadlock-break behavior as an existing rehab path; the new bound is additive and the existing description still reads correctly. Worth a follow-up doc PR after the next 24h soak validates the fix.

## Review Focus

- `[IMPORTANT]` `src/microverse/run.py:170-175` and `194-208` — the counter increments inside the rehab branch (not on every paused tick); reset on successful think() at line ~222. Verify the counter can't grow without an actual deadlock-break invocation.
- `[IMPORTANT]` `src/microverse/config.py:43-50` — threshold value (10). Consider whether this should be lower (more aggressive exit) or higher (more recoverable) given the observed failure pattern.
- `[MINOR]` `src/microverse/prompts/persona_artisan.j2` — verify the remaining Hard rules section reads well without the dropped line.

## Post-Merge Recommendations

1. **Run the 45-min wiring re-soak before re-attempting 24h.** If craft rate stays >50% and `deadlock_break_exit == 0`, proceed to the 24h.
2. **If the rest-trap returns despite Layer B**, escalate to Layer C: drop or downsample `rest` events when assembling `recent_episodic`, and consider chronological (oldest-first) order. Touches `memory/__init__.py` and `memory/episodic.py`.
3. **Track `watchdog_stagnation` in the next soak.** Stagnation fired 42 times in the failed soak but no Stranger appeared. The watchdog → Stranger spawn path is worth a separate audit — it's documented as the echo-chamber escape hatch but apparently isn't triggering.
4. **Consider renaming `llm_timeout`.** It counts any think() exception, not just timeouts. A doc-only rename PR would clarify operator dashboards.