### PR TITLE
chore: release v0.1.1 — Path-3 hardening + documented constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "microverse"
-version = "0.1.0"
+version = "0.1.1"
 description = "Long-running multi-agent simulation that produces artifacts on local Ollama gemma4:e4b"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -414,7 +414,7 @@ wheels = [
 
 [[package]]
 name = "microverse"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` 0.1.0 → 0.1.1 and refreshes `uv.lock`.
- Captures eight PRs of post-v0.1.0 work (Layers A-G #17-23, Path-3 #24, ADR 0002 #30) under a single release tag.

## What this release is

A harness, not a fix. The 24h Path-3 soak (`data/soak-24h-pr24`,
seed 38, 22,614 events, 19,918 manifest lines) showed:

- **Zero structural leaks** across 897 sampled `WorldContext`s
  (thoughts, artifacts, action verbs, lore names — all 0). The
  Path-3 architecture works for its structural goal.
- **Aki at 93-94% craft sustained 24 hours** — model-level
  attractor under the default Artisan persona. Documented in
  ADR 0002 (#30); the Layer pattern stops here.

## Test plan

- [x] `uv run ruff check && uv run ruff format --check`
- [x] `uv run mypy src/microverse`
- [x] `uv run pip-audit` (clean post-#30's urllib3 2.7.0 bump)
- [x] `uv run pytest -q -m 'not integration'` — 329 passed
- [x] `uv build` — produces `microverse-0.1.1.tar.gz` and the wheel
- [ ] After merge: tag `v0.1.1` on the squash-merge commit and push