### PR TITLE
fix(memory): drop Latest thought from rest-run summary (Layer D)

### DIFF
--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -43,14 +43,19 @@ def _format_episodic(actor: str, action: str, thought: str) -> str:
 
 def _compress_rest_runs(events: list[Event]) -> list[str]:
     """Collapse runs of >=2 consecutive same-actor rest events into a
-    single summary line so a long rest streak cannot poison
-    ``recent_episodic`` by repeating identical narratives. Preserves the
-    latest rest's thought (events arrive newest-first from
-    ``EpisodicMemory.since``) so body-state signal survives.
+    single count-only summary line so a long rest streak cannot poison
+    ``recent_episodic``.
 
-    A single isolated rest is left verbatim; only runs of length >=2 are
-    compressed. Runs are broken by any non-rest event or a rest by a
-    different actor.
+    A single isolated rest is left verbatim (its thought is real recent
+    context, not a run); only runs of length >=2 are compressed. Runs
+    are broken by any non-rest event or a rest by a different actor.
+
+    The summary is intentionally count-only ("Aki rested 80 times"). An
+    earlier Layer C draft preserved the latest rest's thought, but
+    soak-24h-3 hour-1 showed the LLM keeps constructing an "exhausted
+    artisan" self-narrative when fatigue thoughts are fed forward — even
+    one summary line is enough seed for the next tick's reasoning. The
+    count alone conveys magnitude without amplifying the narrative.
     """
     out: list[str] = []
     run_actor: str | None = None
@@ -60,10 +65,7 @@ def _compress_rest_runs(events: list[Event]) -> list[str]:
     def flush() -> None:
         nonlocal run_actor, run_count, run_thought
         if run_count >= 2 and run_actor:
-            line = f"{run_actor} rested {run_count} times"
-            if run_thought:
-                line += f". Latest: {run_thought}"
-            out.append(line)
+            out.append(f"{run_actor} rested {run_count} times")
         elif run_count == 1 and run_actor:
             out.append(_format_episodic(run_actor, "rest", run_thought))
         run_actor = None

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -153,9 +153,11 @@ def test_build_context_compresses_consecutive_rest_runs(tmp_path: Path) -> None:
     fix is at the memory layer.
 
     A run of >=2 consecutive same-actor rests must collapse to a single
-    summary line that preserves the latest rest's thought (so body
-    state is retained), keeping the rest of the slice budget for
-    non-rest context.
+    summary line carrying ONLY the count, no thought text. PR #19
+    initially preserved the latest rest's thought, but soak-24h-3 hour-1
+    showed Aki keeps constructing a coherent ``exhausted artisan`` self-
+    narrative when the latest fatigue thought is fed forward — even one
+    summary line is enough seed for the loop. Layer D drops the thought.
     """
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
         ep.append(
@@ -183,7 +185,9 @@ def test_build_context_compresses_consecutive_rest_runs(tmp_path: Path) -> None:
 
     summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
     assert len(summary_lines) == 1, f"expected one rest summary, got {summary_lines!r}"
-    assert "rested 80 times" in summary_lines[0]
+    assert summary_lines[0] == "Aki rested 80 times", (
+        f"summary must be count-only after Layer D, got {summary_lines[0]!r}"
+    )
 
     bare_rest = [line for line in out.recent_episodic if line.startswith("Aki rest:")]
     assert len(bare_rest) <= 1, f"expected <=1 bare 'Aki rest:' line, got {bare_rest!r}"
@@ -192,8 +196,8 @@ def test_build_context_compresses_consecutive_rest_runs(tmp_path: Path) -> None:
     assert craft_lines, "the older craft event must still surface"
 
     mandate_repeats = joined.count("mandate for rest")
-    assert mandate_repeats <= 1, (
-        f"trap language must not repeat after compression, got {mandate_repeats}x"
+    assert mandate_repeats == 0, (
+        f"trap language must NOT survive into compressed slice, got {mandate_repeats}x"
     )
 
     assert est_tokens(joined) <= 1500
@@ -234,12 +238,15 @@ def test_build_context_compression_run_broken_by_other_actor(tmp_path: Path) -> 
     assert counts == [5, 7], f"counts must match the two runs, got {counts}"
 
 
-def test_build_context_summary_captures_latest_thought(tmp_path: Path) -> None:
-    """The compression docstring promises the summary preserves the
-    latest rest's thought (newest-by-id). Append rests with distinct,
-    sequential thoughts so we can verify which one ends up in the
-    'Latest:' tail rather than relying on identical-thought tests
-    where the contract is unobservable.
+def test_build_context_rest_summary_omits_thoughts(tmp_path: Path) -> None:
+    """Layer D inversion of the earlier "captures latest thought" test.
+
+    Hour-1 of the post-Layer-C 24h soak (seed 38) showed the LLM
+    constructing a coherent "exhausted artisan" narrative even when
+    100+ rests were collapsed to one summary line: the ``Latest:``
+    thought in that summary kept seeding the next tick's reasoning
+    with fatigue language. The fix is to drop the thought entirely
+    from compressed summaries — the count alone signals magnitude.
     """
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
         for marker in ("first", "second", "third"):
@@ -254,12 +261,12 @@ def test_build_context_summary_captures_latest_thought(tmp_path: Path) -> None:
     summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
     assert len(summary_lines) == 1, f"expected one summary, got {summary_lines!r}"
     summary = summary_lines[0]
-    assert "rested 3 times" in summary
-    assert "the third rest" in summary, (
-        f"summary must capture the newest rest's thought, got {summary!r}"
+    assert summary == "Aki rested 3 times", (
+        f"summary must be count-only, got {summary!r}"
     )
-    assert "the first rest" not in summary
-    assert "the second rest" not in summary
+    assert "Latest" not in summary
+    for marker in ("first", "second", "third"):
+        assert f"the {marker} rest" not in summary
 
 
 def test_build_context_compression_separates_runs_by_actor(tmp_path: Path) -> None:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -261,9 +261,7 @@ def test_build_context_rest_summary_omits_thoughts(tmp_path: Path) -> None:
     summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
     assert len(summary_lines) == 1, f"expected one summary, got {summary_lines!r}"
     summary = summary_lines[0]
-    assert summary == "Aki rested 3 times", (
-        f"summary must be count-only, got {summary!r}"
-    )
+    assert summary == "Aki rested 3 times", f"summary must be count-only, got {summary!r}"
     assert "Latest" not in summary
     for marker in ("first", "second", "third"):
         assert f"the {marker} rest" not in summary


### PR DESCRIPTION
## Summary

PR #19 (Layer C) compressed rest evidence to one summary line. Hour-1 of a post-Layer-C 24h soak (`data/soak-24h-3`, seed 38) showed Aki STILL hit 76.9% rest with degrading craft per quartile (Q1=45 → Q2=19 → Q3=16 → Q4=12%). Inspection revealed a coherent "exhausted artisan with aching hands" self-narrative that persists across both rest AND craft choices — the `Latest: <thought>` clause in the rest summary kept seeding the next tick with fatigue language.

Layer D drops the thought entirely. The summary becomes count-only: `Aki rested 80 times`. The count signals magnitude without feeding the narrative loop.

## Evidence from soak-24h-3

Sample thoughts during a 114-rest run:

```
id=100 (rest): "The persistent ache suggests my hands need more time to mend..."
id=101 (rest): "The exhaustion is deep... My hands beg for stillness..."
id=107 (craft): "The ache is deep, and the quiet has been a balm. My hands deserve more than mere rest now; they need a final, gentle expression..."
id=110 (craft): "The ache remains... My fingers protest charcoal, but the memory..."
id=553 (rest): "The weariness is a steady weight today. Despite the lingering call to create, the body's insistence on deep quiet is overwhelming..."
id=558 (rest): "The weariness is deep, a constant companion to this beautiful, clear spring day..."
```

Even craft thoughts reference fatigue. Layer C broke the *evidence* poison (one summary line, not 100), but the latest thought in the summary kept feeding the *narrative*.

## Why this candidate (Codex senior review)

Six Layer D candidates evaluated:

| Option | Verdict |
|---|---|
| **(1) Drop `Latest:` from compressed summary** | **Best evidence-to-effort. Removes the exact injection point.** |
| (2) Drop rest entirely from `recent_episodic` | Loses isolated-rest signal too |
| (3) Cap `Latest:` at 60 chars | Surface fix; trap language fits in 60 chars |
| (4) Persona prompt nudge | Already failed in spirit; addresses interpretation not evidence |
| (5) Watchdog Stranger spawn on rest fraction | `watchdog_diversity_pct=79` didn't trip the 0.35 floor; useful later |
| (6) Narrative-reset injection ("Aki feels refreshed") | Heavier, test-hard, treats symptom not cause |

Codex: "The fatigue seed is injected at `_compress_rest_runs:63-65`. The `Latest:` clause is the exact injection point that survives Layer C and poisons the next tick's prompt."

## Risk

Losing body-state signal: Codex flagged this as minor. The count (`rested N times`) still conveys exhaustion magnitude. The thought was the narrative amplifier, not the signal itself. If a future soak shows Aki entering rest streaks despite this fix, Layers (5) or (6) become candidates.

## TDD

| Commit | Status |
|---|---|
| `98cdee4` test: red — rest-run summary must omit thoughts (Layer D) | red |
| `8bc09b2` fix(memory): drop Latest thought from rest-run summary (Layer D) | green |

Test changes:

- `test_build_context_compresses_consecutive_rest_runs`: tightened to assert the summary is exactly `"Aki rested 80 times"` (no Latest, no thought) and `"mandate for rest"` count is 0.
- `test_build_context_summary_captures_latest_thought` → renamed to `test_build_context_rest_summary_omits_thoughts` (inverted): asserts summary is exactly `"Aki rested 3 times"`, no `Latest`, no per-rest thought.

Single isolated rests still carry their thought verbatim — real recent context, not a run.

## Quality gate

- `uv run ruff check` ✓
- `uv run ruff format --check` ✓
- `uv run mypy src/microverse` ✓
- `uv run pytest -q -m 'not integration'` 240 passed
- `uv run pip-audit` no vulns
- `uv build` ✓

## Test plan

- [x] Red commit reproduces the bug deterministically (no LLM)
- [x] Green commit makes red pass
- [ ] After merge: 45-min wiring soak + new 24h soak attempt