### PR TITLE
fix(run): catch generic exceptions from maybe_snapshot

### DIFF
--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -257,6 +257,16 @@ def run(
                 # will try again.
                 _logger.warning("snapshot skipped: WAL checkpoint busy")
                 metrics.bump("snapshot_skip_busy")
+            except Exception:
+                # Anything else (sqlite3.OperationalError "disk I/O
+                # error", a transient FS failure, OS-level truncate
+                # racing tar) must NOT kill the loop. WAL is the
+                # durability boundary; snapshots are cold backups, so
+                # missing one interval is acceptable. A 24h soak
+                # crashed here once when this branch only caught
+                # SnapshotBusyError.
+                _logger.exception("snapshot failed")
+                metrics.bump("snapshot_fail")
 
             sleep_s = tempo if tempo is not None else agent.tempo()
             if sleep_s > 0:

--- a/tests/test_run_smoke.py
+++ b/tests/test_run_smoke.py
@@ -232,6 +232,48 @@ def test_run_exits_after_consecutive_deadlock_breaks(tmp_path: Path):
     assert rows == [(1,)], f"expected deadlock_break_exit=1, got {rows}"
 
 
+def test_run_survives_snapshot_disk_io_error(tmp_path: Path):
+    """A 24h soak crashed at hour 4 because sqlite3.OperationalError
+    ('disk I/O error') was raised from PRAGMA wal_checkpoint(TRUNCATE)
+    inside maybe_snapshot, but the snapshot site only caught
+    SnapshotBusyError. The OperationalError escaped, killed the loop,
+    and 451 trailing rest events were lost. The loop must absorb
+    arbitrary snapshot exceptions with a metric bump."""
+    import sqlite3
+
+    def raise_io(*_args: object, **_kwargs: object) -> None:
+        raise sqlite3.OperationalError("disk I/O error")
+
+    rest_only = {
+        "content": '{"thought": "x", "action": "rest", "target": null, "artifact": null}',
+        "thinking": "",
+        "raw": {},
+    }
+
+    with (
+        patch("microverse.run.time.sleep", side_effect=lambda *_a, **_k: None),
+        patch("microverse.agents.artisan.chat", return_value=rest_only),
+        patch("microverse.run.maybe_snapshot", side_effect=raise_io),
+    ):
+        executed = run(
+            ticks=3,
+            seed=0,
+            tempo=0,
+            data_dir=tmp_path / "data",
+            harvest_dir=tmp_path / "harvest",
+        )
+
+    assert executed == 3, "loop must complete despite snapshot I/O error"
+
+    with sqlite3.connect(str(tmp_path / "data" / "metrics.sqlite")) as conn:
+        rows = conn.execute(
+            "SELECT MAX(value) FROM metrics WHERE name='snapshot_fail'"
+        ).fetchall()
+    assert rows and rows[0][0] is not None and rows[0][0] >= 1, (
+        f"expected snapshot_fail bumped, got {rows}"
+    )
+
+
 def test_run_recovers_from_all_paused_via_consecutive_fail_reset(tmp_path: Path):
     """Three consecutive parse failures pause the only agent. The tick
     loop must auto-rehab via reset(consecutive_fail) so the run can

--- a/tests/test_run_smoke.py
+++ b/tests/test_run_smoke.py
@@ -266,12 +266,11 @@ def test_run_survives_snapshot_disk_io_error(tmp_path: Path):
     assert executed == 3, "loop must complete despite snapshot I/O error"
 
     with sqlite3.connect(str(tmp_path / "data" / "metrics.sqlite")) as conn:
-        rows = conn.execute(
+        max_val = conn.execute(
             "SELECT MAX(value) FROM metrics WHERE name='snapshot_fail'"
-        ).fetchall()
-    assert rows and rows[0][0] is not None and rows[0][0] >= 1, (
-        f"expected snapshot_fail bumped, got {rows}"
-    )
+        ).fetchone()[0]
+    assert max_val is not None, "snapshot_fail metric not persisted"
+    assert max_val >= 1, f"expected snapshot_fail >= 1, got {max_val}"
 
 
 def test_run_recovers_from_all_paused_via_consecutive_fail_reset(tmp_path: Path):


### PR DESCRIPTION
## Summary

A 24-hour soak crashed at hour 4 because `PRAGMA wal_checkpoint(TRUNCATE)` inside `maybe_snapshot()` raised `sqlite3.OperationalError("disk I/O error")`, but the snapshot site at `run.py:246-259` only caught `SnapshotBusyError`. The OperationalError escaped, killed the loop, and 451 trailing rest events were lost.

This PR adds a second `except Exception` arm that logs and bumps a new `snapshot_fail` metric, mirroring the established harvester.flush() exception handling pattern just above (`run.py:240-245`).

## Background

WAL on the episodic event log is the actual durability boundary. Snapshots are cold backups for catastrophic recovery (kernel panic, disk corruption, accidental `rm`). Skipping a snapshot interval is therefore preferable to crashing the simulation.

The crash signature from `soak-24h-2.log`:

```
File "src/microverse/run.py", line 247, in run
    maybe_snapshot(...)
File "src/microverse/world/snapshot.py", line 136, in take_snapshot
    _checkpoint_wal(data_dir)
File "src/microverse/world/snapshot.py", line 66, in _checkpoint_wal
    row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
sqlite3.OperationalError: disk I/O error
```

`OperationalError` is a `DatabaseError` subclass, but `_checkpoint_wal` only filters on `sqlite_errorcode == _SQLITE_NOTADB`; everything else re-raises by design. The call site has to absorb it.

## Changes

- `src/microverse/run.py:253-269` add `except Exception` arm with `snapshot_fail` metric bump
- `tests/test_run_smoke.py` add `test_run_survives_snapshot_disk_io_error` with patched `maybe_snapshot` raising `sqlite3.OperationalError`

## TDD

| Commit | Status |
|---|---|
| `3fd32f8` test: red — run loop must survive snapshot disk I/O errors | red |
| `25afcfe` fix(run): catch generic exceptions from maybe_snapshot | green |
| `6c950a5` chore(test): split composite assertion to satisfy PT018 | lint |

## Quality gate

- `uv run ruff check` ✓
- `uv run ruff format --check` ✓
- `uv run mypy src/microverse` ✓
- `uv run pytest -q -m 'not integration'` 235 passed
- `uv run pip-audit` no vulns
- `uv build` ✓

## Out of scope

The 24h soak surfaced a second, harder failure: rest-trap recurrence at hour 4 (PR #17's persona-prompt fix proved insufficient). That is being scoped separately as Layer C from the original soak-stability plan, with Codex consultation in progress on the right intervention (downsampling rest events from `recent_episodic`, chronological ordering, or both). Tracked as task #36.

## Test plan

- [x] Red commit reproduces the bug deterministically (mock injects `sqlite3.OperationalError`)
- [x] Green commit makes red pass + the rest of the suite stays green
- [ ] Re-run the 24h soak after the Layer C fix (#36) lands so both bugs are exercised together