### PR TITLE
fix: empty-artifact craft Layer F (persona rule + Artisan coercion)

### DIFF
--- a/src/microverse/agents/artisan.py
+++ b/src/microverse/agents/artisan.py
@@ -10,6 +10,13 @@ After ``ARTISAN_REST_STREAK_LIMIT`` rests in a row, the next intentional
 rest is coerced to speak (if peers exist) or study. Parse-fallback
 rests are excluded — they must propagate so the watchdog can see the
 real JSON-failure signal.
+
+Layer F.2: a post-LLM coercion for craft actions whose ``artifact``
+field is null or whitespace. Empty-artifact crafts are coerced to
+``study`` with a neutral replacement thought so the silent-woodworker
+narrative observed in soak-24h-4 cannot propagate through
+``recent_episodic``. Runs BEFORE the rest rate-limiter — empty-craft
+is an active tick, not rest-avoidance.
 """
 
 from __future__ import annotations
@@ -28,6 +35,17 @@ from microverse.ops.metrics import Metrics
 from microverse.prompts import render
 
 _PERSONA_TEMPLATE = "persona_artisan.j2"
+
+# Replacement thought for Layer F.2 empty-craft coercion. Crucially
+# neutral: it does NOT mention silence/fatigue/etc. — feeding the
+# original "every fiber demands silence" thought back into
+# ``recent_episodic`` is what sustained the trap (the LLM read its own
+# narrative and continued it). The replacement names a productive
+# fallback (study) so the next-tick context reads as recovery, not
+# repetition.
+_EMPTY_CRAFT_REPLACEMENT_THOUGHT = (
+    "The work needs a concrete form, so I study materials before making it."
+)
 
 
 class Artisan(Agent):
@@ -64,7 +82,38 @@ class Artisan(Agent):
             timeout_s=LLM_TIMEOUT_S,  # explicit so a hung model can't freeze the tick loop
         )
         action = parse_action(result["content"], metrics=self._metrics, agent=self.name)
+        # F.2 must run BEFORE the rest rate-limiter: empty-craft is an
+        # active tick that should reset the rest streak, not pass
+        # through it as rest.
+        action = self._maybe_coerce_empty_craft(action)
         return self._maybe_rate_limit(action, world)
+
+    def _maybe_coerce_empty_craft(self, action: Action) -> Action:
+        """Layer F.2: if the LLM picks ``craft`` without populating
+        ``artifact`` (None, empty, or whitespace), coerce to ``study``
+        with a neutral replacement thought.
+
+        The original thought is intentionally DROPPED — preserving it
+        would feed the silent-woodworker narrative back into
+        ``recent_episodic`` via ``_format_episodic`` and reinforce the
+        trap. Bumps ``artisan_empty_craft_coerced`` (per-agent metric)
+        so runaway firing is observable.
+
+        Note: ``Action`` has ``str_strip_whitespace=True``, so a
+        whitespace-only artifact arrives here normalised to ``""`` —
+        the truthy check covers both None and stripped-empty.
+        """
+        if action.action != ActionKind.CRAFT:
+            return action
+        if action.artifact:
+            return action
+        self._metrics.bump("artisan_empty_craft_coerced", agent=self.name)
+        return Action(
+            thought=_EMPTY_CRAFT_REPLACEMENT_THOUGHT,
+            action=ActionKind.STUDY,
+            target=None,
+            artifact=None,
+        )
 
     def _maybe_rate_limit(self, action: Action, world: WorldContext) -> Action:
         """Coerce the action when the LLM picks rest too many times in

--- a/src/microverse/agents/artisan.py
+++ b/src/microverse/agents/artisan.py
@@ -108,11 +108,16 @@ class Artisan(Agent):
         if action.artifact:
             return action
         self._metrics.bump("artisan_empty_craft_coerced", agent=self.name)
-        return Action(
-            thought=_EMPTY_CRAFT_REPLACEMENT_THOUGHT,
-            action=ActionKind.STUDY,
-            target=None,
-            artifact=None,
+        # ``model_copy(update=...)`` over direct ``Action(...)`` so a
+        # future field added to ``Action`` is preserved by default;
+        # forgetting to mention it here would silently drop it.
+        return action.model_copy(
+            update={
+                "thought": _EMPTY_CRAFT_REPLACEMENT_THOUGHT,
+                "action": ActionKind.STUDY,
+                "target": None,
+                "artifact": None,
+            }
         )
 
     def _maybe_rate_limit(self, action: Action, world: WorldContext) -> Action:

--- a/src/microverse/prompts/persona_artisan.j2
+++ b/src/microverse/prompts/persona_artisan.j2
@@ -32,5 +32,6 @@ Decide ONE action. Output STRICT JSON with exactly these keys:
 Hard rules:
 - Never refer to a simulation, AI, model, prompt, or "the outside".
 - Never include any text outside the JSON object.
+- When action is "craft", artifact must be a non-empty description of what you made. Crafting silently is forbidden.
 
 Output only the JSON object. No preamble. No code fences.

--- a/tests/test_agent_artisan.py
+++ b/tests/test_agent_artisan.py
@@ -163,6 +163,88 @@ def test_artisan_rate_limit_resets_on_non_rest(metrics: Metrics):
     assert metrics.get("artisan_rest_rate_limited", agent="Aki") == 0
 
 
+def _craft_chat(thought: str = "I will shape the wood.", artifact: str | None = None):
+    """Build an Ollama-style chat response with action=craft. ``artifact``
+    of None renders as JSON ``null``; non-None renders as a quoted string."""
+    artifact_json = "null" if artifact is None else f'"{artifact}"'
+    return {
+        "content": (
+            f'{{"thought": "{thought}", "action": "craft", '
+            f'"target": null, "artifact": {artifact_json}}}'
+        ),
+        "thinking": "",
+        "raw": {},
+    }
+
+
+def test_artisan_passes_through_craft_with_artifact(metrics: Metrics):
+    """Layer F.2: a craft with a real artifact is unaffected."""
+    canned = _craft_chat(artifact="a wooden bowl")
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(WorldContext())
+    assert result.action == ActionKind.CRAFT
+    assert result.artifact == "a wooden bowl"
+    assert metrics.get("artisan_empty_craft_coerced", agent="Aki") == 0
+
+
+def test_artisan_coerces_empty_craft_to_study(metrics: Metrics):
+    """Layer F.2: craft + artifact=null gets coerced to study, the
+    empty-craft metric bumps, and the original 'silent' thought is
+    DROPPED rather than preserved (per Codex insight: feeding the
+    fatigue-or-silent narrative back into recent_episodic is what
+    sustained the trap)."""
+    canned = _craft_chat(thought="Every fiber demands silence", artifact=None)
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(WorldContext())
+    assert result.action == ActionKind.STUDY
+    assert "silent" not in result.thought.lower()
+    assert "demands" not in result.thought.lower()
+    assert metrics.get("artisan_empty_craft_coerced", agent="Aki") == 1
+
+
+def test_artisan_coerces_whitespace_craft_to_study(metrics: Metrics):
+    """Pydantic ``str_strip_whitespace=True`` normalises ' ' to '' so
+    the coercion fires the same way as None."""
+    canned = _craft_chat(artifact="   ")
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(WorldContext())
+    assert result.action == ActionKind.STUDY
+    assert metrics.get("artisan_empty_craft_coerced", agent="Aki") == 1
+
+
+def test_artisan_empty_craft_does_not_trigger_rest_limiter(metrics: Metrics):
+    """Empty-craft is an active tick, not avoidance. Coercion must
+    NOT bump artisan_rest_rate_limited and must reset the rest streak,
+    so a trailing rest after coercion is the 1st in a new streak."""
+    rest_chat = _intentional_rest_chat()
+    empty_craft = _craft_chat(artifact=None)
+    responses = [rest_chat, rest_chat, rest_chat, empty_craft, rest_chat]
+    with patch("microverse.agents.artisan.chat", side_effect=responses):
+        a = Artisan(name="Aki", metrics=metrics)
+        for _ in responses:
+            a.think(WorldContext())
+    assert metrics.get("artisan_rest_rate_limited", agent="Aki") == 0
+    assert metrics.get("artisan_empty_craft_coerced", agent="Aki") == 1
+
+
+def test_artisan_empty_craft_uses_neutral_replacement_thought(metrics: Metrics):
+    """Codex Layer F insight: the replacement thought must break the
+    silent-woodworker narrative continuity rather than preserve it."""
+    canned = _craft_chat(thought="Every fiber demands silence", artifact=None)
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(WorldContext())
+    assert "demands silence" not in result.thought
+    assert "silent" not in result.thought.lower()
+    # Replacement thought references something productive the agent
+    # falls back to: studying materials.
+    lower = result.thought.lower()
+    assert "study" in lower or "materials" in lower
+
+
 def test_artisan_rate_limit_skips_empty_thought_rest(metrics: Metrics):
     """Layer E.2 trade-off: the rate-limiter classifies "intentional
     rest" as ``action == REST and bool(thought)``. A legitimate LLM rest

--- a/tests/test_persona_artisan_prompt.py
+++ b/tests/test_persona_artisan_prompt.py
@@ -38,9 +38,6 @@ def test_artisan_prompt_requires_artifact_for_craft():
     assert "Hard rules:" in rendered
     hard_rules = rendered.split("Hard rules:", 1)[1]
     rule_present = any(
-        "craft" in line.lower() and "artifact" in line.lower()
-        for line in hard_rules.splitlines()
+        "craft" in line.lower() and "artifact" in line.lower() for line in hard_rules.splitlines()
     )
-    assert rule_present, (
-        f"missing craft+artifact hard rule in Hard rules section: {hard_rules!r}"
-    )
+    assert rule_present, f"missing craft+artifact hard rule in Hard rules section: {hard_rules!r}"

--- a/tests/test_persona_artisan_prompt.py
+++ b/tests/test_persona_artisan_prompt.py
@@ -25,3 +25,22 @@ def test_artisan_prompt_does_not_default_to_rest():
     assert "Hard rules:" in rendered
     hard_rules = rendered.split("Hard rules:", 1)[1]
     assert "rest" not in hard_rules.lower()
+
+
+def test_artisan_prompt_requires_artifact_for_craft():
+    """Layer F.1: post-Layer-E 24h soak (data/soak-24h-4, seed 38)
+    showed Aki picking craft with artifact=null for hours at a time
+    (1581 null vs 678 non-null over the run). The persona must contain
+    a Hard rule pinning the contract so the LLM stops treating null
+    as artistically intentional.
+    """
+    rendered = render("persona_artisan.j2", world=WorldContext(), name="Aki")
+    assert "Hard rules:" in rendered
+    hard_rules = rendered.split("Hard rules:", 1)[1]
+    rule_present = any(
+        "craft" in line.lower() and "artifact" in line.lower()
+        for line in hard_rules.splitlines()
+    )
+    assert rule_present, (
+        f"missing craft+artifact hard rule in Hard rules section: {hard_rules!r}"
+    )


### PR DESCRIPTION
## Summary

Layer F closes the empty-artifact narrative trap that surfaced once Layer E (PR #21) decisively solved the rest-trap. Two coordinated interventions per Codex senior review.

| Layer | What | Where |
|---|---|---|
| F.1 | Persona Hard rule: craft requires non-empty artifact | `src/microverse/prompts/persona_artisan.j2` |
| F.2 | Post-parse coercion: empty-artifact craft → study with neutral thought | `src/microverse/agents/artisan.py` |

## Background

Post-Layer-E 24h soak (`data/soak-24h-4`, seed 38):

| Hour | Crafts | with artifact | rate |
|---|---|---|---|
| h1 | 364 | 69 | 19% |
| h2 | 599 | 0 | 0% |
| h3 | 461 | 0 | 0% |

Across the live ~6000-event run: 1581 craft-with-NULL-artifact vs 678 craft-with-artifact (192 mode flips). The rest-trap was decisively solved (longest_rest_run=3, no fatal metrics) but a separate failure emerged. Sample h3 thoughts:

```
id=1178: "The dialogue with the wood is at its unbearable zenith;
         speaking would violate the sacred rhythm. My hands must
         continue their silent work..."
id=1177: "...Words are a distraction; only the sound of the blade
         against the grain matters..."
id=1176: "Every fiber demands silence..."
```

A coherent "silent reverent woodworker" persona where the LLM treats `artifact=null` as artistically intentional. The harvester silently skips these (`run.py:108-110`), so the simulation produced zero new harvested output for hours 2-3. Manifest frozen at 70 lines / 26 accepted since hour 1.

Codex pre-flagged this exact case during Layer E review: *"if rest is bounded but craft quality decays (empty artifacts, repetition), that is a different problem from the rest-trap."*

## F.1 — persona Hard rule

One line added to `persona_artisan.j2` Hard rules:

> "When action is `craft`, artifact must be a non-empty description of what you made. Crafting silently is forbidden."

Cheap insurance. Codex flagged that prompt nudges aren't load-bearing alone (Layer B precedent on the rest case), but combined with F.2 they document the contract clearly.

## F.2 — post-parse coercion

`Artisan._maybe_coerce_empty_craft` runs in `think()` AFTER `parse_action` but BEFORE `_maybe_rate_limit`. If `action.action == CRAFT and not action.artifact` (None or whitespace — Pydantic's `str_strip_whitespace=True` normalises both to ""), coerce to `STUDY` with a neutral replacement thought:

> *"The work needs a concrete form, so I study materials before making it."*

Bumps `artisan_empty_craft_coerced` (per-agent metric, mirrors E.2 convention).

**Order matters.** F.2 runs first because empty-craft is an active tick, not rest-avoidance — it correctly resets `_consecutive_rest`, so the rate-limiter doesn't see it as part of a rest streak.

**Critical Codex insight: the original thought is DROPPED, not preserved.** Preserving it would feed "every fiber demands silence" back into `recent_episodic` via `_format_episodic` and reinforce the trap. The neutral replacement breaks narrative continuity.

**Why not Pydantic schema enforcement?** Adding `craft → artifact required` validation would raise `ValidationError` → fall through to `parse_repair` → `_rest_action()` (the parse-fallback path). Layer E.2's rate-limiter SKIPS parse-fallback rests so the watchdog can see them. That means an empty-craft would bump `json_fallback_rest`, increment `consecutive_fail`, eventually pause Aki, and trigger the deadlock-break path — polluting parse-failure signal with policy violations. Confirmed bad idea by Codex.

## Why F.2 not F.2 + F.3 (memory filter)

F.3 was considered (filter empty-artifact crafts from `recent_episodic`). Deferred because with F.2 running pre-commit, committed events become `study`, not `craft+null` — the narrative reinforcement breaks at source. Revisit only if a post-F.2 soak still shows the silent-woodworker narrative re-emerging through some other channel.

## TDD

| Commit | Status |
|---|---|
| `c6a1ec0` test: red — Artisan persona must require artifact when crafting (F.1) | red |
| `b422399` fix(prompts): Artisan craft must populate artifact (F.1) | green |
| `f953289` test: red — Artisan coerces empty-artifact craft (F.2) | red |
| `2c375fc` fix(artisan): coerce empty-artifact craft to study (F.2) | green |

Five F.2 tests in `tests/test_agent_artisan.py`:

1. craft with real artifact passes through
2. craft + null → study, no "silent"/"demands" in thought, metric bumped
3. craft + whitespace artifact → study
4. empty-craft does NOT bump `artisan_rest_rate_limited`; resets rest streak (3 rests + empty-craft + 1 rest = no rate-limit fire)
5. replacement thought is neutral (mentions "study" or "materials")

## Quality gate

- `uv run ruff check` ✓
- `uv run ruff format --check` ✓
- `uv run mypy src/microverse` ✓
- `uv run pytest -q -m 'not integration'` 253 passed (was 247)
- `uv run pip-audit` no vulns
- `uv build` ✓

## Risk

The neutral replacement thought intentionally breaks narrative continuity. If craft+null is unexpectedly common, this could create a new "perpetual studier" mode — `artisan_empty_craft_coerced` will surface that. Codex's runaway threshold for the next 24h soak: < 30 fires/hour. Higher means F.1 isn't holding the contract and we'd need F.3 (memory filter) or persona reinforcement.

## Success criteria for next soak

- `artifact-rate >= 50%` over the full window (vs ~10% in h1, 0% in h2-h3)
- `longest_rest_run_anywhere <= 4` (Layer E unchanged)
- `artisan_empty_craft_coerced > 0` — limiter actually fires
- `json_fallback_rest` does NOT spike — verifies we kept policy off the parse-failure path
- Manifest grows past hour 1 with new accepted artifacts

## Test plan

- [x] Red commits reproduce the bug deterministically (no LLM)
- [x] Green commits make red pass + suite stays green
- [ ] After merge: 45-min wiring soak with seed 38 (the trap-triggering seed)
- [ ] After wiring gate: 24-hour soak

## Related

- PR #17 — Layer A+B (deadlock-break bound + persona rest-bias removal)
- PR #18 — snapshot disk-I/O resilience
- PR #19 — Layer C (compress runs to summary)
- PR #20 — Layer D (drop Latest thought)
- PR #21 — Layer E (memory threshold + Artisan rate-limit)
- This PR — Layer F (persona artifact rule + empty-craft coercion)