### PR TITLE
fix(memory): compress consecutive rest runs (Layer C)

### DIFF
--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 from microverse.agents.base import WorldContext
 
 if TYPE_CHECKING:
-    from microverse.memory.episodic import EpisodicMemory
+    from microverse.memory.episodic import EpisodicMemory, Event
     from microverse.memory.semantic import SemanticMemory
 
 
@@ -41,7 +41,7 @@ def _format_episodic(actor: str, action: str, thought: str) -> str:
     return f"{actor} {action}"
 
 
-def _compress_rest_runs(events: list) -> list[str]:
+def _compress_rest_runs(events: list[Event]) -> list[str]:
     """Collapse runs of >=2 consecutive same-actor rest events into a
     single summary line so a long rest streak cannot poison
     ``recent_episodic`` by repeating identical narratives. Preserves the

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -41,6 +41,52 @@ def _format_episodic(actor: str, action: str, thought: str) -> str:
     return f"{actor} {action}"
 
 
+def _compress_rest_runs(events: list) -> list[str]:
+    """Collapse runs of >=2 consecutive same-actor rest events into a
+    single summary line so a long rest streak cannot poison
+    ``recent_episodic`` by repeating identical narratives. Preserves the
+    latest rest's thought (events arrive newest-first from
+    ``EpisodicMemory.since``) so body-state signal survives.
+
+    A single isolated rest is left verbatim; only runs of length >=2 are
+    compressed. Runs are broken by any non-rest event or a rest by a
+    different actor.
+    """
+    out: list[str] = []
+    run_actor: str | None = None
+    run_count = 0
+    run_thought = ""
+
+    def flush() -> None:
+        nonlocal run_actor, run_count, run_thought
+        if run_count >= 2 and run_actor:
+            line = f"{run_actor} rested {run_count} times"
+            if run_thought:
+                line += f". Latest: {run_thought}"
+            out.append(line)
+        elif run_count == 1 and run_actor:
+            out.append(_format_episodic(run_actor, "rest", run_thought))
+        run_actor = None
+        run_count = 0
+        run_thought = ""
+
+    for e in events:
+        thought = str(e.payload.get("thought") or "")
+        if e.action == "rest":
+            if run_actor == e.actor:
+                run_count += 1
+            else:
+                flush()
+                run_actor = e.actor
+                run_count = 1
+                run_thought = thought
+        else:
+            flush()
+            out.append(_format_episodic(e.actor, e.action, thought))
+    flush()
+    return out
+
+
 def _pack_under_budget(items: list[str], token_budget: int, joiner: str = "\n") -> tuple[str, ...]:
     """Take items in order; drop trailing items once the rendered
     (joined) token count would exceed the budget. We measure the
@@ -99,9 +145,7 @@ def build_context(
     """
     cutoff = time.time() - episodic_window_s
     events = episodic.since(cutoff, limit=episodic_lookback)
-    recent_lines = [
-        _format_episodic(e.actor, e.action, str(e.payload.get("thought") or "")) for e in events
-    ]
+    recent_lines = _compress_rest_runs(events)
     recent = _pack_under_budget(recent_lines, episodic_tok)
 
     lore_lines: list[str] = []

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -234,6 +234,66 @@ def test_build_context_compression_run_broken_by_other_actor(tmp_path: Path) -> 
     assert counts == [5, 7], f"counts must match the two runs, got {counts}"
 
 
+def test_build_context_summary_captures_latest_thought(tmp_path: Path) -> None:
+    """The compression docstring promises the summary preserves the
+    latest rest's thought (newest-by-id). Append rests with distinct,
+    sequential thoughts so we can verify which one ends up in the
+    'Latest:' tail rather than relying on identical-thought tests
+    where the contract is unobservable.
+    """
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for marker in ("first", "second", "third"):
+            ep.append(
+                actor="Aki",
+                action="rest",
+                target=None,
+                payload={"thought": f"the {marker} rest"},
+            )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
+    assert len(summary_lines) == 1, f"expected one summary, got {summary_lines!r}"
+    summary = summary_lines[0]
+    assert "rested 3 times" in summary
+    assert "the third rest" in summary, (
+        f"summary must capture the newest rest's thought, got {summary!r}"
+    )
+    assert "the first rest" not in summary
+    assert "the second rest" not in summary
+
+
+def test_build_context_compression_separates_runs_by_actor(tmp_path: Path) -> None:
+    """Watchdog can spawn a Stranger mid-run, so a real production
+    scenario is `Aki rest * 3 / Stranger rest * 2 / Aki rest * 4`.
+    The actor change must break the run, producing three separate
+    summaries (or, when the middle run has length 1, leaving it
+    verbatim) rather than collapsing into one merged span keyed off
+    'rest action'.
+    """
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for _ in range(3):
+            ep.append(actor="Aki", action="rest", target=None, payload={"thought": "Aki tired"})
+        for _ in range(2):
+            ep.append(actor="Mira", action="rest", target=None, payload={"thought": "Mira tired"})
+        for _ in range(4):
+            ep.append(
+                actor="Aki",
+                action="rest",
+                target=None,
+                payload={"thought": "Aki still tired"},
+            )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    aki_summaries = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
+    mira_summaries = [line for line in out.recent_episodic if line.startswith("Mira rested ")]
+    assert len(aki_summaries) == 2, f"expected two Aki summaries, got {aki_summaries!r}"
+    assert len(mira_summaries) == 1, f"expected one Mira summary, got {mira_summaries!r}"
+
+    aki_counts = sorted(int(line.split()[2]) for line in aki_summaries)
+    assert aki_counts == [3, 4], f"Aki counts must match its two runs, got {aki_counts}"
+    assert "rested 2 times" in mira_summaries[0]
+
+
 def test_episodic_excerpts_capped_to_budget(tmp_path: Path):
     rng = random.Random(7)
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -205,9 +205,7 @@ def test_build_context_keeps_isolated_rest_uncompressed(tmp_path: Path) -> None:
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
         ep.append(actor="Aki", action="craft", target=None, payload={"thought": "shaped a bowl"})
         ep.append(actor="Aki", action="rest", target=None, payload={"thought": "a brief pause"})
-        ep.append(
-            actor="Aki", action="craft", target=None, payload={"thought": "shaped another"}
-        )
+        ep.append(actor="Aki", action="craft", target=None, payload={"thought": "shaped another"})
         out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
 
     summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
@@ -223,9 +221,7 @@ def test_build_context_compression_run_broken_by_other_actor(tmp_path: Path) -> 
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
         for _ in range(5):
             ep.append(actor="Aki", action="rest", target=None, payload={"thought": "tired"})
-        ep.append(
-            actor="world", action="weather.drought", target=None, payload={"thought": ""}
-        )
+        ep.append(actor="world", action="weather.drought", target=None, payload={"thought": ""})
         for _ in range(7):
             ep.append(actor="Aki", action="rest", target=None, payload={"thought": "still tired"})
         out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -146,6 +146,98 @@ def test_est_tokens_is_len_div_four():
     assert est_tokens("") == 0
 
 
+def test_build_context_compresses_consecutive_rest_runs(tmp_path: Path) -> None:
+    """The 24h soak (#29) saw Aki collapse into a 451-event rest streak
+    that poisoned ``recent_episodic`` with a wall of identical rest
+    narratives. PR #17's prompt nudge alone could not break this; the
+    fix is at the memory layer.
+
+    A run of >=2 consecutive same-actor rests must collapse to a single
+    summary line that preserves the latest rest's thought (so body
+    state is retained), keeping the rest of the slice budget for
+    non-rest context.
+    """
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(
+            actor="Aki",
+            action="craft",
+            target=None,
+            payload={"thought": "I shaped the cedar.", "artifact": "cedar bowl"},
+        )
+        for _ in range(80):
+            ep.append(
+                actor="Aki",
+                action="rest",
+                target=None,
+                payload={"thought": "the mandate for rest is absolute"},
+            )
+        out = build_context(
+            world_base=WorldContext(),
+            episodic=ep,
+            semantic=se,
+            topic="",
+            episodic_tok=1500,
+        )
+
+    joined = "\n".join(out.recent_episodic)
+
+    summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
+    assert len(summary_lines) == 1, f"expected one rest summary, got {summary_lines!r}"
+    assert "rested 80 times" in summary_lines[0]
+
+    bare_rest = [line for line in out.recent_episodic if line.startswith("Aki rest:")]
+    assert len(bare_rest) <= 1, f"expected <=1 bare 'Aki rest:' line, got {bare_rest!r}"
+
+    craft_lines = [line for line in out.recent_episodic if line.startswith("Aki craft")]
+    assert craft_lines, "the older craft event must still surface"
+
+    mandate_repeats = joined.count("mandate for rest")
+    assert mandate_repeats <= 1, (
+        f"trap language must not repeat after compression, got {mandate_repeats}x"
+    )
+
+    assert est_tokens(joined) <= 1500
+
+
+def test_build_context_keeps_isolated_rest_uncompressed(tmp_path: Path) -> None:
+    """A single isolated rest must not be summarised; only runs of
+    >=2 consecutive rests get collapsed."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(actor="Aki", action="craft", target=None, payload={"thought": "shaped a bowl"})
+        ep.append(actor="Aki", action="rest", target=None, payload={"thought": "a brief pause"})
+        ep.append(
+            actor="Aki", action="craft", target=None, payload={"thought": "shaped another"}
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
+    assert summary_lines == [], f"isolated rest must not be summarised, got {summary_lines!r}"
+
+    bare_rest = [line for line in out.recent_episodic if line.startswith("Aki rest:")]
+    assert len(bare_rest) == 1, f"isolated rest must appear verbatim, got {bare_rest!r}"
+
+
+def test_build_context_compression_run_broken_by_other_actor(tmp_path: Path) -> None:
+    """A non-Aki event (e.g. world weather) breaks a rest run, producing
+    two summaries flanking the interloper rather than one merged span."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for _ in range(5):
+            ep.append(actor="Aki", action="rest", target=None, payload={"thought": "tired"})
+        ep.append(
+            actor="world", action="weather.drought", target=None, payload={"thought": ""}
+        )
+        for _ in range(7):
+            ep.append(actor="Aki", action="rest", target=None, payload={"thought": "still tired"})
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
+    assert len(summary_lines) == 2, (
+        f"expected two summaries flanking weather, got {summary_lines!r}"
+    )
+    counts = sorted(int(line.split()[2]) for line in summary_lines)
+    assert counts == [5, 7], f"counts must match the two runs, got {counts}"
+
+
 def test_episodic_excerpts_capped_to_budget(tmp_path: Path):
     rng = random.Random(7)
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:


### PR DESCRIPTION
## Summary

PR #17 (Layer A + B of the soak-stability plan) bounded the deadlock-break loop and removed the explicit `If unsure, choose "rest".` line from the Artisan and Stranger personas. That was insufficient: the 24h soak (issue #29) saw Aki collapse into a 451-event rest streak after hour 3 anyway, with `json_ok=2000` matching event count and `consecutive_fail=0` — a real LLM choice, not a parse failure.

Diagnosis (independently confirmed by Codex review): when `recent_episodic` fills with identical rest narratives, the LLM keeps reading "the most recent things were all rest" and continues the pattern. The trap lives at the memory layer, not the prompt layer.

This PR implements Layer C from the original plan: collapse runs of >=2 consecutive same-actor rest events into a single summary line in `build_context`, before the token-budget packer runs.

## Behaviour

Before:
```
Aki rest: today I will rest
Aki rest: the mandate for rest is absolute
Aki rest: the mandate for rest is absolute
... × 78 more identical lines, filling 1500 tokens with no signal ...
```

After:
```
Aki rested 80 times. Latest: the mandate for rest is absolute
Aki craft: I shaped the cedar.
... budget freed for non-rest context ...
```

A single isolated rest stays verbatim (`Aki rest: a brief pause`); only runs of length >=2 are compressed. Runs are broken by any non-rest event or a rest by a different actor (so a `world weather.drought` event between rests produces two flanking summaries, not one merged span).

## Why this design (per Codex)

| Option | Why not |
|---|---|
| Drop rest entirely from `recent_episodic` | semantically lossy, hides body-state, can create opposite bias |
| Downsample 1-in-5 | weak when 100% of window is rest (still 90 lines from 451) |
| Reverse to chronological order | improvement but insufficient if the entire slice is rest |
| **Compress consecutive runs** | preserves latest rest's thought, frees budget, breaks the narrative repetition that fed the trap |

Codex flagged: "prompt nudge alone is NOT sufficient; it addresses interpretation, not the poisoned evidence." Hold prompt-template changes in reserve only if a follow-up soak still drifts after compression ships.

## TDD

| Commit | Status |
|---|---|
| `174243b` test: red — build_context must compress consecutive rest runs | red |
| `53dddbf` fix(memory): compress consecutive rest runs in build_context | green |

Three tests in `tests/test_context_budget.py`:

1. `test_build_context_compresses_consecutive_rest_runs`: 80 rests collapse to one summary; older craft still surfaces; `mandate for rest` does not repeat; budget held.
2. `test_build_context_keeps_isolated_rest_uncompressed`: a single rest between crafts stays verbatim.
3. `test_build_context_compression_run_broken_by_other_actor`: a `world weather.drought` event splits a rest run into two summaries.

## Quality gate

- `uv run ruff check` ✓
- `uv run ruff format --check` ✓
- `uv run mypy src/microverse` ✓
- `uv run pytest -q -m 'not integration'` 238 passed
- `uv run pip-audit` no vulns
- `uv build` ✓

## Related

- Followup of PR #17 (deadlock-break bound + persona rest-bias removal)
- Pairs with PR #18 (snapshot disk-I/O resilience) — both crashes from soak #29

## Test plan

- [x] Red commit reproduces the bug deterministically (no LLM)
- [x] Green commit makes red pass + the rest of the suite stays green
- [ ] After merge: re-run wiring soak (~45 min) to confirm the 451-rest pattern cannot recur
- [ ] After wiring soak passes: re-attempt the 24h soak