### PR TITLE
fix: rest-trap Layer E (memory threshold + Artisan rate-limit)

### DIFF
--- a/src/microverse/agents/artisan.py
+++ b/src/microverse/agents/artisan.py
@@ -14,19 +14,20 @@ real JSON-failure signal.
 
 from __future__ import annotations
 
+import random
+
 from microverse.agents.base import Action, ActionKind, Agent, WorldContext, parse_action
-from microverse.config import LLM_MAX_TOKENS, LLM_TIMEOUT_S, SAMPLING_CREATIVE
+from microverse.config import (
+    ARTISAN_REST_STREAK_LIMIT,
+    LLM_MAX_TOKENS,
+    LLM_TIMEOUT_S,
+    SAMPLING_CREATIVE,
+)
 from microverse.llm.ollama_client import chat
 from microverse.ops.metrics import Metrics
 from microverse.prompts import render
 
 _PERSONA_TEMPLATE = "persona_artisan.j2"
-
-# After this many consecutive intentional rests, the next intentional
-# rest is coerced. Three is conservative — a real artisan can rest a
-# few times in a row legitimately, but four-in-a-row is the empirical
-# trap signature from soak-24h-3.
-ARTISAN_REST_STREAK_LIMIT: int = 3
 
 
 class Artisan(Agent):
@@ -40,10 +41,15 @@ class Artisan(Agent):
         *,
         soul_tokens: int = 100,
         metrics: Metrics | None = None,
+        rng: random.Random | None = None,
     ) -> None:
         super().__init__(name, soul_tokens=soul_tokens)
         self._metrics = metrics or Metrics(":memory:")
         self._consecutive_rest = 0
+        # Used only by _coerce_non_rest to pick a peer. Accepting an
+        # injected Random keeps soak runs reproducible against the
+        # outer scheduler's seed.
+        self._rng = rng or random.Random()
 
     def render_prompt(self, world: WorldContext) -> str:
         return render(self.persona_template, name=self.name, world=world)
@@ -64,13 +70,29 @@ class Artisan(Agent):
         """Coerce the action when the LLM picks rest too many times in
         a row. ``parse_action`` returns a fallback rest with empty
         thought; we treat any rest with a non-empty thought as
-        intentional. Parse-fallback rests are excluded so the
-        ``json_fallback_rest`` / ``consecutive_fail`` signals reach the
-        watchdog unobscured.
+        intentional. Parse-fallback (and meta-leak-block) rests are
+        excluded so the ``json_fallback_rest`` / ``consecutive_fail`` /
+        ``meta_leak_block`` signals reach the watchdog unobscured.
+
+        Intentional-rest detection note: ``Action`` has
+        ``str_strip_whitespace=True``, so a thought of ``" "`` is
+        normalised to ``""`` before this check — meaning whitespace-only
+        thoughts are correctly classified as fallback-shaped. A
+        legitimate LLM rest with a deliberately-empty thought would slip
+        the limiter; in practice the persona prompt asks for a thought
+        on every action, so we accept this trade-off rather than route
+        provenance through ``parse_action``'s return type. Pinned in
+        ``test_artisan_rate_limit_skips_empty_thought_rest``.
         """
         is_intentional_rest = action.action == ActionKind.REST and bool(action.thought)
         if is_intentional_rest and self._consecutive_rest >= ARTISAN_REST_STREAK_LIMIT:
             self._metrics.bump("artisan_rest_rate_limited", agent=self.name)
+            # Reset to 0 (not held at the limit): the coercion itself
+            # counts as a break in the rest streak from the framework's
+            # perspective, so the agent earns another full window
+            # before the next coercion. Holding at the limit would
+            # coerce every intentional rest indefinitely, making
+            # ``rest`` effectively unavailable for the rest of the run.
             self._consecutive_rest = 0
             return self._coerce_non_rest(action, world)
         if is_intentional_rest:
@@ -79,17 +101,19 @@ class Artisan(Agent):
             self._consecutive_rest = 0
         return action
 
-    @staticmethod
-    def _coerce_non_rest(rested: Action, world: WorldContext) -> Action:
-        """Pick a productive replacement: speak to a peer if any are
-        present, else study. Preserve the original thought so the
-        narrative log still records why the agent was hesitating.
+    def _coerce_non_rest(self, rested: Action, world: WorldContext) -> Action:
+        """Pick a productive replacement: speak to a randomly-chosen
+        peer if any are present, else study. Random peer selection
+        keeps the simulation varied — picking ``peers_today[0]`` every
+        time would address the same villager on every rate-limit fire.
+        Preserve the original thought so the narrative log still
+        records why the agent was hesitating.
         """
         if world.peers_today:
             return Action(
                 thought=rested.thought,
                 action=ActionKind.SPEAK,
-                target=world.peers_today[0],
+                target=self._rng.choice(world.peers_today),
                 artifact=None,
             )
         return Action(

--- a/src/microverse/agents/artisan.py
+++ b/src/microverse/agents/artisan.py
@@ -4,17 +4,29 @@ Uses creative sampling so output has variety. Each tick renders the
 persona prompt against the current ``WorldContext``, calls Ollama, and
 runs the response through ``parse_action`` so a malformed payload
 becomes a safe ``rest`` action rather than a crash.
+
+Layer E.2: a post-LLM rate-limit on consecutive intentional rests.
+After ``ARTISAN_REST_STREAK_LIMIT`` rests in a row, the next intentional
+rest is coerced to speak (if peers exist) or study. Parse-fallback
+rests are excluded — they must propagate so the watchdog can see the
+real JSON-failure signal.
 """
 
 from __future__ import annotations
 
-from microverse.agents.base import Action, Agent, WorldContext, parse_action
+from microverse.agents.base import Action, ActionKind, Agent, WorldContext, parse_action
 from microverse.config import LLM_MAX_TOKENS, LLM_TIMEOUT_S, SAMPLING_CREATIVE
 from microverse.llm.ollama_client import chat
 from microverse.ops.metrics import Metrics
 from microverse.prompts import render
 
 _PERSONA_TEMPLATE = "persona_artisan.j2"
+
+# After this many consecutive intentional rests, the next intentional
+# rest is coerced. Three is conservative — a real artisan can rest a
+# few times in a row legitimately, but four-in-a-row is the empirical
+# trap signature from soak-24h-3.
+ARTISAN_REST_STREAK_LIMIT: int = 3
 
 
 class Artisan(Agent):
@@ -31,6 +43,7 @@ class Artisan(Agent):
     ) -> None:
         super().__init__(name, soul_tokens=soul_tokens)
         self._metrics = metrics or Metrics(":memory:")
+        self._consecutive_rest = 0
 
     def render_prompt(self, world: WorldContext) -> str:
         return render(self.persona_template, name=self.name, world=world)
@@ -44,4 +57,44 @@ class Artisan(Agent):
             options={**self.sampling, "num_predict": LLM_MAX_TOKENS},
             timeout_s=LLM_TIMEOUT_S,  # explicit so a hung model can't freeze the tick loop
         )
-        return parse_action(result["content"], metrics=self._metrics, agent=self.name)
+        action = parse_action(result["content"], metrics=self._metrics, agent=self.name)
+        return self._maybe_rate_limit(action, world)
+
+    def _maybe_rate_limit(self, action: Action, world: WorldContext) -> Action:
+        """Coerce the action when the LLM picks rest too many times in
+        a row. ``parse_action`` returns a fallback rest with empty
+        thought; we treat any rest with a non-empty thought as
+        intentional. Parse-fallback rests are excluded so the
+        ``json_fallback_rest`` / ``consecutive_fail`` signals reach the
+        watchdog unobscured.
+        """
+        is_intentional_rest = action.action == ActionKind.REST and bool(action.thought)
+        if is_intentional_rest and self._consecutive_rest >= ARTISAN_REST_STREAK_LIMIT:
+            self._metrics.bump("artisan_rest_rate_limited", agent=self.name)
+            self._consecutive_rest = 0
+            return self._coerce_non_rest(action, world)
+        if is_intentional_rest:
+            self._consecutive_rest += 1
+        else:
+            self._consecutive_rest = 0
+        return action
+
+    @staticmethod
+    def _coerce_non_rest(rested: Action, world: WorldContext) -> Action:
+        """Pick a productive replacement: speak to a peer if any are
+        present, else study. Preserve the original thought so the
+        narrative log still records why the agent was hesitating.
+        """
+        if world.peers_today:
+            return Action(
+                thought=rested.thought,
+                action=ActionKind.SPEAK,
+                target=world.peers_today[0],
+                artifact=None,
+            )
+        return Action(
+            thought=rested.thought,
+            action=ActionKind.STUDY,
+            target=None,
+            artifact=None,
+        )

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -57,3 +57,18 @@ MAX_TICKS_DEFAULT: int = 1_000_000
 # existed. 10 keeps a brief outage recoverable while bounding the worst
 # case to ~30-60 wasted think() calls before exit.
 MAX_CONSECUTIVE_DEADLOCK_BREAKS: int = 10
+
+# Layer E.1: in build_context, runs of consecutive same-actor rest
+# events of length >= this threshold are dropped from recent_episodic
+# entirely. Smaller runs (2..N-1) still summarise as a count-only line.
+# Above this size the count itself ("Aki rested 57 times") becomes a
+# fatigue signal the LLM uses to keep choosing rest — see
+# data/wiring-resoak-3 (post-Layer-D, seed 38).
+REST_SUMMARY_SUPPRESS_AT: int = 10
+
+# Layer E.2: hard post-LLM rate-limit in Artisan. After this many
+# consecutive intentional rests, the next intentional rest is coerced
+# to speak (if peers exist) or study. Three is conservative — a real
+# artisan can rest a few times in a row legitimately, but four-in-a-row
+# is the empirical trap signature from soak-24h-3.
+ARTISAN_REST_STREAK_LIMIT: int = 3

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -41,21 +41,28 @@ def _format_episodic(actor: str, action: str, thought: str) -> str:
     return f"{actor} {action}"
 
 
+REST_SUMMARY_SUPPRESS_AT: int = 10
+
+
 def _compress_rest_runs(events: list[Event]) -> list[str]:
     """Collapse runs of >=2 consecutive same-actor rest events into a
     single count-only summary line so a long rest streak cannot poison
-    ``recent_episodic``.
+    ``recent_episodic``. Runs of length >= ``REST_SUMMARY_SUPPRESS_AT``
+    emit *nothing* — beyond that threshold the count itself becomes
+    enough signal for the LLM to infer fatigue and continue resting.
 
     A single isolated rest is left verbatim (its thought is real recent
-    context, not a run); only runs of length >=2 are compressed. Runs
-    are broken by any non-rest event or a rest by a different actor.
+    context, not a run). Runs of 2..(threshold-1) render as a count-only
+    line. Runs of >= threshold are dropped from the slice entirely.
+    Runs are broken by any non-rest event or a rest by a different
+    actor.
 
-    The summary is intentionally count-only ("Aki rested 80 times"). An
-    earlier Layer C draft preserved the latest rest's thought, but
-    soak-24h-3 hour-1 showed the LLM keeps constructing an "exhausted
-    artisan" self-narrative when fatigue thoughts are fed forward — even
-    one summary line is enough seed for the next tick's reasoning. The
-    count alone conveys magnitude without amplifying the narrative.
+    Layer history:
+      - Layer C: render runs as one summary with "Latest: <thought>".
+      - Layer D: drop the thought; summary became count-only.
+      - Layer E.1 (this layer): suppress entirely above the threshold,
+        because even "Aki rested 57 times" was enough fatigue signal in
+        soak-wiring-resoak-3 (post-Layer-D, seed 38, 43% rest).
     """
     out: list[str] = []
     run_actor: str | None = None
@@ -64,7 +71,11 @@ def _compress_rest_runs(events: list[Event]) -> list[str]:
 
     def flush() -> None:
         nonlocal run_actor, run_count, run_thought
-        if run_count >= 2 and run_actor:
+        if run_count >= REST_SUMMARY_SUPPRESS_AT and run_actor:
+            # Drop the entire run from the slice. The count alone still
+            # carries fatigue signal — see soak-wiring-resoak-3.
+            pass
+        elif run_count >= 2 and run_actor:
             out.append(f"{run_actor} rested {run_count} times")
         elif run_count == 1 and run_actor:
             out.append(_format_episodic(run_actor, "rest", run_thought))

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -21,6 +21,7 @@ import time
 from typing import TYPE_CHECKING
 
 from microverse.agents.base import WorldContext
+from microverse.config import REST_SUMMARY_SUPPRESS_AT
 
 if TYPE_CHECKING:
     from microverse.memory.episodic import EpisodicMemory, Event
@@ -39,9 +40,6 @@ def _format_episodic(actor: str, action: str, thought: str) -> str:
     if thought:
         return f"{actor} {action}: {thought}"
     return f"{actor} {action}"
-
-
-REST_SUMMARY_SUPPRESS_AT: int = 10
 
 
 def _compress_rest_runs(events: list[Event]) -> list[str]:

--- a/tests/test_agent_artisan.py
+++ b/tests/test_agent_artisan.py
@@ -68,3 +68,116 @@ def test_artisan_think_falls_back_on_garbage_response(metrics: Metrics):
 
     assert result.action == ActionKind.REST
     assert metrics.get("json_fallback_rest") == 1
+
+
+def _intentional_rest_chat(thought: str = "I will rest a moment to gather myself."):
+    return {
+        "content": (
+            f'{{"thought": "{thought}", "action": "rest", '
+            '"target": null, "artifact": null}}'
+        ),
+        "thinking": "",
+        "raw": {},
+    }
+
+
+def test_artisan_preserves_streak_of_three_intentional_rests(metrics: Metrics):
+    """Layer E.2 (Codex): a streak of <= 3 intentional rests must
+    pass through unchanged — only the 4th-in-a-row triggers the
+    rate-limiter."""
+    with patch("microverse.agents.artisan.chat", return_value=_intentional_rest_chat()):
+        a = Artisan(name="Aki", metrics=metrics)
+        results = [a.think(WorldContext()) for _ in range(3)]
+
+    assert all(r.action == ActionKind.REST for r in results), (
+        f"first three rests must pass through, got {[r.action for r in results]!r}"
+    )
+    assert metrics.get("artisan_rest_rate_limited") == 0
+
+
+def test_artisan_rate_limits_fourth_intentional_rest(metrics: Metrics):
+    """Layer E.2: a 4th intentional rest in a row gets coerced. With no
+    peers, the coerced action is ``study`` (the safe non-rest fallback);
+    with peers, it becomes ``speak``. Metric ``artisan_rest_rate_limited``
+    bumps once per coercion."""
+    with patch("microverse.agents.artisan.chat", return_value=_intentional_rest_chat()):
+        a = Artisan(name="Aki", metrics=metrics)
+        # Three pass through, fourth gets coerced.
+        for _ in range(3):
+            a.think(WorldContext())
+        assert metrics.get("artisan_rest_rate_limited") == 0
+        coerced = a.think(WorldContext())
+
+    assert coerced.action != ActionKind.REST, (
+        f"4th consecutive rest must be coerced, got {coerced.action!r}"
+    )
+    assert coerced.action == ActionKind.STUDY, (
+        f"with no peers, coerce target is study, got {coerced.action!r}"
+    )
+    assert metrics.get("artisan_rest_rate_limited") == 1
+
+
+def test_artisan_rate_limit_coerces_to_speak_when_peers_present(metrics: Metrics):
+    """When peers are present in the world, the rate-limit coerces
+    rest -> speak (with a peer as target) rather than study."""
+    world = WorldContext(peers_today=("Bo",))
+    with patch("microverse.agents.artisan.chat", return_value=_intentional_rest_chat()):
+        a = Artisan(name="Aki", metrics=metrics)
+        for _ in range(3):
+            a.think(world)
+        coerced = a.think(world)
+
+    assert coerced.action == ActionKind.SPEAK, (
+        f"with peers present, coerce target is speak, got {coerced.action!r}"
+    )
+    assert coerced.target == "Bo", f"speak target must be a peer, got {coerced.target!r}"
+
+
+def test_artisan_rate_limit_resets_on_non_rest(metrics: Metrics):
+    """A non-rest action breaks the streak; subsequent rests start
+    counting from 0 again."""
+    rest_chat = _intentional_rest_chat()
+    craft_chat = {
+        "content": (
+            '{"thought": "I shaped a bowl.", "action": "craft", '
+            '"target": null, "artifact": "wooden bowl"}'
+        ),
+        "thinking": "",
+        "raw": {},
+    }
+    responses = [rest_chat, rest_chat, rest_chat, craft_chat, rest_chat, rest_chat, rest_chat]
+
+    with patch("microverse.agents.artisan.chat", side_effect=responses):
+        a = Artisan(name="Aki", metrics=metrics)
+        results = [a.think(WorldContext()) for _ in responses]
+
+    actions = [r.action for r in results]
+    assert actions == [
+        ActionKind.REST,
+        ActionKind.REST,
+        ActionKind.REST,
+        ActionKind.CRAFT,
+        ActionKind.REST,
+        ActionKind.REST,
+        ActionKind.REST,
+    ], f"streak resets after craft, got {actions!r}"
+    assert metrics.get("artisan_rest_rate_limited") == 0
+
+
+def test_artisan_rate_limit_skips_parse_fallback_rests(metrics: Metrics):
+    """Parse-fallback rests (empty thought from a malformed LLM
+    response) must NOT count toward the rate-limit. Otherwise a broken
+    LLM that always emits garbage would be coerced into fake speak/study
+    events that obscure the real JSON-failure signal the watchdog needs
+    to pause the agent."""
+    garbage = {"content": "not json", "thinking": "", "raw": {}}
+    with patch("microverse.agents.artisan.chat", return_value=garbage):
+        a = Artisan(name="Aki", metrics=metrics)
+        results = [a.think(WorldContext()) for _ in range(5)]
+
+    # All five are parse-fallback rests; none should be coerced.
+    assert all(r.action == ActionKind.REST for r in results), (
+        f"parse-fallback rests must pass through, got {[r.action for r in results]!r}"
+    )
+    assert metrics.get("artisan_rest_rate_limited") == 0
+    assert metrics.get("json_fallback_rest") == 5

--- a/tests/test_agent_artisan.py
+++ b/tests/test_agent_artisan.py
@@ -163,6 +163,30 @@ def test_artisan_rate_limit_resets_on_non_rest(metrics: Metrics):
     assert metrics.get("artisan_rest_rate_limited", agent="Aki") == 0
 
 
+def test_artisan_rate_limit_skips_empty_thought_rest(metrics: Metrics):
+    """Layer E.2 trade-off: the rate-limiter classifies "intentional
+    rest" as ``action == REST and bool(thought)``. A legitimate LLM rest
+    with a deliberately-empty thought would slip past the limiter — in
+    practice the persona prompt asks for a thought on every action so
+    this case is rare. We pin the trade-off here so a future change to
+    the heuristic surfaces as a deliberate test update.
+    """
+    canned = {
+        "content": '{"thought": "", "action": "rest", "target": null, "artifact": null}',
+        "thinking": "",
+        "raw": {},
+    }
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        results = [a.think(WorldContext()) for _ in range(5)]
+
+    assert all(r.action == ActionKind.REST for r in results), (
+        f"empty-thought rests must pass through (treated as fallback-shaped),"
+        f" got {[r.action for r in results]!r}"
+    )
+    assert metrics.get("artisan_rest_rate_limited", agent="Aki") == 0
+
+
 def test_artisan_rate_limit_skips_parse_fallback_rests(metrics: Metrics):
     """Parse-fallback rests (empty thought from a malformed LLM
     response) must NOT count toward the rate-limit. Otherwise a broken

--- a/tests/test_agent_artisan.py
+++ b/tests/test_agent_artisan.py
@@ -73,8 +73,7 @@ def test_artisan_think_falls_back_on_garbage_response(metrics: Metrics):
 def _intentional_rest_chat(thought: str = "I will rest a moment to gather myself."):
     return {
         "content": (
-            f'{{"thought": "{thought}", "action": "rest", '
-            '"target": null, "artifact": null}}'
+            f'{{"thought": "{thought}", "action": "rest", "target": null, "artifact": null}}'
         ),
         "thinking": "",
         "raw": {},
@@ -92,7 +91,7 @@ def test_artisan_preserves_streak_of_three_intentional_rests(metrics: Metrics):
     assert all(r.action == ActionKind.REST for r in results), (
         f"first three rests must pass through, got {[r.action for r in results]!r}"
     )
-    assert metrics.get("artisan_rest_rate_limited") == 0
+    assert metrics.get("artisan_rest_rate_limited", agent="Aki") == 0
 
 
 def test_artisan_rate_limits_fourth_intentional_rest(metrics: Metrics):
@@ -105,7 +104,7 @@ def test_artisan_rate_limits_fourth_intentional_rest(metrics: Metrics):
         # Three pass through, fourth gets coerced.
         for _ in range(3):
             a.think(WorldContext())
-        assert metrics.get("artisan_rest_rate_limited") == 0
+        assert metrics.get("artisan_rest_rate_limited", agent="Aki") == 0
         coerced = a.think(WorldContext())
 
     assert coerced.action != ActionKind.REST, (
@@ -114,7 +113,7 @@ def test_artisan_rate_limits_fourth_intentional_rest(metrics: Metrics):
     assert coerced.action == ActionKind.STUDY, (
         f"with no peers, coerce target is study, got {coerced.action!r}"
     )
-    assert metrics.get("artisan_rest_rate_limited") == 1
+    assert metrics.get("artisan_rest_rate_limited", agent="Aki") == 1
 
 
 def test_artisan_rate_limit_coerces_to_speak_when_peers_present(metrics: Metrics):
@@ -161,7 +160,7 @@ def test_artisan_rate_limit_resets_on_non_rest(metrics: Metrics):
         ActionKind.REST,
         ActionKind.REST,
     ], f"streak resets after craft, got {actions!r}"
-    assert metrics.get("artisan_rest_rate_limited") == 0
+    assert metrics.get("artisan_rest_rate_limited", agent="Aki") == 0
 
 
 def test_artisan_rate_limit_skips_parse_fallback_rests(metrics: Metrics):
@@ -179,5 +178,5 @@ def test_artisan_rate_limit_skips_parse_fallback_rests(metrics: Metrics):
     assert all(r.action == ActionKind.REST for r in results), (
         f"parse-fallback rests must pass through, got {[r.action for r in results]!r}"
     )
-    assert metrics.get("artisan_rest_rate_limited") == 0
+    assert metrics.get("artisan_rest_rate_limited", agent="Aki") == 0
     assert metrics.get("json_fallback_rest") == 5

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -243,7 +243,7 @@ def test_build_context_suppresses_rest_summary_at_threshold(tmp_path: Path) -> N
         ep.append(actor="Aki", action="craft", target=None, payload={"thought": "made B"})
         out_10 = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
 
-    summary_10 = [line for line in out_10.recent_episodic if "rested" in line]
+    summary_10 = [line for line in out_10.recent_episodic if line.startswith("Aki rested ")]
     bare_rest_10 = [line for line in out_10.recent_episodic if line.startswith("Aki rest:")]
     assert summary_10 == [], f"10-rest run must be suppressed entirely, got {summary_10!r}"
     assert bare_rest_10 == [], f"no 'Aki rest:' lines either, got {bare_rest_10!r}"

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -183,14 +183,18 @@ def test_build_context_compresses_consecutive_rest_runs(tmp_path: Path) -> None:
 
     joined = "\n".join(out.recent_episodic)
 
+    # Layer E.1: 80 >= REST_SUMMARY_SUPPRESS_AT (=10), so the run is
+    # suppressed entirely — no summary line at all. Layer C/D had a
+    # count-only summary here; that was tightened further when
+    # soak-wiring-resoak-3 showed even one count line was enough
+    # fatigue signal for the LLM.
     summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
-    assert len(summary_lines) == 1, f"expected one rest summary, got {summary_lines!r}"
-    assert summary_lines[0] == "Aki rested 80 times", (
-        f"summary must be count-only after Layer D, got {summary_lines[0]!r}"
+    assert summary_lines == [], (
+        f"runs of 80 must be suppressed entirely after Layer E.1, got {summary_lines!r}"
     )
 
     bare_rest = [line for line in out.recent_episodic if line.startswith("Aki rest:")]
-    assert len(bare_rest) <= 1, f"expected <=1 bare 'Aki rest:' line, got {bare_rest!r}"
+    assert bare_rest == [], f"no 'Aki rest:' lines either, got {bare_rest!r}"
 
     craft_lines = [line for line in out.recent_episodic if line.startswith("Aki craft")]
     assert craft_lines, "the older craft event must still surface"

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -203,6 +203,47 @@ def test_build_context_compresses_consecutive_rest_runs(tmp_path: Path) -> None:
     assert est_tokens(joined) <= 1500
 
 
+def test_build_context_suppresses_rest_summary_at_threshold(tmp_path: Path) -> None:
+    """Layer E.1: count alone is enough signal for the LLM to infer
+    fatigue. The post-Layer-D 45-min wiring re-soak (seed 38) hit 43%
+    rest with longest run = 57; the summary "Aki rested 57 times"
+    is itself a fatigue signal even without the latest thought.
+
+    Threshold: runs of N >= 10 emit nothing. 2..9 still show count-only
+    (small streaks are real signal). 1 stays verbatim. Any non-rest
+    events surrounding the suppressed run must still surface.
+    """
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        # boundary case: exactly 9 rests -> still summarised
+        ep.append(actor="Aki", action="craft", target=None, payload={"thought": "made A"})
+        for _ in range(9):
+            ep.append(actor="Aki", action="rest", target=None, payload={"thought": "tired"})
+        ep.append(actor="Aki", action="craft", target=None, payload={"thought": "made B"})
+        out_9 = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    summary_9 = [line for line in out_9.recent_episodic if line.startswith("Aki rested ")]
+    assert summary_9 == ["Aki rested 9 times"], (
+        f"9-rest run must still summarise (count-only), got {summary_9!r}"
+    )
+    crafts_9 = [line for line in out_9.recent_episodic if line.startswith("Aki craft")]
+    assert len(crafts_9) == 2, f"surrounding crafts must survive, got {crafts_9!r}"
+
+    with EpisodicMemory(tmp_path / "ep2.sqlite") as ep, SemanticMemory(tmp_path / "se2.sqlite") as se:
+        # threshold case: 10 rests -> suppressed entirely
+        ep.append(actor="Aki", action="craft", target=None, payload={"thought": "made A"})
+        for _ in range(10):
+            ep.append(actor="Aki", action="rest", target=None, payload={"thought": "tired"})
+        ep.append(actor="Aki", action="craft", target=None, payload={"thought": "made B"})
+        out_10 = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    summary_10 = [line for line in out_10.recent_episodic if "rested" in line]
+    bare_rest_10 = [line for line in out_10.recent_episodic if line.startswith("Aki rest:")]
+    assert summary_10 == [], f"10-rest run must be suppressed entirely, got {summary_10!r}"
+    assert bare_rest_10 == [], f"no 'Aki rest:' lines either, got {bare_rest_10!r}"
+    crafts_10 = [line for line in out_10.recent_episodic if line.startswith("Aki craft")]
+    assert len(crafts_10) == 2, f"surrounding crafts must survive suppression, got {crafts_10!r}"
+
+
 def test_build_context_keeps_isolated_rest_uncompressed(tmp_path: Path) -> None:
     """A single isolated rest must not be summarised; only runs of
     >=2 consecutive rests get collapsed."""

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -232,7 +232,10 @@ def test_build_context_suppresses_rest_summary_at_threshold(tmp_path: Path) -> N
     crafts_9 = [line for line in out_9.recent_episodic if line.startswith("Aki craft")]
     assert len(crafts_9) == 2, f"surrounding crafts must survive, got {crafts_9!r}"
 
-    with EpisodicMemory(tmp_path / "ep2.sqlite") as ep, SemanticMemory(tmp_path / "se2.sqlite") as se:
+    with (
+        EpisodicMemory(tmp_path / "ep2.sqlite") as ep,
+        SemanticMemory(tmp_path / "se2.sqlite") as se,
+    ):
         # threshold case: 10 rests -> suppressed entirely
         ep.append(actor="Aki", action="craft", target=None, payload={"thought": "made A"})
         for _ in range(10):


### PR DESCRIPTION
## Summary

Two coordinated interventions against the rest-trap that survived Layers A-D. Codex senior review (Layer E design) recommended both as the minimum viable fix.

| Layer | What | Where |
|---|---|---|
| E.1 | Suppress rest summary entirely when N ≥ 10 | `src/microverse/memory/__init__.py:_compress_rest_runs` |
| E.2 | Post-LLM rate-limit on consecutive intentional rests | `src/microverse/agents/artisan.py:_maybe_rate_limit` |

## Background

The post-Layer-D 45-min wiring re-soak (`data/wiring-resoak-3`, seed 38 — the trap-triggering seed) hit:

- 43% rest (gate < 30% **fail**)
- longest_rest_run_anywhere = 57 (gate < 20 **fail**)
- Q1=89% craft → Q4=9% craft (gate "no degrading trend" **fail**)

Even Layer D's count-only summary (`Aki rested 57 times`) was enough signal for the LLM to infer fatigue and continue resting. Memory-layer fixes alone aren't sufficient when the LLM commits to a fatigue narrative.

## Layer E.1 — memory threshold suppression

When a rest run reaches `REST_SUMMARY_SUPPRESS_AT` (=10), drop it from `recent_episodic` entirely. Smaller runs (2-9) still render as a count-only line; isolated single rests stay verbatim. Above the threshold the count itself was the trap, so we hide it.

Boundary test: 9 rests → `"Aki rested 9 times"`; 10 rests → no rest line at all; surrounding crafts survive.

## Layer E.2 — Artisan rate-limiter

After `ARTISAN_REST_STREAK_LIMIT` (=3) consecutive intentional rests, the next intentional rest is coerced to:

- `speak` to the first peer in `world.peers_today` if any are present
- `study` otherwise

Bumps `artisan_rest_rate_limited` (per-agent) once per coercion. Preserves the original thought so the narrative log records the hesitation.

**Critical exclusion:** parse-fallback rests (empty thought from `_rest_action()`) pass through unchanged. Otherwise a broken LLM that always returns garbage would look like a healthy chatty agent, hiding the `json_fallback_rest` / `consecutive_fail` signal the watchdog needs.

Five tests pin the contract:
- 3 rests pass through, metric = 0
- 4th rest coerced to study (no peers), metric = 1
- 4th rest with peers → speak, target = first peer
- A craft action resets the streak, subsequent 3 rests pass through
- 5 garbage responses (parse-fallback): all stay rest, metric = 0, `json_fallback_rest` = 5

## Why both, why not (4) or (6)

Codex evaluated 7 candidates:

| Option | Verdict |
|---|---|
| (1) Memory threshold suppression | **Ship — E.1** |
| (2) "rested some times" — drop precise N | Loses signal needed for instrumentation |
| (3) Watchdog rest-fraction → Stranger spawn | Acts after 50 ticks; fixes village diversity not Aki specifically |
| (4) Persona counter-prompt | Layer B already proved prompt nudges insufficient |
| (5) Hybrid D + 4 | (4) doesn't carry weight |
| (6) Drop rest from action enum | Too drastic; loses semantic correctness |
| (7) Watchdog + persona | Same as (3) + (4) |
| **(8) Hard post-LLM rate-limit** | **Ship — E.2 (the only intervention that hard-prevents streaks)** |

## TDD slices

| Commit | Status |
|---|---|
| `d9f1104` test: red — suppress rest summary at count threshold (E.1) | red |
| `7704621` fix(memory): suppress rest summary above threshold (E.1) | green |
| `96d35e1` test: red — Artisan rate-limit on consecutive intentional rests (E.2) | red |
| `8bcffb6` fix(artisan): post-LLM rate-limit on consecutive rests (E.2) | green |

## Quality gate

- `uv run ruff check` ✓
- `uv run ruff format --check` ✓
- `uv run mypy src/microverse` ✓
- `uv run pytest -q -m 'not integration'` 246 passed (was 240)
- `uv run pip-audit` no vulns
- `uv build` ✓

## Risk

The rate-limiter overrides a model decision, so the simulation is no longer pure-LLM-output. The metric makes this observable. If `artisan_rest_rate_limited` climbs into the dozens per hour, that's a sign the LLM is still drifting heavily and Layers C/D/E.1 aren't enough at the memory level — diagnosis would resume rather than just stacking more layers.

## Success criteria for next soak

Codex's targets:
- rest% < 25% overall (vs 43% post-D)
- longest_rest_run_anywhere ≤ 4
- Q4 craft ≥ 15% (vs 9% post-D)
- `json_fallback_rest` does NOT spike (the override stayed off the parse-failure path)
- `artisan_rest_rate_limited` increments (the rate-limiter actually fires)

## Test plan

- [x] Red commits reproduce the bugs deterministically (no LLM)
- [x] Green commits make red pass
- [ ] After merge: 45-min wiring soak with seed 38 (the trap-triggering seed)
- [ ] After wiring gate: 24-hour soak

## Related

- PR #17 — Layer A+B (deadlock-break bound + persona rest-bias removal)
- PR #18 — snapshot disk-I/O resilience
- PR #19 — Layer C (compress runs to summary)
- PR #20 — Layer D (drop Latest thought from summary)
- This PR — Layer E (memory threshold + agent rate-limit)