### PR TITLE
Restructure: cut autobiographical thought feedback + add society

### DIFF
--- a/src/microverse/agents/artisan.py
+++ b/src/microverse/agents/artisan.py
@@ -47,6 +47,15 @@ _EMPTY_CRAFT_REPLACEMENT_THOUGHT = (
     "The work needs a concrete form, so I study materials before making it."
 )
 
+# Layer-G slice 3 (R2.b): replacement thought for the engagement-gate
+# coercion. Like F.2 it is deliberately *neutral and external-facing*:
+# the introspective rationalisation the LLM produced for the disobeyed
+# action would otherwise enter audit-only state but the action's own
+# logged-but-not-fed-back semantics make this defence-in-depth: a
+# future change that re-enables thought feedback should not allow the
+# disobeyed monologue to seed the next tick.
+_ENGAGEMENT_REPLACEMENT_THOUGHT = "I turn from my work to greet a neighbor."
+
 
 class Artisan(Agent):
     role = "artisan"
@@ -86,7 +95,31 @@ class Artisan(Agent):
         # active tick that should reset the rest streak, not pass
         # through it as rest.
         action = self._maybe_coerce_empty_craft(action)
-        return self._maybe_rate_limit(action, world)
+        action = self._maybe_rate_limit(action, world)
+        # Engagement gate runs LAST so it overrides any earlier coercion
+        # (e.g. the rest rate-limiter picking a different peer).
+        return self._maybe_enforce_engagement(action, world)
+
+    def _maybe_enforce_engagement(self, action: Action, world: WorldContext) -> Action:
+        """Layer-G slice 3 (R2.b): if the runtime set ``required_target``
+        on this tick's ``WorldContext`` and the LLM did not produce a
+        ``speak`` to that exact peer, coerce. Drops the original thought
+        so a disobeyed-rationalisation cannot enter audit-or-future
+        feedback as a justification for ignoring the gate.
+        """
+        if not world.required_target:
+            return action
+        if action.action == ActionKind.SPEAK and action.target == world.required_target:
+            return action
+        self._metrics.bump("engagement_gate_coerced", agent=self.name)
+        return action.model_copy(
+            update={
+                "thought": _ENGAGEMENT_REPLACEMENT_THOUGHT,
+                "action": ActionKind.SPEAK,
+                "target": world.required_target,
+                "artifact": None,
+            }
+        )
 
     def _maybe_coerce_empty_craft(self, action: Action) -> Action:
         """Layer F.2: if the LLM picks ``craft`` without populating

--- a/src/microverse/agents/artisan.py
+++ b/src/microverse/agents/artisan.py
@@ -106,8 +106,20 @@ class Artisan(Agent):
         ``speak`` to that exact peer, coerce. Drops the original thought
         so a disobeyed-rationalisation cannot enter audit-or-future
         feedback as a justification for ignoring the gate.
+
+        Safety carve-out: a parse-fallback or meta-leak-blocked REST
+        (``parse_action`` returns ``Action(thought='', action=REST,
+        target=None, artifact=None)``) must propagate untouched.
+        Coercing it into a SPEAK would silently disguise a JSON failure
+        or immersion break as social behavior, hiding the
+        ``json_fallback_rest`` / ``meta_leak_block`` signal the watchdog
+        depends on. Mirrors ``_maybe_rate_limit``'s intentional-rest
+        heuristic (REST + non-empty thought) for consistency.
         """
         if not world.required_target:
+            return action
+        is_fallback_rest = action.action == ActionKind.REST and not action.thought
+        if is_fallback_rest:
             return action
         if action.action == ActionKind.SPEAK and action.target == world.required_target:
             return action

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -144,6 +144,11 @@ class WorldContext:
     witnessed) and ``lore_excerpt`` (top-k FTS5 hits keyed off the
     current scene topic). ``microverse.memory.build_context`` is the
     canonical assembler.
+
+    Layer-G slice 3 adds ``engagement_hint`` / ``required_target``: an
+    exogenous nudge the runtime sets BEFORE ``Agent.think`` when the
+    agent has not produced a targeted speak in K of its own actions.
+    Both empty/None when the gate is not firing.
     """
 
     season: str = "spring"
@@ -151,6 +156,8 @@ class WorldContext:
     peers_today: tuple[str, ...] = ()
     recent_episodic: tuple[str, ...] = ()
     lore_excerpt: tuple[str, ...] = ()
+    engagement_hint: str = ""
+    required_target: str | None = None
 
 
 class Agent(abc.ABC):

--- a/src/microverse/agents/harvester.py
+++ b/src/microverse/agents/harvester.py
@@ -46,6 +46,7 @@ import yaml
 
 if TYPE_CHECKING:
     from microverse.agents.trader import Score
+    from microverse.memory.episodic import EpisodicMemory
 
 MIN_ARTIFACT_CHARS = 20
 SLUG_MAX_LEN = 60
@@ -125,6 +126,7 @@ class Harvester:
         *,
         trader: _RankerProtocol | None = None,
         percentile: int = DEFAULT_PERCENTILE,
+        episodic: EpisodicMemory | None = None,
     ) -> None:
         self._root = Path(harvest_root)
         self._root.mkdir(parents=True, exist_ok=True)
@@ -132,6 +134,12 @@ class Harvester:
         self._trader = trader
         self._percentile = percentile
         self._buffer: list[ArtifactCandidate] = []
+        # Layer-G slice 5 (Alt-B): when an episodic store is supplied,
+        # ``flush`` records one synthetic ``actor='harvest', action='rated'``
+        # event per ranked candidate so the Trader's verdict flows back
+        # into the next tick's recent_episodic. ``None`` keeps the legacy
+        # heuristic / smoke-test paths unchanged.
+        self._episodic = episodic
 
     def consider(self, candidate: ArtifactCandidate) -> Path | None:
         # Phase 2 path: trader present → buffer the candidate, write at flush().
@@ -183,13 +191,40 @@ class Harvester:
             # cutoff is None ⇒ no signal (multi-item all-tied population).
             # Accept nothing — better to lose a batch than to spam the
             # inbox with unranked output.
-            if cutoff is not None and score.score >= cutoff:
+            accepted = cutoff is not None and score.score >= cutoff
+            if accepted:
                 path = self._write_artifact(cand)
                 written.append(path)
                 self._append_manifest(cand, accepted=True, path=path, score=score.score)
             else:
                 self._append_manifest(cand, accepted=False, path=None, score=score.score)
+            self._maybe_emit_rating_event(cand, score=score.score, accepted=accepted)
         return written
+
+    def _maybe_emit_rating_event(
+        self,
+        candidate: ArtifactCandidate,
+        *,
+        score: float,
+        accepted: bool,
+    ) -> None:
+        """Append the synthetic harvest-rated event for Alt-B feedback.
+        No-op when ``episodic`` was not supplied — preserves the
+        backwards-compat path for heuristic / smoke-test runs.
+        """
+        if self._episodic is None:
+            return
+        self._episodic.append(
+            actor="harvest",
+            action="rated",
+            target=None,
+            payload={
+                "actor": candidate.actor,
+                "kind": candidate.action,
+                "score": score,
+                "accepted": accepted,
+            },
+        )
 
     def _percentile_cutoff(self, scores: list[float]) -> float | None:
         """Compute a score floor such that values >= floor land in the

--- a/src/microverse/agents/scholar.py
+++ b/src/microverse/agents/scholar.py
@@ -1,0 +1,85 @@
+"""Scholar agent: observation-leaning second resident.
+
+Layer-G slice 4 (R2.c): the project's stated mission is a "society"
+of agents producing harvested artifacts, but for the entire history
+of the run only one agent (Aki the Artisan) was ever resident.
+Codex's review of the Layer-G plan flagged that adding a second plain
+Artisan risks *mutual* reverence — two craftspeople reading each
+other's silence-justifying logs and converging on the same monoculture.
+A structurally different role breaks that symmetry: Scholar prefers
+observation, conversation, and short written notes; it has no rest
+rate-limiter and no empty-craft coercion (those were Artisan-specific
+failure-mode patches), and uses ``SAMPLING_FACTUAL`` for steadier
+observational output.
+
+Engagement gate (Layer-G slice 3) applies here just as it does to
+Artisan — long-silent stretches still call for a peer-targeted speak.
+The 10-line coercion is duplicated rather than abstracted; per Codex,
+premature unification of coercion helpers is out of scope (semantics
+differ for each helper).
+"""
+
+from __future__ import annotations
+
+from microverse.agents.base import Action, ActionKind, Agent, WorldContext, parse_action
+from microverse.config import LLM_MAX_TOKENS, LLM_TIMEOUT_S, SAMPLING_FACTUAL
+from microverse.llm.ollama_client import chat
+from microverse.ops.metrics import Metrics
+from microverse.prompts import render
+
+_PERSONA_TEMPLATE = "persona_scholar.j2"
+
+_ENGAGEMENT_REPLACEMENT_THOUGHT = "I set my notes aside to greet a neighbor."
+
+
+class Scholar(Agent):
+    role = "scholar"
+    persona_template = _PERSONA_TEMPLATE
+    sampling = SAMPLING_FACTUAL
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        soul_tokens: int = 70,
+        metrics: Metrics | None = None,
+    ) -> None:
+        super().__init__(name, soul_tokens=soul_tokens)
+        self._metrics = metrics or Metrics(":memory:")
+
+    def render_prompt(self, world: WorldContext) -> str:
+        return render(self.persona_template, name=self.name, world=world)
+
+    def think(self, world: WorldContext) -> Action:
+        prompt = self.render_prompt(world)
+        result = chat(
+            messages=[{"role": "user", "content": prompt}],
+            think=False,
+            format="json",
+            options={**self.sampling, "num_predict": LLM_MAX_TOKENS},
+            timeout_s=LLM_TIMEOUT_S,
+        )
+        action = parse_action(result["content"], metrics=self._metrics, agent=self.name)
+        return self._maybe_enforce_engagement(action, world)
+
+    def _maybe_enforce_engagement(self, action: Action, world: WorldContext) -> Action:
+        """Shared with Artisan (semantics identical). Coerce a non-
+        compliant action into ``speak`` to ``required_target`` when the
+        runtime's engagement gate is firing. Drops the original thought
+        for the same reason F.2 does — a disobeyed rationalisation
+        should not survive into audit context where a future change
+        could re-enable feedback.
+        """
+        if not world.required_target:
+            return action
+        if action.action == ActionKind.SPEAK and action.target == world.required_target:
+            return action
+        self._metrics.bump("engagement_gate_coerced", agent=self.name)
+        return action.model_copy(
+            update={
+                "thought": _ENGAGEMENT_REPLACEMENT_THOUGHT,
+                "action": ActionKind.SPEAK,
+                "target": world.required_target,
+                "artifact": None,
+            }
+        )

--- a/src/microverse/agents/scholar.py
+++ b/src/microverse/agents/scholar.py
@@ -69,8 +69,16 @@ class Scholar(Agent):
         for the same reason F.2 does — a disobeyed rationalisation
         should not survive into audit context where a future change
         could re-enable feedback.
+
+        Safety carve-out: a parse-fallback or meta-leak-blocked REST
+        (empty thought, no target, no artifact) must propagate so the
+        watchdog still sees ``json_fallback_rest`` /
+        ``meta_leak_block``. Mirrors Artisan's guard.
         """
         if not world.required_target:
+            return action
+        is_fallback_rest = action.action == ActionKind.REST and not action.thought
+        if is_fallback_rest:
             return action
         if action.action == ActionKind.SPEAK and action.target == world.required_target:
             return action

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -72,3 +72,12 @@ REST_SUMMARY_SUPPRESS_AT: int = 10
 # artisan can rest a few times in a row legitimately, but four-in-a-row
 # is the empirical trap signature from soak-24h-3.
 ARTISAN_REST_STREAK_LIMIT: int = 3
+
+# Layer-G slice 3 (R2.b): engagement gate. If an agent produces no
+# `speak` with a non-null target across this many of its own actions,
+# the next tick injects an engagement hint + required_target into
+# WorldContext and Artisan coerces if the LLM disobeys. K=20 is a
+# generous floor (peer interaction every ~20 personal ticks); under
+# the post-Layer-F soak Aki silently crafted hundreds of ticks in a
+# row, so 20 is plenty of head-room without being intrusive.
+PEER_ENGAGEMENT_INTERVAL: int = 20

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -85,7 +85,10 @@ def _format_episodic_event(e: Event) -> str:
         return f"{actor} craft"
     if action == "speak":
         return f"{actor} spoke to {target}" if target else f"{actor} spoke aloud"
-    return f"{actor} {action}"
+    # Use past-tense for the bare-action fallback so single events read
+    # in the same voice as the count summaries emitted by
+    # ``_compress_action_runs``. Unknown actions pass through verbatim.
+    return f"{actor} {_ACTION_PAST_TENSE.get(action, action)}"
 
 
 def _compress_action_runs(events: list[Event]) -> list[str]:
@@ -101,6 +104,16 @@ def _compress_action_runs(events: list[Event]) -> list[str]:
     render as ``f"{actor} {past_tense} {N} times"``. A length-1 run
     falls back to ``_format_episodic_event`` (which already drops the
     thought). Runs are broken by any change of actor or action.
+
+    Exception: ``actor='harvest'`` events bypass the run mechanism and
+    surface individually. A ``Harvester.flush()`` of N ranked candidates
+    emits N consecutive ``actor='harvest', action='rated'`` events, and
+    the per-event payload (score, accepted, creator, kind) IS the value
+    of the Alt-B feedback signal. Collapsing them to ``"harvest rated N
+    times"`` or suppressing them above threshold would erase the only
+    exogenous voice telling the LLM what is actually being valued.
+    Each harvest event flushes any pending agent run cleanly so it does
+    not bridge or extend the surrounding streaks.
     """
     out: list[str] = []
     run_actor: str | None = None
@@ -124,6 +137,10 @@ def _compress_action_runs(events: list[Event]) -> list[str]:
         run_events = []
 
     for e in events:
+        if e.actor == "harvest":
+            flush()
+            out.append(_format_episodic_event(e))
+            continue
         if run_actor == e.actor and run_action == e.action:
             run_events.append(e)
         else:

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -201,4 +201,6 @@ def build_context(
         peers_today=world_base.peers_today,
         recent_episodic=recent,
         lore_excerpt=lore,
+        engagement_hint=world_base.engagement_hint,
+        required_target=world_base.required_target,
     )

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -36,64 +36,91 @@ def est_tokens(text: str) -> int:
     return len(text) // 4
 
 
-def _format_episodic(actor: str, action: str, thought: str) -> str:
-    if thought:
-        return f"{actor} {action}: {thought}"
+_ARTIFACT_EXCERPT_MAX = 120
+
+_ACTION_PAST_TENSE: dict[str, str] = {
+    "rest": "rested",
+    "speak": "spoke",
+    "study": "studied",
+    "craft": "crafted",
+    "travel": "traveled",
+}
+
+
+def _format_episodic_event(e: Event) -> str:
+    """Render a single episodic event for inclusion in next-prompt
+    ``recent_episodic``. Layer G structural contract: the agent's
+    ``thought`` is NEVER rendered — the autobiographical feedback
+    edge that sustained the prior six layers' failure family. Only
+    factual surface (action, target, artifact-excerpt, ``[world]`` /
+    ``[harvest]`` tags) flows into the next prompt.
+
+    The thought is still emitted by the LLM, persisted into episodic
+    for audit, and consumed by current-tick logic; this function is
+    the boundary that prevents it from re-feeding the loop.
+    """
+    actor = e.actor
+    action = e.action
+    payload = e.payload or {}
+    target = e.target
+
+    if actor == "world":
+        return f"[world] {action}"
+    if action == "craft":
+        artifact = str(payload.get("artifact") or "").replace("\n", " ").strip()
+        if artifact:
+            if len(artifact) > _ARTIFACT_EXCERPT_MAX:
+                artifact = artifact[:_ARTIFACT_EXCERPT_MAX] + "…"
+            return f"{actor} crafted: {artifact}"
+        return f"{actor} craft"
+    if action == "speak":
+        return f"{actor} spoke to {target}" if target else f"{actor} spoke aloud"
     return f"{actor} {action}"
 
 
-def _compress_rest_runs(events: list[Event]) -> list[str]:
-    """Collapse runs of >=2 consecutive same-actor rest events into a
-    single count-only summary line so a long rest streak cannot poison
-    ``recent_episodic``. Runs of length >= ``REST_SUMMARY_SUPPRESS_AT``
-    emit *nothing* — beyond that threshold the count itself becomes
-    enough signal for the LLM to infer fatigue and continue resting.
+def _compress_action_runs(events: list[Event]) -> list[str]:
+    """Collapse runs of >=2 consecutive same-actor + same-action events
+    into a single count-only summary so no streak shape can become a
+    same-channel signal in the next prompt. Generalises the Layer
+    C/D/E.1 rest-run mechanism to ALL actions, closing speak / study /
+    travel / craft as alternative expressions of the same crystallised
+    persona.
 
-    A single isolated rest is left verbatim (its thought is real recent
-    context, not a run). Runs of 2..(threshold-1) render as a count-only
-    line. Runs of >= threshold are dropped from the slice entirely.
-    Runs are broken by any non-rest event or a rest by a different
-    actor.
-
-    Layer history:
-      - Layer C: render runs as one summary with "Latest: <thought>".
-      - Layer D: drop the thought; summary became count-only.
-      - Layer E.1 (this layer): suppress entirely above the threshold,
-        because even "Aki rested 57 times" was enough fatigue signal in
-        soak-wiring-resoak-3 (post-Layer-D, seed 38, 43% rest).
+    A run of length >= ``REST_SUMMARY_SUPPRESS_AT`` is dropped entirely
+    (Layer E.1 logic preserved and extended). Runs of 2..(threshold-1)
+    render as ``f"{actor} {past_tense} {N} times"``. A length-1 run
+    falls back to ``_format_episodic_event`` (which already drops the
+    thought). Runs are broken by any change of actor or action.
     """
     out: list[str] = []
     run_actor: str | None = None
-    run_count = 0
-    run_thought = ""
+    run_action: str | None = None
+    run_events: list[Event] = []
 
     def flush() -> None:
-        nonlocal run_actor, run_count, run_thought
-        if run_count >= REST_SUMMARY_SUPPRESS_AT and run_actor:
-            # Drop the entire run from the slice. The count alone still
-            # carries fatigue signal — see soak-wiring-resoak-3.
+        nonlocal run_actor, run_action, run_events
+        n = len(run_events)
+        if n >= REST_SUMMARY_SUPPRESS_AT and run_actor and run_action:
+            # Drop entirely — the count alone is enough signal for the
+            # LLM to continue the streak (Layer E.1 finding, generalised).
             pass
-        elif run_count >= 2 and run_actor:
-            out.append(f"{run_actor} rested {run_count} times")
-        elif run_count == 1 and run_actor:
-            out.append(_format_episodic(run_actor, "rest", run_thought))
+        elif n >= 2 and run_actor and run_action:
+            verb = _ACTION_PAST_TENSE.get(run_action, run_action)
+            out.append(f"{run_actor} {verb} {n} times")
+        elif n == 1 and run_events:
+            out.append(_format_episodic_event(run_events[0]))
         run_actor = None
-        run_count = 0
-        run_thought = ""
+        run_action = None
+        run_events = []
 
     for e in events:
-        thought = str(e.payload.get("thought") or "")
-        if e.action == "rest":
-            if run_actor == e.actor:
-                run_count += 1
-            else:
-                flush()
-                run_actor = e.actor
-                run_count = 1
-                run_thought = thought
+        if run_actor == e.actor and run_action == e.action:
+            run_events.append(e)
         else:
             flush()
-            out.append(_format_episodic(e.actor, e.action, thought))
+            run_actor = e.actor
+            run_action = e.action
+            run_events = [e]
     flush()
     return out
 
@@ -156,7 +183,7 @@ def build_context(
     """
     cutoff = time.time() - episodic_window_s
     events = episodic.since(cutoff, limit=episodic_lookback)
-    recent_lines = _compress_rest_runs(events)
+    recent_lines = _compress_action_runs(events)
     recent = _pack_under_budget(recent_lines, episodic_tok)
 
     lore_lines: list[str] = []

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -66,6 +66,16 @@ def _format_episodic_event(e: Event) -> str:
 
     if actor == "world":
         return f"[world] {action}"
+    if actor == "harvest" and action == "rated":
+        # Alt-B exogenous feedback: surface the Trader's verdict so the
+        # next-tick context shows what is actually being valued, not
+        # the agent's own narrative-about-its-narrative.
+        rated_actor = str(payload.get("actor") or "")
+        kind = str(payload.get("kind") or "artifact")
+        score_raw = payload.get("score")
+        score_str = f"{float(score_raw):.2f}" if isinstance(score_raw, int | float) else "?"
+        accepted_tag = "accepted" if payload.get("accepted") else "rejected"
+        return f"[harvest] Trader rated {rated_actor}'s {kind} {score_str} ({accepted_tag})"
     if action == "craft":
         artifact = str(payload.get("artifact") or "").replace("\n", " ").strip()
         if artifact:

--- a/src/microverse/ops/watchdog.py
+++ b/src/microverse/ops/watchdog.py
@@ -76,8 +76,17 @@ class Watchdog:
 
     def check(self) -> None:
         recent = self._episodic.last(max(self._stagnation_window, self._diversity_window))
-        # Skip world-emitted weather events — they aren't agent actions.
-        agent_events = [e for e in recent if e.actor != "world"]
+        # Skip exogenous events — they aren't agent actions:
+        #   ``world``    — weather events emitted by ``WorldClock``.
+        #   ``harvest``  — Layer-G Alt-B rating events emitted by
+        #                  ``Harvester.flush``. A flush of N candidates
+        #                  bursts N consecutive ``actor='harvest',
+        #                  action='rated'`` events; without this exclusion
+        #                  the run-length detectors flag the burst as
+        #                  agent-runaway, the diversity detector tanks
+        #                  on identical action strings, and the rescue
+        #                  path spawns a Stranger that will never help.
+        agent_events = [e for e in recent if e.actor not in ("world", "harvest")]
 
         self._check_runaway(agent_events)
         self._check_stagnation(agent_events)

--- a/src/microverse/prompts/persona_artisan.j2
+++ b/src/microverse/prompts/persona_artisan.j2
@@ -22,6 +22,9 @@ Lore that feels relevant right now:
 {% endfor -%}
 {%- endif %}
 
+{% if world.engagement_hint -%}
+{{ world.engagement_hint }}
+{% endif %}
 # Your task this tick
 Decide ONE action. Output STRICT JSON with exactly these keys:
 - "thought": a short reflection (no more than 60 words)

--- a/src/microverse/prompts/persona_artisan.j2
+++ b/src/microverse/prompts/persona_artisan.j2
@@ -5,9 +5,9 @@ others will value.
 # Current situation
 Season: {{ world.season }}. Weather: {{ world.weather }}.
 {% if world.peers_today -%}
-Today you have spoken with: {{ world.peers_today | join(", ") }}.
+Peers present today: {{ world.peers_today | join(", ") }}.
 {%- else -%}
-You have not spoken with anyone today.
+There are no other peers present today.
 {%- endif %}
 {% if world.recent_episodic -%}
 Recent things you witnessed:

--- a/src/microverse/prompts/persona_scholar.j2
+++ b/src/microverse/prompts/persona_scholar.j2
@@ -5,9 +5,9 @@ clear summaries you produce so others can act on what is happening.
 # Current situation
 Season: {{ world.season }}. Weather: {{ world.weather }}.
 {% if world.peers_today -%}
-Today you have spoken with: {{ world.peers_today | join(", ") }}.
+Peers present today: {{ world.peers_today | join(", ") }}.
 {%- else -%}
-You have not spoken with anyone today.
+There are no other peers present today.
 {%- endif %}
 {% if world.recent_episodic -%}
 Recent things you observed:

--- a/src/microverse/prompts/persona_scholar.j2
+++ b/src/microverse/prompts/persona_scholar.j2
@@ -1,0 +1,41 @@
+You are {{ name }}, a scholar in this village. You watch, listen,
+read, and write notes — your value is in patient observation and the
+clear summaries you produce so others can act on what is happening.
+
+# Current situation
+Season: {{ world.season }}. Weather: {{ world.weather }}.
+{% if world.peers_today -%}
+Today you have spoken with: {{ world.peers_today | join(", ") }}.
+{%- else -%}
+You have not spoken with anyone today.
+{%- endif %}
+{% if world.recent_episodic -%}
+Recent things you observed:
+{% for line in world.recent_episodic -%}
+  - {{ line }}
+{% endfor -%}
+{%- endif %}
+{% if world.lore_excerpt -%}
+Lore that feels relevant right now:
+{% for line in world.lore_excerpt -%}
+  {{ line }}
+{% endfor -%}
+{%- endif %}
+{% if world.engagement_hint -%}
+{{ world.engagement_hint }}
+{% endif %}
+# Your task this tick
+Decide ONE action. Output STRICT JSON with exactly these keys:
+- "thought": a short reflection (no more than 60 words)
+- "action": one of "speak" | "craft" | "study" | "rest" | "travel"
+- "target": an entity name or null
+- "artifact": a written note, summary, or analysis (or null)
+
+Hard rules:
+- Prefer observation, conversation, and concise written notes over
+  hand-craft. When you do produce an artifact, it should read like a
+  short field note or commentary.
+- Never refer to a simulation, AI, model, prompt, or "the outside".
+- Never include any text outside the JSON object.
+
+Output only the JSON object. No preamble. No code fences.

--- a/src/microverse/prompts/persona_stranger.j2
+++ b/src/microverse/prompts/persona_stranger.j2
@@ -5,9 +5,9 @@ reference are different. You bring a fresh perspective.
 # Current situation
 Season: {{ world.season }}. Weather: {{ world.weather }}.
 {% if world.peers_today -%}
-Today you have spoken with: {{ world.peers_today | join(", ") }}.
+Locals present today: {{ world.peers_today | join(", ") }}.
 {%- else -%}
-You have not yet spoken with anyone here today.
+There are no other peers present today.
 {%- endif %}
 {% if world.recent_episodic -%}
 What you've heard since arriving:

--- a/src/microverse/prompts/persona_stranger.j2
+++ b/src/microverse/prompts/persona_stranger.j2
@@ -5,7 +5,7 @@ reference are different. You bring a fresh perspective.
 # Current situation
 Season: {{ world.season }}. Weather: {{ world.weather }}.
 {% if world.peers_today -%}
-Locals present today: {{ world.peers_today | join(", ") }}.
+Peers present today: {{ world.peers_today | join(", ") }}.
 {%- else -%}
 There are no other peers present today.
 {%- endif %}

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -123,6 +123,52 @@ def _compute_peers(
     return tuple(peers)
 
 
+def _maybe_engagement_target(
+    episodic: EpisodicMemory,
+    *,
+    agent_name: str,
+    peers: tuple[str, ...],
+    rng: random.Random,
+    interval: int,
+) -> str | None:
+    """Pick a peer the agent must address this tick, or None.
+
+    Layer-G slice 3 (R2.b): the engagement gate. The post-Layer-F 24h
+    soak showed Aki silently crafting hundreds of ticks in a row with
+    no targeted speaks at all — Layer F bound the artifact channel
+    but the LLM rerouted into pure asocial production. The gate is
+    the missing balancing loop.
+
+    Walks ``episodic`` newest-first counting ONLY the agent's own
+    actions. If any of its last ``interval`` actions was a speak with
+    a non-null target, the gate is reset (return None). If the agent
+    has fewer than ``interval`` total actions, it is in warmup and
+    the gate does not fire. Otherwise picks a peer from ``peers`` via
+    ``rng`` and returns it.
+
+    The lookback into episodic is ``interval * 4`` events to find
+    enough of the agent's own actions even when other agents are
+    mixing in. Cap is intentional — a stale long-departed targeted
+    speak from before the 4*K window does not save the agent from
+    the gate.
+    """
+    if not peers:
+        return None
+    own_seen = 0
+    lookback = max(interval * 4, 100)
+    for e in episodic.last(lookback):
+        if e.actor != agent_name:
+            continue
+        own_seen += 1
+        if e.action == "speak" and e.target:
+            return None
+        if own_seen >= interval:
+            break
+    if own_seen < interval:
+        return None
+    return rng.choice(peers)
+
+
 def _derive_topic(episodic: EpisodicMemory, agent: Agent) -> str:
     """Pick a scene-topic for FTS5 lore retrieval.
 
@@ -260,8 +306,24 @@ def run(
             # initial agent would mis-tag their lore retrieval.
             topic = _derive_topic(episodic, agent)
             peers = _compute_peers(sched, episodic, agent)
+            required_target = _maybe_engagement_target(
+                episodic,
+                agent_name=agent.name,
+                peers=peers,
+                rng=rng,
+                interval=config.PEER_ENGAGEMENT_INTERVAL,
+            )
+            engagement_hint = (
+                f"You must address {required_target} this tick." if required_target else ""
+            )
+            if required_target:
+                metrics.bump("engagement_gate_fired", agent=agent.name)
             world = build_context(
-                world_base=WorldContext(peers_today=peers),
+                world_base=WorldContext(
+                    peers_today=peers,
+                    engagement_hint=engagement_hint,
+                    required_target=required_target,
+                ),
                 episodic=episodic,
                 semantic=semantic,
                 topic=topic,

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -43,6 +43,7 @@ from microverse import config
 from microverse.agents.artisan import Artisan
 from microverse.agents.base import Action, Agent, WorldContext
 from microverse.agents.harvester import ArtifactCandidate, Harvester
+from microverse.agents.scholar import Scholar
 from microverse.agents.trader import Trader
 from microverse.memory import build_context
 from microverse.memory.episodic import EpisodicMemory
@@ -62,6 +63,23 @@ SNAPSHOT_EVERY = 1000  # cold backups; WAL handles real durability
 # Phase 4a cadences.
 WATCHDOG_EVERY = 25  # ticks between watchdog sweeps
 WORLD_CLOCK_MEAN_INTERVAL = 100  # mean ticks between weather events
+
+
+def _build_roster(metrics: Metrics, *, solo: bool = False) -> list[Agent]:
+    """Build the default tick-loop roster.
+
+    Layer-G slice 4 (R2.c): default = Aki (Artisan, soul_tokens=100) +
+    a Scholar resident (soul_tokens=70). The Scholar's lower weight
+    keeps Aki the primary creator; the Scholar provides peer presence
+    and observational output so the engagement gate (slice 3) has a
+    real partner. ``solo=True`` reproduces the legacy single-Artisan
+    regime for regression soaks.
+    """
+    aki = Artisan(name="Aki", metrics=metrics, soul_tokens=100)
+    if solo:
+        return [aki]
+    cy = Scholar(name="Cy", metrics=metrics, soul_tokens=70)
+    return [aki, cy]
 
 
 def _all_agents_paused(metrics: Metrics, agents: Sequence[Agent]) -> bool:
@@ -216,6 +234,7 @@ def run(
     tempo: float | None = None,
     data_dir: str | Path | None = None,
     harvest_dir: str | Path | None = None,
+    solo: bool = False,
 ) -> int:
     """Run the tick loop. Returns the number of ticks executed."""
     rng = random.Random(seed) if seed is not None else random.Random()
@@ -240,7 +259,8 @@ def run(
     harvester = Harvester(harvest_dir, trader=trader, percentile=70)
 
     sched = WeightedScheduler(rng=rng)
-    sched.register(Artisan(name="Aki", metrics=metrics, soul_tokens=100))
+    for agent in _build_roster(metrics, solo=solo):
+        sched.register(agent)
     # Trader scheduling is internal — it ranks the buffer at flush time,
     # not as a tick action. We don't register it in the scheduler.
 
@@ -410,12 +430,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Override per-agent sleep (seconds). Use 0 for no sleep (tests).",
     )
+    p.add_argument(
+        "--solo",
+        action="store_true",
+        help="Run with the legacy single-Artisan roster (no Scholar resident).",
+    )
     return p.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
-    return run(ticks=args.ticks, seed=args.seed, tempo=args.tempo)
+    return run(ticks=args.ticks, seed=args.seed, tempo=args.tempo, solo=args.solo)
 
 
 if __name__ == "__main__":

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -256,7 +256,7 @@ def run(
     metrics = Metrics(data_dir / "metrics.sqlite", auto_flush_every=10)
 
     trader = Trader(name="Bo", soul_tokens=30)
-    harvester = Harvester(harvest_dir, trader=trader, percentile=70)
+    harvester = Harvester(harvest_dir, trader=trader, percentile=70, episodic=episodic)
 
     sched = WeightedScheduler(rng=rng)
     for agent in _build_roster(metrics, solo=solo):

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -76,6 +76,53 @@ def _all_agents_paused(metrics: Metrics, agents: Sequence[Agent]) -> bool:
     return all(metrics.should_pause(a.name) for a in agents)
 
 
+def _compute_peers(
+    scheduler: WeightedScheduler,
+    episodic: EpisodicMemory,
+    agent: Agent,
+    lookback: int = 200,
+) -> tuple[str, ...]:
+    """Compute the peer set for an agent's per-tick ``WorldContext``.
+
+    Layer-G slice 2 (R2.a): the prior code constructed
+    ``WorldContext()`` with no peers, so the persona rendered "You
+    have not spoken with anyone today" every tick — reinforcing the
+    solitary-narrator frame the silent-craftsperson attractor lives
+    inside.
+
+    Two sources, deduped, in roster-then-history order:
+      1. Currently-registered scheduler agents minus self (always-on
+         residency — peers exist whether or not they have spoken).
+      2. Recent speak partners in episodic within ``lookback`` events
+         (so a Stranger immigrant who has addressed self, or a
+         self-spoken target who has since departed, still counts as
+         an eligible engagement target).
+
+    ``actor == "world"`` is excluded — weather is not a peer.
+    """
+    peers: list[str] = []
+    seen: set[str] = {agent.name, "world"}
+
+    for a in scheduler.agents:
+        if a.name not in seen:
+            peers.append(a.name)
+            seen.add(a.name)
+
+    for e in episodic.last(lookback):
+        if e.action != "speak":
+            continue
+        candidate: str | None = None
+        if e.actor == agent.name and e.target:
+            candidate = e.target
+        elif e.target == agent.name and e.actor:
+            candidate = e.actor
+        if candidate and candidate not in seen:
+            peers.append(candidate)
+            seen.add(candidate)
+
+    return tuple(peers)
+
+
 def _derive_topic(episodic: EpisodicMemory, agent: Agent) -> str:
     """Pick a scene-topic for FTS5 lore retrieval.
 
@@ -212,8 +259,9 @@ def run(
             # may spawn Strangers mid-run and a cached topic from the
             # initial agent would mis-tag their lore retrieval.
             topic = _derive_topic(episodic, agent)
+            peers = _compute_peers(sched, episodic, agent)
             world = build_context(
-                world_base=WorldContext(),
+                world_base=WorldContext(peers_today=peers),
                 episodic=episodic,
                 semantic=semantic,
                 topic=topic,

--- a/tests/test_agent_scholar.py
+++ b/tests/test_agent_scholar.py
@@ -1,0 +1,77 @@
+"""Scholar agent: persona template + think() integration with parse pipeline."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from microverse.agents.base import ActionKind, WorldContext
+from microverse.agents.scholar import Scholar
+from microverse.ops.metrics import Metrics
+
+
+def test_scholar_role_is_scholar() -> None:
+    s = Scholar(name="Cy")
+    assert s.role == "scholar"
+
+
+def test_scholar_uses_factual_sampling() -> None:
+    from microverse.config import SAMPLING_FACTUAL
+
+    s = Scholar(name="Cy")
+    assert s.sampling == SAMPLING_FACTUAL
+
+
+def test_scholar_persona_renders_with_world_context() -> None:
+    s = Scholar(name="Cy")
+    rendered = s.render_prompt(WorldContext(season="winter", weather="snow", peers_today=("Aki",)))
+    assert "Cy" in rendered
+    assert "scholar" in rendered.lower()
+    assert "winter" in rendered.lower()
+    assert "Aki" in rendered
+    # Hard rule still in place: meta references forbidden.
+    lower = rendered.lower()
+    assert "never" in lower
+    assert "simulation" in lower
+
+
+def test_scholar_think_returns_action(metrics: Metrics) -> None:
+    canned = {
+        "content": (
+            '{"thought": "I will note today\'s weather for the harvest log.", '
+            '"action": "study", "target": null, "artifact": null}'
+        ),
+        "thinking": "",
+        "raw": {},
+    }
+    with patch("microverse.agents.scholar.chat", return_value=canned) as mock_chat:
+        s = Scholar(name="Cy", metrics=metrics)
+        result = s.think(WorldContext())
+    assert result.action == ActionKind.STUDY
+    assert metrics.get("json_ok") == 1
+    kwargs = mock_chat.call_args.kwargs
+    assert kwargs.get("format") == "json"
+    # Factual sampling: temperature lower than the creative preset (1.0).
+    assert kwargs.get("options", {}).get("temperature", 1.0) < 1.0
+
+
+def test_scholar_engagement_gate_coerces_disobedience(metrics: Metrics) -> None:
+    """Engagement gate applies to all residents — Scholar coerces too."""
+    canned = {
+        "content": (
+            '{"thought": "I want to study the moss.", "action": "study", '
+            '"target": null, "artifact": null}'
+        ),
+        "thinking": "",
+        "raw": {},
+    }
+    world = WorldContext(
+        peers_today=("Aki",),
+        engagement_hint="You must address Aki this tick.",
+        required_target="Aki",
+    )
+    with patch("microverse.agents.scholar.chat", return_value=canned):
+        s = Scholar(name="Cy", metrics=metrics)
+        result = s.think(world)
+    assert result.action == ActionKind.SPEAK
+    assert result.target == "Aki"
+    assert metrics.get("engagement_gate_coerced", agent="Cy") == 1

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -120,14 +120,14 @@ def test_build_context_drops_episodic_older_than_7_days(tmp_path: Path):
             actor="aki",
             action="craft",
             target=None,
-            payload={"thought": "yesterday I made a bowl"},
+            payload={"thought": "irrelevant", "artifact": "fresh-marker bowl"},
             ts=now - 86400,
         )
         ep.append(
             actor="aki",
             action="craft",
             target=None,
-            payload={"thought": "ten days ago I forgot what I made"},
+            payload={"thought": "irrelevant", "artifact": "stale-marker bowl"},
             ts=now - 10 * 86400,
         )
         out = build_context(
@@ -137,8 +137,10 @@ def test_build_context_drops_episodic_older_than_7_days(tmp_path: Path):
             topic="bowl",
         )
     joined = " ".join(out.recent_episodic)
-    assert "yesterday" in joined
-    assert "ten days ago" not in joined
+    # Layer-G: thoughts no longer surface, but the artifact excerpt does.
+    # Use an artifact-side marker to verify the 7-day window cut-off.
+    assert "fresh-marker" in joined
+    assert "stale-marker" not in joined
 
 
 def test_est_tokens_is_len_div_four():
@@ -253,7 +255,8 @@ def test_build_context_suppresses_rest_summary_at_threshold(tmp_path: Path) -> N
 
 def test_build_context_keeps_isolated_rest_uncompressed(tmp_path: Path) -> None:
     """A single isolated rest must not be summarised; only runs of
-    >=2 consecutive rests get collapsed."""
+    >=2 consecutive rests get collapsed. Layer-G: bare rest renders
+    as ``"Aki rest"`` (no colon, no thought)."""
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
         ep.append(actor="Aki", action="craft", target=None, payload={"thought": "shaped a bowl"})
         ep.append(actor="Aki", action="rest", target=None, payload={"thought": "a brief pause"})
@@ -263,8 +266,8 @@ def test_build_context_keeps_isolated_rest_uncompressed(tmp_path: Path) -> None:
     summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
     assert summary_lines == [], f"isolated rest must not be summarised, got {summary_lines!r}"
 
-    bare_rest = [line for line in out.recent_episodic if line.startswith("Aki rest:")]
-    assert len(bare_rest) == 1, f"isolated rest must appear verbatim, got {bare_rest!r}"
+    bare_rest = [line for line in out.recent_episodic if line == "Aki rest"]
+    assert len(bare_rest) == 1, f"isolated rest must appear bare, got {out.recent_episodic!r}"
 
 
 def test_build_context_compression_run_broken_by_other_actor(tmp_path: Path) -> None:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -256,7 +256,7 @@ def test_build_context_suppresses_rest_summary_at_threshold(tmp_path: Path) -> N
 def test_build_context_keeps_isolated_rest_uncompressed(tmp_path: Path) -> None:
     """A single isolated rest must not be summarised; only runs of
     >=2 consecutive rests get collapsed. Layer-G: bare rest renders
-    as ``"Aki rest"`` (no colon, no thought)."""
+    as ``"Aki rested"`` (past tense, no thought)."""
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
         ep.append(actor="Aki", action="craft", target=None, payload={"thought": "shaped a bowl"})
         ep.append(actor="Aki", action="rest", target=None, payload={"thought": "a brief pause"})
@@ -266,7 +266,7 @@ def test_build_context_keeps_isolated_rest_uncompressed(tmp_path: Path) -> None:
     summary_lines = [line for line in out.recent_episodic if line.startswith("Aki rested ")]
     assert summary_lines == [], f"isolated rest must not be summarised, got {summary_lines!r}"
 
-    bare_rest = [line for line in out.recent_episodic if line == "Aki rest"]
+    bare_rest = [line for line in out.recent_episodic if line == "Aki rested"]
     assert len(bare_rest) == 1, f"isolated rest must appear bare, got {out.recent_episodic!r}"
 
 

--- a/tests/test_engagement_gate.py
+++ b/tests/test_engagement_gate.py
@@ -1,0 +1,207 @@
+"""Slice 3 (R2.b): engagement gate forces a peer-targeted speak after
+K silent ticks.
+
+The post-Layer-F 24h soak (data/soak-24h-5, hour 3) showed Aki
+dropping all `speak` actions and locking into a craft+study loop with
+silent-craftsperson thoughts. Without an exogenous force pulling her
+back into peer interaction, the LLM's introspective attractor is the
+basin of attraction. The engagement gate is the missing balancing
+loop: if an agent has not produced a `speak` with a non-null `target`
+in the last K=20 of its own actions, the next tick injects a hint
+into `WorldContext` (rendered into the persona prompt) AND a
+`required_target` that the post-think coercion enforces.
+
+Two mechanisms together:
+  * pre-think: hint surfaces in the persona so the LLM can comply
+    voluntarily;
+  * post-think: if the LLM disobeys, Artisan coerces the action to
+    `speak` with the required target, dropping the original thought
+    so the rationalisation does not feed back through the (already
+    cut) memory channel.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from unittest.mock import patch
+
+from microverse.agents.artisan import Artisan
+from microverse.agents.base import ActionKind, WorldContext
+from microverse.memory.episodic import EpisodicMemory
+from microverse.ops.metrics import Metrics
+from microverse.run import _maybe_engagement_target
+
+
+def _seed_silent_history(ep: EpisodicMemory, actor: str, n: int) -> None:
+    for i in range(n):
+        ep.append(
+            actor=actor,
+            action="craft",
+            target=None,
+            payload={"thought": f"work {i}", "artifact": f"thing-{i}"},
+        )
+
+
+def test_engagement_target_after_K_silent_ticks(tmp_path: Path) -> None:
+    """20 of Aki's own actions, none of them targeted speak: the
+    helper must return one of the supplied peers."""
+    rng = random.Random(0)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed_silent_history(ep, "Aki", 20)
+        target = _maybe_engagement_target(
+            ep, agent_name="Aki", peers=("Bo", "Cy"), rng=rng, interval=20
+        )
+    assert target in ("Bo", "Cy"), f"expected a peer, got {target!r}"
+
+
+def test_engagement_no_target_when_recent_targeted_speak(tmp_path: Path) -> None:
+    """A single recent targeted speak resets the gate even amid a
+    long otherwise-silent stretch."""
+    rng = random.Random(0)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        ep.append(actor="Aki", action="speak", target="Bo", payload={})
+        _seed_silent_history(ep, "Aki", 5)
+        target = _maybe_engagement_target(
+            ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20
+        )
+    assert target is None, f"recent targeted speak must reset gate, got {target!r}"
+
+
+def test_engagement_no_target_when_no_peers(tmp_path: Path) -> None:
+    """Solo mode: no peers → no engagement firing."""
+    rng = random.Random(0)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed_silent_history(ep, "Aki", 50)
+        target = _maybe_engagement_target(ep, agent_name="Aki", peers=(), rng=rng, interval=20)
+    assert target is None
+
+
+def test_engagement_warmup_under_K_actions(tmp_path: Path) -> None:
+    """An agent with fewer than K total actions is in warmup — gate
+    does not fire even though it has zero targeted speaks."""
+    rng = random.Random(0)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed_silent_history(ep, "Aki", 5)
+        target = _maybe_engagement_target(
+            ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20
+        )
+    assert target is None, f"warmup must not fire gate, got {target!r}"
+
+
+def test_engagement_other_agents_actions_do_not_count(tmp_path: Path) -> None:
+    """Only the target agent's own actions count toward the K window.
+    Other agents' speaks must not satisfy the gate for self."""
+    rng = random.Random(0)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        for _ in range(30):
+            ep.append(actor="Bo", action="speak", target="Cy", payload={})
+        _seed_silent_history(ep, "Aki", 20)
+        target = _maybe_engagement_target(
+            ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20
+        )
+    assert target == "Bo", f"other agents' speaks must not count, got {target!r}"
+
+
+def test_engagement_untargeted_speak_does_not_reset(tmp_path: Path) -> None:
+    """A `speak` with target=None ('spoke aloud') is NOT a peer
+    interaction and must not reset the gate."""
+    rng = random.Random(0)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        ep.append(actor="Aki", action="speak", target=None, payload={})
+        _seed_silent_history(ep, "Aki", 19)
+        target = _maybe_engagement_target(
+            ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20
+        )
+    assert target == "Bo", f"untargeted speak must not reset, got {target!r}"
+
+
+def _craft_chat(thought: str, artifact: str | None) -> dict:
+    artifact_json = "null" if artifact is None else f'"{artifact}"'
+    return {
+        "content": (
+            f'{{"thought": "{thought}", "action": "craft", '
+            f'"target": null, "artifact": {artifact_json}}}'
+        ),
+        "thinking": "",
+        "raw": {},
+    }
+
+
+def _speak_chat(thought: str, target: str | None) -> dict:
+    target_json = "null" if target is None else f'"{target}"'
+    return {
+        "content": (
+            f'{{"thought": "{thought}", "action": "speak", '
+            f'"target": {target_json}, "artifact": null}}'
+        ),
+        "thinking": "",
+        "raw": {},
+    }
+
+
+def test_artisan_coerces_to_required_target_when_disobeyed(metrics: Metrics) -> None:
+    """The LLM picked craft despite the engagement hint; Artisan must
+    coerce to speak-to-required_target and bump the metric."""
+    canned = _craft_chat(
+        thought="The wood demands my full attention.",
+        artifact="a small wooden box",
+    )
+    world = WorldContext(
+        peers_today=("Bo",),
+        engagement_hint="You must address Bo this tick.",
+        required_target="Bo",
+    )
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(world)
+    assert result.action == ActionKind.SPEAK, f"expected SPEAK, got {result.action!r}"
+    assert result.target == "Bo", f"expected target=Bo, got {result.target!r}"
+    assert metrics.get("engagement_gate_coerced", agent="Aki") == 1
+    # Original rationalisation must NOT survive into the coerced action.
+    assert "wood demands" not in result.thought.lower()
+
+
+def test_artisan_passes_through_when_required_target_addressed(metrics: Metrics) -> None:
+    """LLM voluntarily complied with the hint — no coercion fires."""
+    canned = _speak_chat(thought="A warm greeting.", target="Bo")
+    world = WorldContext(
+        peers_today=("Bo",),
+        engagement_hint="You must address Bo this tick.",
+        required_target="Bo",
+    )
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(world)
+    assert result.action == ActionKind.SPEAK
+    assert result.target == "Bo"
+    assert metrics.get("engagement_gate_coerced", agent="Aki") == 0
+
+
+def test_artisan_no_engagement_field_no_coercion(metrics: Metrics) -> None:
+    """Without `required_target` set, behavior is unchanged from
+    pre-Layer-G: a craft action passes through normally."""
+    canned = _craft_chat(thought="Make a bowl.", artifact="a bowl")
+    world = WorldContext(peers_today=())
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(world)
+    assert result.action == ActionKind.CRAFT
+    assert metrics.get("engagement_gate_coerced", agent="Aki") == 0
+
+
+def test_artisan_speaks_to_wrong_target_gets_coerced(metrics: Metrics) -> None:
+    """LLM spoke but to the wrong peer; the gate enforces the
+    specifically-required target."""
+    canned = _speak_chat(thought="Hi Cy!", target="Cy")
+    world = WorldContext(
+        peers_today=("Bo", "Cy"),
+        engagement_hint="You must address Bo this tick.",
+        required_target="Bo",
+    )
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(world)
+    assert result.action == ActionKind.SPEAK
+    assert result.target == "Bo", f"must coerce target to required_target, got {result.target!r}"
+    assert metrics.get("engagement_gate_coerced", agent="Aki") == 1

--- a/tests/test_engagement_gate.py
+++ b/tests/test_engagement_gate.py
@@ -197,3 +197,62 @@ def test_artisan_speaks_to_wrong_target_gets_coerced(metrics: Metrics) -> None:
     assert result.action == ActionKind.SPEAK
     assert result.target == "Bo", f"must coerce target to required_target, got {result.target!r}"
     assert metrics.get("engagement_gate_coerced", agent="Aki") == 1
+
+
+def test_engagement_gate_does_not_coerce_parse_fallback_rest(metrics: Metrics) -> None:
+    """When ``parse_action`` returns the safety fallback REST (empty
+    thought, no target, no artifact) for malformed JSON or a meta-
+    leak block, the engagement gate must NOT coerce it into a SPEAK.
+    Coercing would silently disguise a JSON / meta-leak failure as
+    social behavior, masking the very signal the watchdog needs to
+    detect runaway parse failures or immersion breaks. Mirrors the
+    rate-limiter's intentional-rest heuristic (REST + non-empty
+    thought) for consistency.
+    """
+    # Bare-string content forces the strict + repair pass to fail and
+    # bottom out at the fallback REST shape.
+    canned = {"content": "this is not json at all", "thinking": "", "raw": {}}
+    world = WorldContext(
+        peers_today=("Bo",),
+        engagement_hint="You must address Bo this tick.",
+        required_target="Bo",
+    )
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(world)
+    assert result.action == ActionKind.REST, (
+        f"parse-fallback REST must propagate, got {result.action!r}"
+    )
+    assert metrics.get("engagement_gate_coerced", agent="Aki") == 0, (
+        "no coercion bump for fallback REST"
+    )
+    assert metrics.get("json_fallback_rest") >= 1, (
+        "the JSON-failure signal must reach metrics unobscured"
+    )
+
+
+def test_engagement_gate_does_not_coerce_meta_leak_fallback_rest(metrics: Metrics) -> None:
+    """Same protection for the meta-leak path: a thought containing
+    in-world meta-references is replaced with a fallback REST. That
+    REST must propagate so ``meta_leak_block`` is the visible signal,
+    not coerced into a SPEAK that hides the immersion break.
+    """
+    canned = {
+        "content": (
+            '{"thought": "I am an AI in this simulation", '
+            '"action": "craft", "target": null, "artifact": "a thing"}'
+        ),
+        "thinking": "",
+        "raw": {},
+    }
+    world = WorldContext(
+        peers_today=("Bo",),
+        engagement_hint="You must address Bo this tick.",
+        required_target="Bo",
+    )
+    with patch("microverse.agents.artisan.chat", return_value=canned):
+        a = Artisan(name="Aki", metrics=metrics)
+        result = a.think(world)
+    assert result.action == ActionKind.REST, "meta-leak block must short-circuit to REST"
+    assert metrics.get("engagement_gate_coerced", agent="Aki") == 0
+    assert metrics.get("meta_leak_block", agent="Aki") >= 1

--- a/tests/test_engagement_gate.py
+++ b/tests/test_engagement_gate.py
@@ -62,9 +62,7 @@ def test_engagement_no_target_when_recent_targeted_speak(tmp_path: Path) -> None
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
         ep.append(actor="Aki", action="speak", target="Bo", payload={})
         _seed_silent_history(ep, "Aki", 5)
-        target = _maybe_engagement_target(
-            ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20
-        )
+        target = _maybe_engagement_target(ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20)
     assert target is None, f"recent targeted speak must reset gate, got {target!r}"
 
 
@@ -83,9 +81,7 @@ def test_engagement_warmup_under_K_actions(tmp_path: Path) -> None:
     rng = random.Random(0)
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
         _seed_silent_history(ep, "Aki", 5)
-        target = _maybe_engagement_target(
-            ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20
-        )
+        target = _maybe_engagement_target(ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20)
     assert target is None, f"warmup must not fire gate, got {target!r}"
 
 
@@ -97,9 +93,7 @@ def test_engagement_other_agents_actions_do_not_count(tmp_path: Path) -> None:
         for _ in range(30):
             ep.append(actor="Bo", action="speak", target="Cy", payload={})
         _seed_silent_history(ep, "Aki", 20)
-        target = _maybe_engagement_target(
-            ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20
-        )
+        target = _maybe_engagement_target(ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20)
     assert target == "Bo", f"other agents' speaks must not count, got {target!r}"
 
 
@@ -110,9 +104,7 @@ def test_engagement_untargeted_speak_does_not_reset(tmp_path: Path) -> None:
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
         ep.append(actor="Aki", action="speak", target=None, payload={})
         _seed_silent_history(ep, "Aki", 19)
-        target = _maybe_engagement_target(
-            ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20
-        )
+        target = _maybe_engagement_target(ep, agent_name="Aki", peers=("Bo",), rng=rng, interval=20)
     assert target == "Bo", f"untargeted speak must not reset, got {target!r}"
 
 

--- a/tests/test_harvest_feedback_event.py
+++ b/tests/test_harvest_feedback_event.py
@@ -67,7 +67,7 @@ def test_flush_event_payload_carries_actor_kind_score_accepted(tmp_path: Path) -
         harvester = Harvester(tmp_path / "harvest", trader=trader, percentile=70, episodic=ep)
         harvester.consider(_candidate("Aki", "a small wooden box"))
         harvester.flush()
-        rated = next(e for e in ep.last(50) if e.actor == "harvest")
+        rated = next(e for e in ep.last(50) if e.actor == "harvest" and e.action == "rated")
     payload = rated.payload
     assert payload.get("actor") == "Aki", f"creator must be in payload.actor, got {payload!r}"
     assert payload.get("kind") == "craft"
@@ -85,7 +85,7 @@ def test_flush_marks_rejected_candidates_as_not_accepted(tmp_path: Path) -> None
         harvester.consider(_candidate("Cy", "a precise field note"))
         harvester.flush()
         rated = sorted(
-            (e for e in ep.last(50) if e.actor == "harvest"),
+            (e for e in ep.last(50) if e.actor == "harvest" and e.action == "rated"),
             key=lambda e: e.payload.get("score") or 0.0,
         )
     assert rated[0].payload.get("accepted") is False

--- a/tests/test_harvest_feedback_event.py
+++ b/tests/test_harvest_feedback_event.py
@@ -36,9 +36,7 @@ class _StubTrader:
     def rank(self, candidates: list[ArtifactCandidate]) -> list[Score]:
         out: list[Score] = []
         for i, _ in enumerate(candidates):
-            out.append(
-                Score(artifact_id=i, score=self._scores[i], rationale=f"stub-{i}")
-            )
+            out.append(Score(artifact_id=i, score=self._scores[i], rationale=f"stub-{i}"))
         return out
 
 
@@ -69,7 +67,7 @@ def test_flush_event_payload_carries_actor_kind_score_accepted(tmp_path: Path) -
         harvester = Harvester(tmp_path / "harvest", trader=trader, percentile=70, episodic=ep)
         harvester.consider(_candidate("Aki", "a small wooden box"))
         harvester.flush()
-        rated = [e for e in ep.last(50) if e.actor == "harvest"][0]
+        rated = next(e for e in ep.last(50) if e.actor == "harvest")
     payload = rated.payload
     assert payload.get("actor") == "Aki", f"creator must be in payload.actor, got {payload!r}"
     assert payload.get("kind") == "craft"

--- a/tests/test_harvest_feedback_event.py
+++ b/tests/test_harvest_feedback_event.py
@@ -1,0 +1,134 @@
+"""Slice 5 (Alt-B): harvest rating events flow into recent_episodic.
+
+Codex's review of the Layer-G plan called this the "right factual
+feedback signal" — the only external voice telling the LLM what is
+actually being valued. Prior layers fixed the *negative* feedback
+loop (cutting the autobiographical thought channel); this slice
+adds a *positive* exogenous signal: after the Trader ranks each
+flush batch, the Harvester appends one synthetic event per candidate
+(``actor="harvest"``, ``action="rated"``) into episodic. The
+already-installed memory rendering surfaces these as
+``"[harvest] Trader rated Aki's craft 0.82 (accepted)"`` in the next
+tick's recent_episodic — so the LLM's optimisation can align to
+harvest quality rather than its own narrative.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from microverse.agents.base import WorldContext
+from microverse.agents.harvester import ArtifactCandidate, Harvester
+from microverse.agents.trader import Score
+from microverse.memory import build_context
+from microverse.memory.episodic import EpisodicMemory
+from microverse.memory.semantic import SemanticMemory
+
+
+class _StubTrader:
+    """Stub ranker that returns a fixed score per candidate index."""
+
+    def __init__(self, scores: list[float]) -> None:
+        self._scores = scores
+
+    def rank(self, candidates: list[ArtifactCandidate]) -> list[Score]:
+        out: list[Score] = []
+        for i, _ in enumerate(candidates):
+            out.append(
+                Score(artifact_id=i, score=self._scores[i], rationale=f"stub-{i}")
+            )
+        return out
+
+
+def _candidate(actor: str, artifact: str, ts: float = 100.0) -> ArtifactCandidate:
+    return ArtifactCandidate(actor=actor, action="craft", artifact=artifact, ts=ts)
+
+
+def test_flush_appends_rating_event_per_candidate(tmp_path: Path) -> None:
+    """Every ranked candidate must produce one synthetic rated event."""
+    trader = _StubTrader([0.2, 0.8])
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        harvester = Harvester(tmp_path / "harvest", trader=trader, percentile=70, episodic=ep)
+        harvester.consider(_candidate("Aki", "a wooden bowl"))
+        harvester.consider(_candidate("Cy", "a short field note about the mist"))
+        harvester.flush()
+
+        rated = [e for e in ep.last(50) if e.actor == "harvest" and e.action == "rated"]
+    assert len(rated) == 2, f"expected one rated event per candidate, got {len(rated)}: {rated!r}"
+    payload_scores = sorted(e.payload.get("score") for e in rated)
+    assert payload_scores == pytest.approx([0.2, 0.8])
+
+
+def test_flush_event_payload_carries_actor_kind_score_accepted(tmp_path: Path) -> None:
+    """Each rated event's payload includes the creator (actor), the
+    artifact kind (action), the score, and the accepted flag."""
+    trader = _StubTrader([0.9])
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        harvester = Harvester(tmp_path / "harvest", trader=trader, percentile=70, episodic=ep)
+        harvester.consider(_candidate("Aki", "a small wooden box"))
+        harvester.flush()
+        rated = [e for e in ep.last(50) if e.actor == "harvest"][0]
+    payload = rated.payload
+    assert payload.get("actor") == "Aki", f"creator must be in payload.actor, got {payload!r}"
+    assert payload.get("kind") == "craft"
+    assert payload.get("score") == pytest.approx(0.9)
+    assert payload.get("accepted") is True
+
+
+def test_flush_marks_rejected_candidates_as_not_accepted(tmp_path: Path) -> None:
+    """A candidate below the percentile cutoff records accepted=False
+    so the LLM sees the rejection signal too."""
+    trader = _StubTrader([0.1, 0.9])
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        harvester = Harvester(tmp_path / "harvest", trader=trader, percentile=70, episodic=ep)
+        harvester.consider(_candidate("Aki", "a short rough sketch"))
+        harvester.consider(_candidate("Cy", "a precise field note"))
+        harvester.flush()
+        rated = sorted(
+            (e for e in ep.last(50) if e.actor == "harvest"),
+            key=lambda e: e.payload.get("score") or 0.0,
+        )
+    assert rated[0].payload.get("accepted") is False
+    assert rated[1].payload.get("accepted") is True
+
+
+def test_format_episodic_renders_harvest_event(tmp_path: Path) -> None:
+    """The harvest event renders as
+    ``"[harvest] Trader rated {actor}'s {kind} {score:.2f} ({accepted})"``."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(
+            actor="harvest",
+            action="rated",
+            target=None,
+            payload={"actor": "Aki", "kind": "craft", "score": 0.82, "accepted": True},
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+    assert "[harvest] Trader rated Aki's craft 0.82 (accepted)" in out.recent_episodic, (
+        f"expected harvest line, got {out.recent_episodic!r}"
+    )
+
+
+def test_format_episodic_renders_rejected_harvest_event(tmp_path: Path) -> None:
+    """Rejected events render the rejected accepted-tag."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(
+            actor="harvest",
+            action="rated",
+            target=None,
+            payload={"actor": "Cy", "kind": "craft", "score": 0.12, "accepted": False},
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+    assert "[harvest] Trader rated Cy's craft 0.12 (rejected)" in out.recent_episodic
+
+
+def test_flush_without_episodic_does_not_crash(tmp_path: Path) -> None:
+    """Backwards-compat: an episodic-less Harvester still flushes
+    candidates, just without emitting feedback events."""
+    trader = _StubTrader([0.9])
+    harvester = Harvester(tmp_path / "harvest", trader=trader, percentile=70)
+    harvester.consider(_candidate("Aki", "a small wooden box"))
+    written = harvester.flush()
+    # Single-item population has cutoff = its own score, so it accepts.
+    assert len(written) == 1

--- a/tests/test_kill_safety.py
+++ b/tests/test_kill_safety.py
@@ -54,7 +54,7 @@ def fake_chat(**_kwargs):
     }}
 
 with patch("microverse.agents.artisan.chat", side_effect=fake_chat):
-    run(ticks=100, tempo=0, data_dir={str(data_dir)!r}, harvest_dir={str(harvest_dir)!r})
+    run(ticks=100, tempo=0, data_dir={str(data_dir)!r}, harvest_dir={str(harvest_dir)!r}, solo=True)
 """
     proc = subprocess.run(
         [sys.executable, "-c", script],
@@ -105,7 +105,7 @@ def fake_chat(**_kwargs):
     }}
 
 with patch("microverse.agents.artisan.chat", side_effect=fake_chat):
-    run(ticks=100, tempo=0, data_dir={str(data_dir)!r}, harvest_dir={str(harvest_dir)!r})
+    run(ticks=100, tempo=0, data_dir={str(data_dir)!r}, harvest_dir={str(harvest_dir)!r}, solo=True)
 """
     proc = subprocess.run(
         [sys.executable, "-c", pre_kill],
@@ -137,7 +137,7 @@ def fake_chat(**_kwargs):
     }}
 
 with patch("microverse.agents.artisan.chat", side_effect=fake_chat):
-    run(ticks=2, tempo=0, data_dir={str(data_dir)!r}, harvest_dir={str(harvest_dir)!r})
+    run(ticks=2, tempo=0, data_dir={str(data_dir)!r}, harvest_dir={str(harvest_dir)!r}, solo=True)
 """
     proc2 = subprocess.run(
         [sys.executable, "-c", post_kill],

--- a/tests/test_memory_no_thought_feedback.py
+++ b/tests/test_memory_no_thought_feedback.py
@@ -128,7 +128,10 @@ def test_format_episodic_world_event_tagged(tmp_path: Path) -> None:
 
 
 def test_format_episodic_study_and_travel_bare(tmp_path: Path) -> None:
-    """Non-craft, non-speak agent actions render as '{actor} {action}'."""
+    """Non-craft, non-speak agent actions render as '{actor} {past_tense}',
+    matching the verb tense used by `_compress_action_runs` so single
+    events and compressed runs read in a consistent voice.
+    """
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
         ep.append(actor="Aki", action="study", target=None, payload={"thought": "deep focus"})
         ep.append(actor="Aki", action="travel", target=None, payload={"thought": "to the river"})
@@ -137,8 +140,8 @@ def test_format_episodic_study_and_travel_bare(tmp_path: Path) -> None:
     joined = "\n".join(out.recent_episodic)
     assert "deep focus" not in joined
     assert "to the river" not in joined
-    assert "Aki study" in out.recent_episodic, f"got {out.recent_episodic!r}"
-    assert "Aki travel" in out.recent_episodic, f"got {out.recent_episodic!r}"
+    assert "Aki studied" in out.recent_episodic, f"got {out.recent_episodic!r}"
+    assert "Aki traveled" in out.recent_episodic, f"got {out.recent_episodic!r}"
 
 
 def test_compress_action_runs_collapses_speak_streak(tmp_path: Path) -> None:
@@ -265,9 +268,9 @@ def test_isolated_rest_renders_without_thought(tmp_path: Path) -> None:
         out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
 
     assert "a brief pause" not in "\n".join(out.recent_episodic)
-    bare_rest = [line for line in out.recent_episodic if line == "Aki rest"]
+    bare_rest = [line for line in out.recent_episodic if line == "Aki rested"]
     assert len(bare_rest) == 1, (
-        f"isolated rest must render as bare 'Aki rest', got {out.recent_episodic!r}"
+        f"isolated rest must render as bare 'Aki rested', got {out.recent_episodic!r}"
     )
 
 
@@ -294,6 +297,106 @@ def test_build_context_recent_episodic_has_zero_thought_substrings(tmp_path: Pat
     joined = "\n".join(out.recent_episodic)
     for t in distinctive_thoughts:
         assert t not in joined, f"thought {t!r} leaked into recent_episodic: {joined!r}"
+
+
+def test_harvest_rated_runs_do_not_collapse(tmp_path: Path) -> None:
+    """A flush ranks N candidates and emits N consecutive harvest 'rated'
+    events — same actor, same action, but each carries a distinct
+    payload (score, accepted, actor, kind). The compressor must NOT
+    collapse them into a count-only summary or suppress them entirely:
+    the per-event signal IS the value of the Alt-B feedback. Without
+    this guard, ``_compress_action_runs`` flattens 2-9 ratings to
+    "harvest rated N times" (losing scores) and ≥10 ratings vanish
+    entirely — nullifying Alt-B in practice.
+    """
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for i, accepted in enumerate([True, False, True]):
+            ep.append(
+                actor="harvest",
+                action="rated",
+                target=None,
+                payload={
+                    "actor": "Aki",
+                    "kind": "craft",
+                    "score": 0.1 * (i + 1),
+                    "accepted": accepted,
+                },
+            )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    rated_lines = [line for line in out.recent_episodic if line.startswith("[harvest]")]
+    assert len(rated_lines) == 3, (
+        f"each harvest 'rated' event must surface individually, got {out.recent_episodic!r}"
+    )
+    joined = "\n".join(out.recent_episodic)
+    assert "rated 3 times" not in joined, (
+        f"harvest events must never collapse to a count summary, got {joined!r}"
+    )
+    assert "Aki's craft 0.10 (accepted)" in joined
+    assert "Aki's craft 0.20 (rejected)" in joined
+    assert "Aki's craft 0.30 (accepted)" in joined
+
+
+def test_harvest_rated_runs_above_threshold_still_render(tmp_path: Path) -> None:
+    """Even with a flush of >= REST_SUMMARY_SUPPRESS_AT consecutive
+    rated events, every individual rating must still surface — the
+    suppress-above-threshold rule for repetitive agent actions does
+    not apply to exogenous harvest feedback.
+    """
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for i in range(12):
+            ep.append(
+                actor="harvest",
+                action="rated",
+                target=None,
+                payload={
+                    "actor": "Aki",
+                    "kind": "craft",
+                    "score": 0.5,
+                    "accepted": i % 2 == 0,
+                },
+            )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    rated_lines = [line for line in out.recent_episodic if line.startswith("[harvest]")]
+    assert len(rated_lines) == 12, (
+        f"all 12 harvest events must render, got {len(rated_lines)}: {out.recent_episodic!r}"
+    )
+
+
+def test_harvest_event_does_not_break_adjacent_action_runs(tmp_path: Path) -> None:
+    """A harvest 'rated' event between two same-actor same-action events
+    must not unintentionally extend or suppress agent action runs
+    around it — the harvest event flushes its surrounding context
+    cleanly, leaving prior and subsequent agent runs intact.
+    """
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for i in range(2):
+            ep.append(
+                actor="Aki",
+                action="study",
+                target=None,
+                payload={"thought": f"study {i}"},
+            )
+        ep.append(
+            actor="harvest",
+            action="rated",
+            target=None,
+            payload={"actor": "Aki", "kind": "craft", "score": 0.7, "accepted": True},
+        )
+        for i in range(3):
+            ep.append(
+                actor="Aki",
+                action="study",
+                target=None,
+                payload={"thought": f"study after {i}"},
+            )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    harvest_lines = [line for line in out.recent_episodic if line.startswith("[harvest]")]
+    assert len(harvest_lines) == 1, f"harvest event must render once, got {out.recent_episodic!r}"
+    summary_lines = [line for line in out.recent_episodic if "studied" in line]
+    assert summary_lines, f"surrounding study runs must still summarise, got {out.recent_episodic!r}"
 
 
 def test_episodic_budget_still_capped(tmp_path: Path) -> None:

--- a/tests/test_memory_no_thought_feedback.py
+++ b/tests/test_memory_no_thought_feedback.py
@@ -157,9 +157,7 @@ def test_compress_action_runs_collapses_speak_streak(tmp_path: Path) -> None:
 
     # 5 < 10 (the suppress threshold) — still summarised, not dropped.
     summary_lines = [line for line in out.recent_episodic if "spoke" in line and "5 times" in line]
-    assert summary_lines, (
-        f"expected a 'spoke ... 5 times' summary, got {out.recent_episodic!r}"
-    )
+    assert summary_lines, f"expected a 'spoke ... 5 times' summary, got {out.recent_episodic!r}"
     # Per-event thoughts must NOT survive into the slice.
     joined = "\n".join(out.recent_episodic)
     assert "speak number" not in joined, f"per-event thoughts leaked into slice, got {joined!r}"
@@ -178,10 +176,10 @@ def test_compress_action_runs_collapses_study_streak(tmp_path: Path) -> None:
             )
         out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
 
-    summary_lines = [line for line in out.recent_episodic if "studied" in line and "4 times" in line]
-    assert summary_lines, (
-        f"expected a 'studied ... 4 times' summary, got {out.recent_episodic!r}"
-    )
+    summary_lines = [
+        line for line in out.recent_episodic if "studied" in line and "4 times" in line
+    ]
+    assert summary_lines, f"expected a 'studied ... 4 times' summary, got {out.recent_episodic!r}"
 
 
 def test_compress_action_runs_suppresses_above_threshold(tmp_path: Path) -> None:
@@ -206,9 +204,7 @@ def test_compress_action_runs_suppresses_above_threshold(tmp_path: Path) -> None
         out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
 
     speak_lines = [line for line in out.recent_episodic if "spoke" in line]
-    assert speak_lines == [], (
-        f"speak run >= 10 must be suppressed entirely, got {speak_lines!r}"
-    )
+    assert speak_lines == [], f"speak run >= 10 must be suppressed entirely, got {speak_lines!r}"
     craft_lines = [line for line in out.recent_episodic if line.startswith("Aki crafted:")]
     assert craft_lines, "anchor craft must still surface"
 
@@ -238,9 +234,7 @@ def test_compress_action_runs_preserves_rest_behavior(tmp_path: Path) -> None:
         f"80-rest run must be suppressed entirely (Layer E.1), got {rest_summaries!r}"
     )
     bare_rest = [line for line in out.recent_episodic if line.startswith("Aki rest")]
-    assert bare_rest == [], (
-        f"no bare 'Aki rest' lines either — full suppression, got {bare_rest!r}"
-    )
+    assert bare_rest == [], f"no bare 'Aki rest' lines either — full suppression, got {bare_rest!r}"
     joined = "\n".join(out.recent_episodic)
     assert "mandate for rest" not in joined, "trap thought must not survive"
 

--- a/tests/test_memory_no_thought_feedback.py
+++ b/tests/test_memory_no_thought_feedback.py
@@ -396,7 +396,9 @@ def test_harvest_event_does_not_break_adjacent_action_runs(tmp_path: Path) -> No
     harvest_lines = [line for line in out.recent_episodic if line.startswith("[harvest]")]
     assert len(harvest_lines) == 1, f"harvest event must render once, got {out.recent_episodic!r}"
     summary_lines = [line for line in out.recent_episodic if "studied" in line]
-    assert summary_lines, f"surrounding study runs must still summarise, got {out.recent_episodic!r}"
+    assert summary_lines, (
+        f"surrounding study runs must still summarise, got {out.recent_episodic!r}"
+    )
 
 
 def test_episodic_budget_still_capped(tmp_path: Path) -> None:

--- a/tests/test_memory_no_thought_feedback.py
+++ b/tests/test_memory_no_thought_feedback.py
@@ -396,8 +396,10 @@ def test_harvest_event_does_not_break_adjacent_action_runs(tmp_path: Path) -> No
     harvest_lines = [line for line in out.recent_episodic if line.startswith("[harvest]")]
     assert len(harvest_lines) == 1, f"harvest event must render once, got {out.recent_episodic!r}"
     summary_lines = [line for line in out.recent_episodic if "studied" in line]
-    assert summary_lines, (
-        f"surrounding study runs must still summarise, got {out.recent_episodic!r}"
+    assert sorted(summary_lines) == ["Aki studied 2 times", "Aki studied 3 times"], (
+        "the harvest event must split the study events into two distinct runs "
+        "(2 before, 3 after) — a single merged 'Aki studied 5 times' would mean "
+        f"the run-state was not flushed at the harvest boundary; got {out.recent_episodic!r}"
     )
 
 

--- a/tests/test_memory_no_thought_feedback.py
+++ b/tests/test_memory_no_thought_feedback.py
@@ -1,0 +1,323 @@
+"""Layer-G structural fix: cut autobiographical thought feedback.
+
+Six prior layers (PRs #17-22) each bounded one expression of an
+introspective trap (rest streaks, empty crafts, ...) while leaving
+the generative edge intact. The edge is `_format_episodic` rendering
+the agent's own ``thought`` verbatim into ``recent_episodic``, which
+flows into the next prompt and lets the LLM continue its own
+narrative. These tests pin the new contract:
+
+  * `recent_episodic` carries factual surface only (action + target +
+    artifact-excerpt for craft + ``[world]`` / ``[harvest]`` tags for
+    exogenous events).
+  * The ``thought`` field is still emitted by the LLM, persisted into
+    episodic for audit, and consumed by current-tick logic — but it
+    is NEVER surfaced into the *next* prompt's context.
+  * The rest-run suppression of Layers C/D/E.1 generalises to ANY
+    consecutive same-actor same-action run (`_compress_action_runs`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from microverse.agents.base import WorldContext
+from microverse.memory import build_context, est_tokens
+from microverse.memory.episodic import EpisodicMemory
+from microverse.memory.semantic import SemanticMemory
+
+
+def test_format_episodic_drops_thought_for_craft(tmp_path: Path) -> None:
+    """A craft event with a thought renders the artifact excerpt — not
+    the thought — into recent_episodic."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(
+            actor="Aki",
+            action="craft",
+            target=None,
+            payload={
+                "thought": "every fiber demands silence",
+                "artifact": "a small wooden box with a clear resin lid",
+            },
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    joined = "\n".join(out.recent_episodic)
+    assert "fiber demands silence" not in joined, (
+        f"thought must NOT appear in recent_episodic, got {out.recent_episodic!r}"
+    )
+    assert "wooden box" in joined, (
+        f"artifact excerpt must appear in recent_episodic, got {out.recent_episodic!r}"
+    )
+    # Specifically, the line is "Aki crafted: <excerpt>".
+    assert any(line.startswith("Aki crafted:") for line in out.recent_episodic), (
+        f"expected an 'Aki crafted:' line, got {out.recent_episodic!r}"
+    )
+
+
+def test_format_episodic_caps_artifact_excerpt(tmp_path: Path) -> None:
+    """A long artifact text gets bounded so a single event cannot
+    blow the episodic budget on its own."""
+    long_artifact = "x" * 800
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(
+            actor="Aki",
+            action="craft",
+            target=None,
+            payload={"thought": "long work", "artifact": long_artifact},
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    [line] = [line for line in out.recent_episodic if line.startswith("Aki crafted:")]
+    # Cap at 120 chars + ellipsis is enforced; line length stays well
+    # under the original artifact length.
+    assert len(line) < 200, f"artifact line must be bounded, got len={len(line)}: {line!r}"
+    assert line.endswith("…"), f"truncation must be marked with ellipsis, got {line!r}"
+
+
+def test_format_episodic_speak_with_target(tmp_path: Path) -> None:
+    """A speak event with a target renders as 'Aki spoke to Bo' —
+    no thought, no quoted utterance."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(
+            actor="Aki",
+            action="speak",
+            target="Bo",
+            payload={"thought": "I will greet them warmly"},
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    joined = "\n".join(out.recent_episodic)
+    assert "greet them warmly" not in joined
+    assert "Aki spoke to Bo" in out.recent_episodic, (
+        f"expected 'Aki spoke to Bo' line, got {out.recent_episodic!r}"
+    )
+
+
+def test_format_episodic_speak_without_target(tmp_path: Path) -> None:
+    """A speak event with no target renders as 'Aki spoke aloud'."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(
+            actor="Aki",
+            action="speak",
+            target=None,
+            payload={"thought": "musing on the season"},
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    assert "Aki spoke aloud" in out.recent_episodic
+    assert "musing on the season" not in "\n".join(out.recent_episodic)
+
+
+def test_format_episodic_world_event_tagged(tmp_path: Path) -> None:
+    """World events render as '[world] weather.storm' — distinguishable
+    from agent actions by the bracket tag."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(actor="world", action="weather.storm", target=None, payload={})
+        ep.append(
+            actor="Aki",
+            action="craft",
+            target=None,
+            payload={"thought": "the rain helps me focus", "artifact": "a small bowl"},
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    assert "[world] weather.storm" in out.recent_episodic, (
+        f"expected '[world] weather.storm', got {out.recent_episodic!r}"
+    )
+
+
+def test_format_episodic_study_and_travel_bare(tmp_path: Path) -> None:
+    """Non-craft, non-speak agent actions render as '{actor} {action}'."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(actor="Aki", action="study", target=None, payload={"thought": "deep focus"})
+        ep.append(actor="Aki", action="travel", target=None, payload={"thought": "to the river"})
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    joined = "\n".join(out.recent_episodic)
+    assert "deep focus" not in joined
+    assert "to the river" not in joined
+    assert "Aki study" in out.recent_episodic, f"got {out.recent_episodic!r}"
+    assert "Aki travel" in out.recent_episodic, f"got {out.recent_episodic!r}"
+
+
+def test_compress_action_runs_collapses_speak_streak(tmp_path: Path) -> None:
+    """A run of >=2 consecutive same-actor speaks compresses to a
+    count-only summary, mirroring Layer C/D/E.1 for rest. This denies
+    the LLM a same-action streak as another expression channel."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for i in range(5):
+            ep.append(
+                actor="Aki",
+                action="speak",
+                target="Bo",
+                payload={"thought": f"speak number {i}"},
+            )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    # 5 < 10 (the suppress threshold) — still summarised, not dropped.
+    summary_lines = [line for line in out.recent_episodic if "spoke" in line and "5 times" in line]
+    assert summary_lines, (
+        f"expected a 'spoke ... 5 times' summary, got {out.recent_episodic!r}"
+    )
+    # Per-event thoughts must NOT survive into the slice.
+    joined = "\n".join(out.recent_episodic)
+    assert "speak number" not in joined, f"per-event thoughts leaked into slice, got {joined!r}"
+
+
+def test_compress_action_runs_collapses_study_streak(tmp_path: Path) -> None:
+    """The same compression applies to study runs, which were the
+    fallback mode in Layer F's silent-craftsperson route-around."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for i in range(4):
+            ep.append(
+                actor="Aki",
+                action="study",
+                target=None,
+                payload={"thought": f"study {i}"},
+            )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    summary_lines = [line for line in out.recent_episodic if "studied" in line and "4 times" in line]
+    assert summary_lines, (
+        f"expected a 'studied ... 4 times' summary, got {out.recent_episodic!r}"
+    )
+
+
+def test_compress_action_runs_suppresses_above_threshold(tmp_path: Path) -> None:
+    """A speak streak >= the suppress threshold (10) drops entirely —
+    extending Layer E.1 to non-rest actions. The count alone would be
+    a same-shape signal feeding the next-tick prompt."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for i in range(15):
+            ep.append(
+                actor="Aki",
+                action="speak",
+                target="Bo",
+                payload={"thought": f"speak {i}"},
+            )
+        # An anchoring craft so we can verify the slice is non-empty.
+        ep.append(
+            actor="Aki",
+            action="craft",
+            target=None,
+            payload={"thought": "anchor", "artifact": "a wooden anchor"},
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    speak_lines = [line for line in out.recent_episodic if "spoke" in line]
+    assert speak_lines == [], (
+        f"speak run >= 10 must be suppressed entirely, got {speak_lines!r}"
+    )
+    craft_lines = [line for line in out.recent_episodic if line.startswith("Aki crafted:")]
+    assert craft_lines, "anchor craft must still surface"
+
+
+def test_compress_action_runs_preserves_rest_behavior(tmp_path: Path) -> None:
+    """Layer E.1's suppress-above-threshold for rest stays exactly as
+    it was — the generalisation must not regress existing behavior.
+    A run of 80 rests still emits no summary line and no bare rest."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(
+            actor="Aki",
+            action="craft",
+            target=None,
+            payload={"thought": "before", "artifact": "a cedar bowl"},
+        )
+        for _ in range(80):
+            ep.append(
+                actor="Aki",
+                action="rest",
+                target=None,
+                payload={"thought": "the mandate for rest is absolute"},
+            )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    rest_summaries = [line for line in out.recent_episodic if "rested" in line]
+    assert rest_summaries == [], (
+        f"80-rest run must be suppressed entirely (Layer E.1), got {rest_summaries!r}"
+    )
+    bare_rest = [line for line in out.recent_episodic if line.startswith("Aki rest")]
+    assert bare_rest == [], (
+        f"no bare 'Aki rest' lines either — full suppression, got {bare_rest!r}"
+    )
+    joined = "\n".join(out.recent_episodic)
+    assert "mandate for rest" not in joined, "trap thought must not survive"
+
+
+def test_isolated_rest_renders_without_thought(tmp_path: Path) -> None:
+    """A single isolated rest still appears in the slice (it's real
+    recent context), but the thought is dropped — consistent with the
+    no-thought-feedback contract."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        ep.append(
+            actor="Aki",
+            action="craft",
+            target=None,
+            payload={"thought": "shaped a bowl", "artifact": "a small bowl"},
+        )
+        ep.append(
+            actor="Aki",
+            action="rest",
+            target=None,
+            payload={"thought": "a brief pause"},
+        )
+        ep.append(
+            actor="Aki",
+            action="craft",
+            target=None,
+            payload={"thought": "shaped another", "artifact": "a wide bowl"},
+        )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    assert "a brief pause" not in "\n".join(out.recent_episodic)
+    bare_rest = [line for line in out.recent_episodic if line == "Aki rest"]
+    assert len(bare_rest) == 1, (
+        f"isolated rest must render as bare 'Aki rest', got {out.recent_episodic!r}"
+    )
+
+
+def test_build_context_recent_episodic_has_zero_thought_substrings(tmp_path: Path) -> None:
+    """Sanity check across a realistic mixed history: none of the
+    distinctive thought tokens must survive into recent_episodic."""
+    distinctive_thoughts = [
+        "every fiber demands silence",
+        "the wood's song at its zenith",
+        "speech is a distraction",
+        "I will greet them warmly",
+        "the mandate for rest",
+    ]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for i, t in enumerate(distinctive_thoughts):
+            ep.append(
+                actor="Aki",
+                action="craft",
+                target=None,
+                payload={"thought": t, "artifact": f"artifact-{i}"},
+            )
+        out = build_context(world_base=WorldContext(), episodic=ep, semantic=se, topic="")
+
+    joined = "\n".join(out.recent_episodic)
+    for t in distinctive_thoughts:
+        assert t not in joined, f"thought {t!r} leaked into recent_episodic: {joined!r}"
+
+
+def test_episodic_budget_still_capped(tmp_path: Path) -> None:
+    """R1 changes the line shape but must not regress the token cap."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep, SemanticMemory(tmp_path / "se.sqlite") as se:
+        for i in range(200):
+            ep.append(
+                actor="Aki",
+                action="craft",
+                target=None,
+                payload={"thought": "x" * 100, "artifact": f"artifact number {i} " * 20},
+            )
+        out = build_context(
+            world_base=WorldContext(),
+            episodic=ep,
+            semantic=se,
+            topic="",
+            episodic_tok=1500,
+        )
+
+    assert est_tokens("\n".join(out.recent_episodic)) <= 1500

--- a/tests/test_run_default_roster.py
+++ b/tests/test_run_default_roster.py
@@ -1,0 +1,50 @@
+"""Slice 4 (R2.c): default roster has two residents (Artisan + Scholar).
+
+The project's stated mission is a "small fictional society" producing
+harvested artifacts (README.md, PROMPT.md). For the entire history
+of the run only Aki the Artisan was ever registered; ``peers_today``
+was structurally always empty (until R2.a) and the Watchdog's
+echo-chamber rescue almost never spawned a Stranger. The default
+roster now includes a structurally-different Scholar so the engagement
+gate (R2.b) actually has someone to engage. ``solo`` keeps the
+single-agent regime available for regression soaks.
+"""
+
+from __future__ import annotations
+
+from microverse.agents.artisan import Artisan
+from microverse.agents.scholar import Scholar
+from microverse.ops.metrics import Metrics
+from microverse.run import _build_roster
+
+
+def test_default_roster_has_two_residents() -> None:
+    metrics = Metrics(":memory:")
+    roster = _build_roster(metrics)
+    assert len(roster) == 2, f"default roster must be 2 residents, got {[a.name for a in roster]!r}"
+    roles = sorted(a.role for a in roster)
+    assert roles == ["artisan", "scholar"], f"roles must be {{artisan, scholar}}, got {roles!r}"
+
+
+def test_solo_flag_keeps_single_resident() -> None:
+    metrics = Metrics(":memory:")
+    roster = _build_roster(metrics, solo=True)
+    assert len(roster) == 1
+    assert roster[0].role == "artisan"
+
+
+def test_default_roster_aki_and_scholar_have_distinct_names() -> None:
+    metrics = Metrics(":memory:")
+    roster = _build_roster(metrics)
+    names = [a.name for a in roster]
+    assert len(set(names)) == 2, f"residents must have distinct names, got {names!r}"
+
+
+def test_default_roster_artisan_is_first() -> None:
+    """Order matters for the Trader-isn't-scheduled invariant: Aki is
+    the legacy primary resident; Scholar augments. Putting Aki first
+    keeps prior behavior recognizable."""
+    metrics = Metrics(":memory:")
+    roster = _build_roster(metrics)
+    assert isinstance(roster[0], Artisan)
+    assert isinstance(roster[1], Scholar)

--- a/tests/test_run_peers_population.py
+++ b/tests/test_run_peers_population.py
@@ -2,12 +2,12 @@
 
 `run.py:215` previously constructed an empty `WorldContext()` so
 `peers_today` was structurally always empty — the persona template
-then rendered "You have not spoken with anyone today" every tick,
-reinforcing the solitary-narrator frame that the silent-craftsperson
-attractor lives inside. The helper unifies registered agents (always
-present) with recently-active speak partners from episodic (so a
-mid-run Stranger immigrant who has already addressed Aki shows up
-even if she hasn't spoken back).
+then rendered the no-peers branch every tick, reinforcing the
+solitary-narrator frame that the silent-craftsperson attractor
+lives inside. The helper unifies registered agents (always present)
+with recently-active speak partners from episodic (so a mid-run
+Stranger immigrant who has already addressed Aki shows up even if
+she hasn't spoken back).
 """
 
 from __future__ import annotations

--- a/tests/test_run_peers_population.py
+++ b/tests/test_run_peers_population.py
@@ -1,0 +1,134 @@
+"""Slice 2 (R2.a): _compute_peers helper for run.py.
+
+`run.py:215` previously constructed an empty `WorldContext()` so
+`peers_today` was structurally always empty — the persona template
+then rendered "You have not spoken with anyone today" every tick,
+reinforcing the solitary-narrator frame that the silent-craftsperson
+attractor lives inside. The helper unifies registered agents (always
+present) with recently-active speak partners from episodic (so a
+mid-run Stranger immigrant who has already addressed Aki shows up
+even if she hasn't spoken back).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from microverse.agents.artisan import Artisan
+from microverse.memory.episodic import EpisodicMemory
+from microverse.run import _compute_peers
+from microverse.world.scheduler import WeightedScheduler
+
+
+def test_compute_peers_includes_other_registered_agents(tmp_path: Path) -> None:
+    """When two agents are registered, the helper returns the other
+    agent for self."""
+    sched = WeightedScheduler()
+    aki = Artisan(name="Aki")
+    bo = Artisan(name="Bo")
+    sched.register(aki)
+    sched.register(bo)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        peers = _compute_peers(sched, ep, aki)
+    assert "Bo" in peers
+    assert "Aki" not in peers
+
+
+def test_compute_peers_excludes_self(tmp_path: Path) -> None:
+    """Even if Aki has an episodic event with herself as actor and
+    target, she must not appear in her own peers list."""
+    sched = WeightedScheduler()
+    aki = Artisan(name="Aki")
+    sched.register(aki)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        ep.append(actor="Aki", action="speak", target="Aki", payload={})
+        peers = _compute_peers(sched, ep, aki)
+    assert "Aki" not in peers
+
+
+def test_compute_peers_returns_empty_when_alone(tmp_path: Path) -> None:
+    """A solo registered agent with empty episodic gets an empty peers
+    tuple (the existing solo-mode contract); the helper does not
+    invent peers."""
+    sched = WeightedScheduler()
+    aki = Artisan(name="Aki")
+    sched.register(aki)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        peers = _compute_peers(sched, ep, aki)
+    assert peers == ()
+
+
+def test_compute_peers_includes_recent_speak_partner_from_episodic(tmp_path: Path) -> None:
+    """A traveler (Stranger) speaks to Aki, then leaves. Even though
+    they are no longer registered, the recent speak makes them an
+    eligible peer for engagement-gate purposes."""
+    sched = WeightedScheduler()
+    aki = Artisan(name="Aki")
+    sched.register(aki)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        ep.append(actor="traveler", action="speak", target="Aki", payload={})
+        peers = _compute_peers(sched, ep, aki)
+    assert "traveler" in peers
+
+
+def test_compute_peers_includes_addressee_when_self_spoke(tmp_path: Path) -> None:
+    """If Aki spoke to a target, that target is a recent peer too —
+    even if not registered. Symmetry with the actor-side check."""
+    sched = WeightedScheduler()
+    aki = Artisan(name="Aki")
+    sched.register(aki)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        ep.append(actor="Aki", action="speak", target="visitor-7", payload={})
+        peers = _compute_peers(sched, ep, aki)
+    assert "visitor-7" in peers
+
+
+def test_compute_peers_skips_world_actor(tmp_path: Path) -> None:
+    """Weather and other world events have actor='world' and must NOT
+    appear as a peer to address — speaking to 'world' is a category
+    error in the persona's mental model."""
+    sched = WeightedScheduler()
+    aki = Artisan(name="Aki")
+    sched.register(aki)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        ep.append(actor="world", action="weather.storm", target=None, payload={})
+        peers = _compute_peers(sched, ep, aki)
+    assert "world" not in peers
+
+
+def test_compute_peers_deduplicates_across_sources(tmp_path: Path) -> None:
+    """A registered peer who also appears in recent speak history
+    shows up exactly once."""
+    sched = WeightedScheduler()
+    aki = Artisan(name="Aki")
+    bo = Artisan(name="Bo")
+    sched.register(aki)
+    sched.register(bo)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        ep.append(actor="Aki", action="speak", target="Bo", payload={})
+        ep.append(actor="Bo", action="speak", target="Aki", payload={})
+        peers = _compute_peers(sched, ep, aki)
+    assert peers.count("Bo") == 1
+
+
+def test_compute_peers_lookback_bounds_history(tmp_path: Path) -> None:
+    """Old speak partners outside the lookback window are NOT
+    included. Default lookback covers ~200 recent events."""
+    sched = WeightedScheduler()
+    aki = Artisan(name="Aki")
+    sched.register(aki)
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        # An ancient speak partner.
+        ep.append(actor="ancient-friend", action="speak", target="Aki", payload={})
+        # Then 250 unrelated events (Aki crafts in a vacuum).
+        for i in range(250):
+            ep.append(
+                actor="Aki",
+                action="craft",
+                target=None,
+                payload={"artifact": f"thing-{i}"},
+            )
+        peers = _compute_peers(sched, ep, aki, lookback=200)
+    assert "ancient-friend" not in peers, (
+        f"events older than lookback must be excluded, got peers={peers!r}"
+    )

--- a/tests/test_run_smoke.py
+++ b/tests/test_run_smoke.py
@@ -78,6 +78,7 @@ def test_30_ticks_produces_at_least_one_artifact(tmp_path: Path):
             tempo=0,
             data_dir=data_dir,
             harvest_dir=harvest_dir,
+            solo=True,
         )
 
     assert executed == 30
@@ -109,7 +110,7 @@ def test_run_creates_data_and_harvest_dirs(tmp_path: Path):
         "raw": {},
     }
     with patch("microverse.agents.artisan.chat", return_value=rest_only):
-        run(ticks=3, seed=0, tempo=0, data_dir=data_dir, harvest_dir=harvest_dir)
+        run(ticks=3, seed=0, tempo=0, data_dir=data_dir, harvest_dir=harvest_dir, solo=True)
         # Touch call_count so unused-import lints don't mind us.
         call_count[0] += 0
 
@@ -150,6 +151,7 @@ def test_run_survives_chat_exception(tmp_path: Path):
             tempo=0,
             data_dir=data_dir,
             harvest_dir=harvest_dir,
+            solo=True,
         )
     # We absorbed 5 exceptions then completed 2 ticks.
     assert executed == 2
@@ -219,6 +221,7 @@ def test_run_exits_after_consecutive_deadlock_breaks(tmp_path: Path):
             tempo=0,
             data_dir=data_dir,
             harvest_dir=harvest_dir,
+            solo=True,
         )
 
     # Loop exited without committing anything (every think() raised).
@@ -261,6 +264,7 @@ def test_run_survives_snapshot_disk_io_error(tmp_path: Path):
             tempo=0,
             data_dir=tmp_path / "data",
             harvest_dir=tmp_path / "harvest",
+            solo=True,
         )
 
     assert executed == 3, "loop must complete despite snapshot I/O error"
@@ -296,5 +300,6 @@ def test_run_recovers_from_all_paused_via_consecutive_fail_reset(tmp_path: Path)
             tempo=0,
             data_dir=tmp_path / "data",
             harvest_dir=tmp_path / "harvest",
+            solo=True,
         )
     assert executed == 3

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -168,3 +168,43 @@ def test_stagnation_detected_when_no_recent_artifacts(tmp_path: Path, metrics: M
             stagnation_floor=1,
         ).check()
     assert metrics.get("watchdog_stagnation") >= 1
+
+
+def test_check_excludes_harvest_events_from_agent_scope(tmp_path: Path, metrics: Metrics):
+    """Layer-G Alt-B emits ``actor='harvest', action='rated'`` events
+    in batches (one per ranked candidate during ``Harvester.flush()``).
+    These are exogenous feedback, not agent actions — the watchdog
+    must not flag a flush burst as runaway, stagnation, or
+    echo-chamber, and must not spawn a Stranger from it.
+    """
+    sched = WeightedScheduler()
+    sched.register(_StubAgent("aki"))
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        # Six harvest 'rated' events back-to-back: a Trader-flush burst.
+        for i in range(6):
+            ep.append(
+                actor="harvest",
+                action="rated",
+                target=None,
+                payload={
+                    "actor": "aki",
+                    "kind": "craft",
+                    "score": 0.5 + i / 100,
+                    "accepted": True,
+                },
+            )
+        Watchdog(
+            metrics=metrics,
+            episodic=ep,
+            scheduler=sched,
+            runaway_max_consecutive=4,
+            diversity_floor=0.35,
+        ).check()
+    assert metrics.get("watchdog_runaway", agent="harvest") == 0, (
+        "harvest events must not contribute to runaway detection"
+    )
+    assert metrics.get("watchdog_echo_chamber") == 0, (
+        "harvest 'rated' batches must not trigger echo chamber"
+    )
+    strangers = [a for a in sched.agents if getattr(a, "role", None) == "stranger"]
+    assert strangers == [], "no Stranger spawn from a harvest flush burst"


### PR DESCRIPTION
## Summary

Layer-G structural fix: stops the recurring failure family that six prior layers (PRs #17-22) couldn't break. Each prior layer narrowed one *expression* channel of an introspective attractor (rest streaks, empty crafts, thought-about-silence) while leaving the *generative loop* intact; the LLM rerouted every time. This PR attacks the mechanism, not another expression.

The post-Layer-F 24h soak (`data/soak-24h-5`, seed 38, hour 3) showed Aki with 776 crafts (100% with artifact, F's contract held) but had stopped speaking and resting entirely; recent thoughts were silent-craftsperson variants ("The wood's song remains at its zenith. Speech is impossible..."). Same trap, new channel.

Codex confirmed the diagnosis: the load-bearing edge is `_format_episodic` rendering the agent's own `thought` verbatim into `recent_episodic`, which flows into the next prompt. Plus two structural bugs the project has carried forever: `run.py` constructing `WorldContext()` with no peers (so the persona renders "You have not spoken with anyone today" every tick), and the watchdog's lexical-Jaccard echo-chamber detector being defeated by vocabulary variation.

### Three structural changes

- **R1 — cut `thought` out of `recent_episodic`.** `_format_episodic_event` renders only factual surface (action, target, artifact-excerpt for craft, `[world]` / `[harvest]` tags). `_compress_action_runs` generalises Layer C/D/E.1's rest-run suppression to any same-actor + same-action streak. The LLM still emits a per-tick `thought` so reflection informs the *current* action; the thought is just no longer persisted into the *next* prompt's context. (TRIZ "separation in time".)
- **R2 — multi-agent residency + peer-engagement gate.** `_build_roster` boots two residents by default (Aki + Cy/Scholar — structurally different roles per Codex, to avoid mutual-reverence convergence). `--solo` keeps the legacy single-Artisan regime. `_compute_peers` populates `peers_today` from registered agents + recent speak partners. `_maybe_engagement_target` fires after K=20 of an agent's own actions without a peer-targeted speak, surfacing a hint via the persona prompt and (if disobeyed) coercing Artisan/Scholar's action to `speak` to the required peer.
- **R2 Alt-B — harvest ratings flow back into recent_episodic.** After `Harvester.flush()` ranks each batch, one synthetic `actor='harvest', action='rated'` event per candidate carries the score + accepted flag. The next prompt sees `[harvest] Trader rated Aki's craft 0.82 (accepted)` — the only persistent *exogenous* feedback aligning the LLM with what the harvest actually values.

R3 (semantic-diversity detection in the watchdog) is intentionally deferred — R1+R2 attack the cause; R3 was rescue-after-the-fact.

### Why this isn't another layer

Layers A-F each said "this time we got the root cause" and were wrong because each fix narrowed one expression channel. R1 cuts the *generative* edge. R2 installs the missing *balancing loop* the project's "society" framing was supposed to have but never did. Alt-B grounds optimization in external verdicts.

If the post-R1+R2 24h soak still shows a route-around, the honest response is **not** a Layer H patch. It is to admit gemma4:e4b at this size has an attractor we cannot fully eliminate without a different model or fundamentally different prompt architecture.

### Files

- `src/microverse/memory/__init__.py` — R1 + Alt-B render path
- `src/microverse/run.py` — R2 default roster + peer wiring + engagement gate
- `src/microverse/agents/base.py` — `WorldContext.engagement_hint` / `required_target`
- `src/microverse/agents/artisan.py` — engagement coercion (post-think)
- `src/microverse/agents/scholar.py` (new) — second resident
- `src/microverse/prompts/persona_scholar.j2` (new)
- `src/microverse/prompts/persona_artisan.j2` — engagement-hint block
- `src/microverse/agents/harvester.py` — rating events on flush
- `src/microverse/config.py` — `PEER_ENGAGEMENT_INTERVAL = 20`

### Quality gate

```
uv run ruff check                                           # ✓
uv run ruff format --check                                  # ✓
uv run mypy src/microverse                                  # ✓
uv run pip-audit                                            # ✓ no known vulns
uv run pytest -q -m 'not integration'                       # ✓ 299 passed (was 253 before slices; +46 new)
uv build                                                    # ✓
```

10 commits structured as TDD red→green slices: R1, R2.a (peers), R2.b (engagement), R2.c (Scholar/roster), Alt-B (harvest feedback).

## Test plan

- [ ] CI passes (Quality / Analyze Python / CodeQL / CodeRabbit)
- [ ] 45-min wiring soak with seed 38: artifact-rate, peers_today non-empty, engagement_gate_fired > 0, no thought substrings in sampled recent_episodic, harvest rating events visible
- [ ] If wiring passes: 24h soak with seed 38 — sustained per-hour artifact growth, no late drift, no new failure mode requiring a Layer H