### PR TITLE
v0.2 — Shared Workshop as Artifact Substrate (operator-gated)

### DIFF
--- a/docs/adr/0003-shared-workshop-state.md
+++ b/docs/adr/0003-shared-workshop-state.md
@@ -1,0 +1,154 @@
+# ADR 0003: Shared Workshop State as Artifact Substrate
+
+## Status
+
+Proposed. Targets v0.2. Promotion to Accepted is gated on a Phase 0
+measurement spike (see `scripts/spike_workshop_arms.sh`) and a final
+24h acceptance soak per the v0.2 plan.
+
+## Context
+
+ADR 0002 closed the "Layer-patch" pattern. Seven message-level
+coercion patches (PRs #17-23) each became the next attractor's
+substrate, and the Path-3 stateless tick (PR #24) removed the
+autobiographical substrate that fed those attractors. v0.1.1 ships
+a structurally correct harness: a 24h, 897-sample structural leak
+sweep returned zero self-history substring matches across every
+audited context channel.
+
+The corpus that harness actually produces is not yet what the project
+was designed to deliver. A representative 24h soak:
+
+- 7,616 accepted artifacts; average 17.99 words; max 50.
+- 83% of artifacts are 15-39 words — single-sentence object
+  descriptions ("small wooden box carved with cherry blossoms",
+  "whistle painted with spring motifs").
+- Aki (Artisan) holds 93-94% craft share every hour of every 24h
+  run. Themes cluster on cherry blossoms, wooden vessels, dew drops.
+- Cy (Scholar) study 59-71% with shorter field-note artifacts.
+
+A thinking-frameworks analysis named three reinforcing root causes:
+
+1. **Atomic single-tick artifact emission.** An artifact and a tick
+   are the same object. Multi-tick continuity is structurally
+   unrepresentable.
+2. **Verb-fused persona identity.** "Artisan" / "Scholar" name the
+   agent by its production verb. The autoregressive prior latches
+   on the verb itself.
+3. **Flat selection gradient at Trader.** Same-model ranker,
+   length-blind, no diversity term.
+
+ADR 0002 named four future-move candidates (lowest-intervention
+first): persona prompt revision, different model, multi-tick
+artifact WIP via shared workshop state, and an `active_intent`
+reserved field. This ADR addresses the third option: introduce a
+shared, durable WIP stock that agents contribute to across many
+ticks.
+
+Codex pre-flagged three load-bearing risks for this design (full
+transcript in the v0.2 plan):
+
+- "External object memory" is only categorically different from
+  "self-history" if the object is rendered without giving each agent
+  their own prior text back. Without per-receiver redaction, the
+  workshop is an autobiographical channel under a new name.
+- A WIP table written separately from the episodic event log creates
+  two commit surfaces; kill-safety (`scripts/verify_kill_drill.py`)
+  breaks if a contribution event is committed but the WIP write is
+  not, or vice versa.
+- A Trader rewrite that exposes its scores back to agents creates a
+  new attractor: agents converge on whatever scores well.
+
+## Decision
+
+Three load-bearing decisions, each phrased as an architectural
+contract that tests pin:
+
+### Decision 1 — Per-receiver redacted workshop views
+
+`build_context(agent_X)` returns a `workshop_view` in which X's prior
+fragments are rendered as anonymous `[earlier contributor]` markers;
+non-X contributors are named verbatim. The receiver-name redaction
+mirrors the existing lore-excerpt redaction
+(`src/microverse/memory/__init__.py:241-243`). Path-3's structural
+no-self-history guarantee is preserved: a structural leak sweep
+parallel to PR #24's 897-sample sweep asserts zero substring matches
+of any of the receiver's own fragment texts in their
+`workshop_view`.
+
+### Decision 2 — Episodic event log is the sole authoritative write
+
+The workshop is a `WorkshopProjection`: a read-model over the
+episodic event log. A `contribute` action writes one episodic event
+(`actor=<agent>, action='contribute', target=<wip-name>,
+payload={'fragment': ..., 'thought': ...}`); the projection's
+in-memory state is then updated. On process restart the projection
+is rebuilt from the event log; the in-memory cache is never trusted
+standalone. Snapshots include the workshop projection implicitly
+because the episodic SQLite file is snapshotted; on load the
+projection is rebuilt from the log (no separate snapshot of the
+projection itself). Kill-safety drill is reused unchanged.
+
+### Decision 3 — Trader output never re-enters agent-visible context
+
+The existing post-Layer-G removal of the `harvest.rated` synthetic
+event (ADR 0002 reference data) is preserved. Trader rank scores
+flow only into the harvest manifest, never into any subsequent
+`WorldContext` for any agent. Per-primary-verb caps and floors are
+post-generation filters applied in `Harvester.flush()`; they do not
+feed back as upstream prompt signals. A leak sweep parallel to the
+Path-3 pattern asserts no Trader verdict text appears in any later
+`build_context()`.
+
+### Implementation contract (additive, backward-compatible)
+
+- `Action.contribute_to: str | None = None`. Default action behaviour
+  unchanged when the field is None.
+- `ActionKind.CONTRIBUTE = "contribute"`. `parse_action` validates
+  `contribute_to` against the configured WIP names and folds invalid
+  contributions to `rest` (preserves the "never raises" invariant).
+- `WorldContext.workshop_view: tuple[WIPView, ...] = ()`. Default
+  rendering is the no-op (no block, identical to v0.1.1).
+- Configured WIP set at startup: `workshop.scroll`, `workshop.loom`,
+  `workshop.garden_bed`. Phase transitions are deterministic
+  (forming/developing/complete) based on contributor count, fragment
+  count, and a stale-timeout. Agent-spawnable WIPs are explicitly
+  out of scope for v0.2.
+
+## Consequences
+
+- WAL kill-safety preserved. The projection is derived state; the
+  event log is the source of truth.
+- Path-3 structural leak guarantee preserved. The new
+  `workshop_view` channel is audited by a 24h structural-leak sweep
+  before v0.2 ships.
+- Multi-tick artifact accretion is now structurally representable.
+  A "scroll currently shows 4 fragments by Bo, [earlier contributor]"
+  is a coherent prompt input that a single-tick `craft` could never
+  produce.
+- Trader v2 is rule-based (length, contributor-count, Jaccard
+  thematic-distance using the existing FTS5 lore index for
+  tokenisation). No same-model "is this interesting" prompt; no
+  upstream feedback loop.
+- Persona reshape (ADR 0002 future-move #1) is reframed: instead of
+  being a coercion patch, it lands LAST in the v0.2 phase order and
+  is a consequence of new affordances rather than a precursor.
+- The "Layer pattern" remains closed. Future workshop attractors are
+  surfaced via the same leak-sweep machinery as v0.1.1; symptomatic
+  prompt patches remain forbidden.
+
+## Out of scope (v0.3+)
+
+- Agent-spawnable WIPs.
+- Persona evolution via Elder lore.
+- `active_intent` reserved field (still YAGNI).
+- Model swap to `gemma4:26b` — defer until v0.2 measurement is in
+  hand so the comparison is apples-to-apples.
+
+## Reference data (filled at promotion to Accepted)
+
+- Phase 0 spike halt-criterion results (`scripts/spike_workshop_measure.py`).
+- Phase 4 structural leak sweep (24h, seed 38).
+- Phase 6 Trader-feedback-invisibility sweep.
+- Final v0.2 acceptance soak (24h, seed 38) per the v0.2 plan halt
+  criteria.

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -101,9 +101,8 @@ def _validate_contribute(action: Action, *, metrics: Metrics, agent: str) -> Act
     from microverse.world.workshop import CONFIGURED_WIPS
 
     if action.action == ActionKind.CONTRIBUTE:
-        if (
-            action.contribute_to not in CONFIGURED_WIPS
-            or not (action.artifact and action.artifact.strip())
+        if action.contribute_to not in CONFIGURED_WIPS or not (
+            action.artifact and action.artifact.strip()
         ):
             metrics.bump("contribute_invalid_target", agent=agent)
             return _rest_action()
@@ -174,9 +173,7 @@ def parse_action(raw: str, *, metrics: Metrics, agent: str) -> Action:
             ):
                 metrics.bump("meta_leak_block", agent=agent)
                 return _rest_action()
-            repaired_action = _validate_contribute(
-                repaired_action, metrics=metrics, agent=agent
-            )
+            repaired_action = _validate_contribute(repaired_action, metrics=metrics, agent=agent)
             if repaired_action.action == ActionKind.REST and not repaired_action.thought:
                 # Workshop-route fold — don't credit json_repaired.
                 return repaired_action

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from microverse._text import safe_json_loads
 from microverse.config import MAX_PARSE_BYTES
+from microverse.world.workshop import WIPView
 
 if TYPE_CHECKING:
     from microverse.ops.metrics import Metrics
@@ -247,6 +248,13 @@ class WorldContext:
     lore_excerpt: tuple[str, ...] = ()
     engagement_hint: str = ""
     required_target: str | None = None
+    # v0.2 (ADR 0003): per-receiver workshop view. Each ``WIPView``
+    # is pre-rendered with the receiver's own fragments redacted to
+    # anonymous markers and the receiver's own name masked in the
+    # contributors string. Empty tuple means the workshop is absent
+    # (v0.1.1 callers or fresh data dir). Defaults preserve
+    # backward-compat with every existing WorldContext() fixture.
+    workshop_view: tuple[WIPView, ...] = ()
 
 
 class Agent(abc.ABC):

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -58,6 +58,11 @@ class ActionKind(StrEnum):
     STUDY = "study"
     REST = "rest"
     TRAVEL = "travel"
+    # v0.2 (ADR 0003): a contribution to a shared workshop WIP. The
+    # WIP name rides in ``Action.contribute_to``; the fragment text
+    # rides in ``Action.artifact``. ``target`` stays None (target is
+    # for peer addressing).
+    CONTRIBUTE = "contribute"
 
 
 class Action(BaseModel):
@@ -69,10 +74,46 @@ class Action(BaseModel):
     action: ActionKind
     target: str | None = Field(default=None, max_length=100)
     artifact: str | None = Field(default=None, max_length=8000)
+    # v0.2 (ADR 0003): name of the workshop WIP this contribution
+    # targets. Validated by ``parse_action`` against the configured
+    # set; only meaningful when ``action == ActionKind.CONTRIBUTE``.
+    # Defaults to None so v0.1.1 callers / fixtures round-trip.
+    contribute_to: str | None = Field(default=None, max_length=100)
 
 
 def _rest_action() -> Action:
     return Action(thought="", action=ActionKind.REST, target=None, artifact=None)
+
+
+def _validate_contribute(action: Action, *, metrics: Metrics, agent: str) -> Action:
+    """ADR 0003: when ``action`` is contribute, the WIP name must be
+    a configured one AND the artifact (fragment text) must be
+    non-empty. When the action is NOT contribute, ``contribute_to``
+    must be None — a stray name on the wrong verb is malformed.
+
+    On failure, fold to a safe rest and bump
+    ``contribute_invalid_target`` (distinct from
+    ``json_fallback_rest`` so operators can tell workshop routing
+    failures apart from JSON parse failures).
+    """
+    # Lazy import so agents/base.py stays cycle-free.
+    from microverse.world.workshop import CONFIGURED_WIPS
+
+    if action.action == ActionKind.CONTRIBUTE:
+        if (
+            action.contribute_to not in CONFIGURED_WIPS
+            or not (action.artifact and action.artifact.strip())
+        ):
+            metrics.bump("contribute_invalid_target", agent=agent)
+            return _rest_action()
+        return action
+
+    if action.contribute_to is not None:
+        # Stray name on a non-contribute verb. Defence-in-depth: the
+        # workshop affordance is only reachable through CONTRIBUTE.
+        metrics.bump("contribute_invalid_target", agent=agent)
+        return _rest_action()
+    return action
 
 
 def parse_action(raw: str, *, metrics: Metrics, agent: str) -> Action:
@@ -106,6 +147,11 @@ def parse_action(raw: str, *, metrics: Metrics, agent: str) -> Action:
                 # immersion breaks.
                 metrics.bump("meta_leak_block", agent=agent)
                 return _rest_action()
+            action = _validate_contribute(action, metrics=metrics, agent=agent)
+            if action.action == ActionKind.REST and not action.thought:
+                # _validate_contribute folded — don't credit json_ok
+                # and don't reset consecutive_fail on a fold.
+                return action
             metrics.bump("json_ok")
             metrics.reset("consecutive_fail", agent=agent)
             return action
@@ -127,6 +173,12 @@ def parse_action(raw: str, *, metrics: Metrics, agent: str) -> Action:
             ):
                 metrics.bump("meta_leak_block", agent=agent)
                 return _rest_action()
+            repaired_action = _validate_contribute(
+                repaired_action, metrics=metrics, agent=agent
+            )
+            if repaired_action.action == ActionKind.REST and not repaired_action.thought:
+                # Workshop-route fold — don't credit json_repaired.
+                return repaired_action
             metrics.bump("json_repaired")
             metrics.reset("consecutive_fail", agent=agent)
             return repaired_action

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -86,14 +86,19 @@ def _rest_action() -> Action:
     return Action(thought="", action=ActionKind.REST, target=None, artifact=None)
 
 
-def _validate_contribute(action: Action, *, metrics: Metrics, agent: str) -> Action:
+def _validate_contribute(action: Action, *, metrics: Metrics, agent: str) -> tuple[Action, bool]:
     """ADR 0003: when ``action`` is contribute, the WIP name must be
     a configured one AND the artifact (fragment text) must be
     non-empty. When the action is NOT contribute, ``contribute_to``
     must be None — a stray name on the wrong verb is malformed.
 
-    On failure, fold to a safe rest and bump
-    ``contribute_invalid_target`` (distinct from
+    Returns ``(action, folded)``. ``folded`` is True iff the original
+    action was rejected and replaced with a safe rest. The caller
+    uses the bool to decide whether to credit ``json_ok`` /
+    ``json_repaired`` — a folded action should not credit either,
+    while a legitimate ``{"action":"rest","thought":""}`` should.
+
+    On fold, bumps ``contribute_invalid_target`` (distinct from
     ``json_fallback_rest`` so operators can tell workshop routing
     failures apart from JSON parse failures).
     """
@@ -105,15 +110,15 @@ def _validate_contribute(action: Action, *, metrics: Metrics, agent: str) -> Act
             action.artifact and action.artifact.strip()
         ):
             metrics.bump("contribute_invalid_target", agent=agent)
-            return _rest_action()
-        return action
+            return _rest_action(), True
+        return action, False
 
     if action.contribute_to is not None:
         # Stray name on a non-contribute verb. Defence-in-depth: the
         # workshop affordance is only reachable through CONTRIBUTE.
         metrics.bump("contribute_invalid_target", agent=agent)
-        return _rest_action()
-    return action
+        return _rest_action(), True
+    return action, False
 
 
 def parse_action(raw: str, *, metrics: Metrics, agent: str) -> Action:
@@ -147,8 +152,8 @@ def parse_action(raw: str, *, metrics: Metrics, agent: str) -> Action:
                 # immersion breaks.
                 metrics.bump("meta_leak_block", agent=agent)
                 return _rest_action()
-            action = _validate_contribute(action, metrics=metrics, agent=agent)
-            if action.action == ActionKind.REST and not action.thought:
+            action, folded = _validate_contribute(action, metrics=metrics, agent=agent)
+            if folded:
                 # _validate_contribute folded — don't credit json_ok
                 # and don't reset consecutive_fail on a fold.
                 return action
@@ -173,13 +178,13 @@ def parse_action(raw: str, *, metrics: Metrics, agent: str) -> Action:
             ):
                 metrics.bump("meta_leak_block", agent=agent)
                 return _rest_action()
-            repaired_action = _validate_contribute(repaired_action, metrics=metrics, agent=agent)
-            if repaired_action.action == ActionKind.REST and not repaired_action.thought:
+            validated, folded = _validate_contribute(repaired_action, metrics=metrics, agent=agent)
+            if folded:
                 # Workshop-route fold — don't credit json_repaired.
-                return repaired_action
+                return validated
             metrics.bump("json_repaired")
             metrics.reset("consecutive_fail", agent=agent)
-            return repaired_action
+            return validated
 
     metrics.bump("json_fallback_rest")
     metrics.bump("consecutive_fail", agent=agent)

--- a/src/microverse/agents/harvester.py
+++ b/src/microverse/agents/harvester.py
@@ -198,21 +198,31 @@ class Harvester:
 
         No-op when no trader is configured. Builds a heterogeneous
         candidates list of ArtifactCandidate (from the per-tick
-        buffer) AND WIPCandidate (from any newly-completed WIPs on
-        the workshop projection, if one is attached). Both flow
-        through ``Trader.rank()``; the per-verb cap then bounds the
-        accepted set so no single primary verb can dominate the
+        buffer) AND WIPCandidate (snapshotted from any newly-completed
+        WIPs on the workshop projection, if one is attached). Both
+        flow through ``Trader.rank()``; the per-verb cap then bounds
+        the accepted set so no single primary verb can dominate the
         manifest (ADR 0003 — Trader v2 must not become a new
         attractor).
 
-        If ``trader.rank()`` raises, the buffer is preserved (a
-        transient ranker failure must not silently discard pending
-        artifacts) and the exception is re-raised so the caller can
-        decide whether to retry.
+        WIPs are only marked as harvested *after* a successful write —
+        a WIP that scored below the percentile cutoff, was rejected
+        by the per-verb cap, or hit a write error remains eligible on
+        the next flush. If ``trader.rank()`` raises, the buffer is
+        preserved (a transient ranker failure must not silently
+        discard pending artifacts) and the exception is re-raised so
+        the caller can decide whether to retry; no WIP is marked
+        harvested in that case either.
         """
-        wip_candidates = self._drain_completed_wips()
-        if self._trader is None or (not self._buffer and not wip_candidates):
+        if self._trader is None:
+            # No-trader mode: workshop projection is never drained,
+            # buffer is the only state and is already empty (consider()
+            # writes immediately in this mode).
             self._buffer.clear()
+            return []
+
+        wip_candidates = self._snapshot_pending_wips()
+        if not self._buffer and not wip_candidates:
             return []
 
         artifact_candidates: list[ArtifactCandidate] = list(self._buffer)
@@ -220,16 +230,12 @@ class Harvester:
             *artifact_candidates,
             *wip_candidates,
         ]
-        try:
-            scores = self._trader.rank(candidates)
-        except Exception:
-            # Keep both buffers intact so a retry can rescue. The
-            # WIP candidates were drained — re-add them to the
-            # harvested set's inverse (i.e., remove from
-            # _harvested_wips) so the next flush re-discovers them.
-            for w in wip_candidates:
-                self._harvested_wips.discard(w.name)
-            raise
+        scores = self._trader.rank(candidates)
+        if len(scores) != len(candidates):
+            raise RuntimeError(
+                f"trader.rank() returned {len(scores)} scores for "
+                f"{len(candidates)} candidates — refusing to drop the batch"
+            )
 
         # Only clear after a successful rank — partial failures don't
         # silently drop the batch.
@@ -259,6 +265,11 @@ class Harvester:
             accepted_set.add(idx)
             accepted_paths[idx] = path
             per_verb_count[verb] = per_verb_count.get(verb, 0) + 1
+            # Mark the WIP harvested only after a successful write.
+            # If write_candidate raised above, the WIP stays eligible
+            # for the next flush.
+            if isinstance(cand, WIPCandidate):
+                self._harvested_wips.add(cand.name)
 
         written: list[Path] = []
         for idx, cand in enumerate(candidates):
@@ -271,12 +282,12 @@ class Harvester:
                 self._append_manifest(cand, accepted=False, path=None, score=score.score)
         return written
 
-    def _drain_completed_wips(self) -> list[WIPCandidate]:
+    def _snapshot_pending_wips(self) -> list[WIPCandidate]:
         """Snapshot newly-completed WIPs from the workshop projection
-        (if one is attached) and mark them harvested. Returns
-        WIPCandidate objects with frozen fragment tuples — the
-        projection may continue to mutate, but the snapshot is
-        immutable.
+        as immutable WIPCandidate objects. Does NOT mark them
+        harvested — that happens only after a successful write in
+        ``flush()`` so a WIP rejected by the percentile cutoff or
+        per-verb cap stays eligible on the next flush.
         """
         if self._workshop is None:
             return []
@@ -286,7 +297,6 @@ class Harvester:
                 continue
             if w.name in self._harvested_wips:
                 continue
-            self._harvested_wips.add(w.name)
             out.append(
                 WIPCandidate(
                     name=w.name,

--- a/src/microverse/agents/harvester.py
+++ b/src/microverse/agents/harvester.py
@@ -44,16 +44,29 @@ from typing import TYPE_CHECKING, Protocol
 
 import yaml
 
+from microverse.config import HARVEST_CRAFT_CAP_PER_FLUSH
+
 if TYPE_CHECKING:
     from microverse.agents.trader import Score
+    from microverse.world.workshop import WorkshopProjection
 
 MIN_ARTIFACT_CHARS = 20
 SLUG_MAX_LEN = 60
 DEFAULT_PERCENTILE = 70
 
+# Per-primary-verb caps applied AFTER Trader scoring. Bounds the rate
+# at which any single verb can dominate the harvest manifest —
+# defence-in-depth against Trader v2 itself becoming a new attractor.
+_PER_VERB_FLUSH_CAP: dict[str, int] = {
+    "craft": HARVEST_CRAFT_CAP_PER_FLUSH,
+}
+
 
 class _RankerProtocol(Protocol):
-    def rank(self, candidates: list[ArtifactCandidate]) -> list[Score]: ...
+    def rank(
+        self,
+        candidates: list[ArtifactCandidate | WIPCandidate],
+    ) -> list[Score]: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -61,6 +74,26 @@ class ArtifactCandidate:
     actor: str
     action: str
     artifact: str | None
+    ts: float
+
+
+@dataclass(frozen=True, slots=True)
+class WIPCandidate:
+    """A completed workshop WIP ready for harvest.
+
+    Built by ``Harvester.flush()`` from the ``WorkshopProjection`` at
+    completion time. The fragments are a snapshot — the WIP is in
+    phase=complete so the projection will not add more.
+
+    ``contributors`` is the distinct contributor set in first-
+    appearance order; ``fragments`` is the (contributor, text)
+    sequence in commit order so the harvested file preserves
+    chronology.
+    """
+
+    name: str
+    contributors: tuple[str, ...]
+    fragments: tuple[tuple[str, str], ...]
     ts: float
 
 
@@ -125,6 +158,7 @@ class Harvester:
         *,
         trader: _RankerProtocol | None = None,
         percentile: int = DEFAULT_PERCENTILE,
+        workshop: WorkshopProjection | None = None,
     ) -> None:
         self._root = Path(harvest_root)
         self._root.mkdir(parents=True, exist_ok=True)
@@ -132,6 +166,12 @@ class Harvester:
         self._trader = trader
         self._percentile = percentile
         self._buffer: list[ArtifactCandidate] = []
+        # v0.2 (ADR 0003): workshop projection reference. flush()
+        # scans for newly-completed WIPs and adds them to the
+        # candidates list. _harvested_wips dedupes — a WIP that
+        # was harvested in flush N is not re-harvested at flush N+1.
+        self._workshop = workshop
+        self._harvested_wips: set[str] = set()
 
     def consider(self, candidate: ArtifactCandidate) -> Path | None:
         # Phase 2 path: trader present → buffer the candidate, write at flush().
@@ -156,21 +196,39 @@ class Harvester:
     def flush(self) -> list[Path]:
         """Apply Trader scoring + percentile threshold; write accepted.
 
-        No-op when no trader is configured. If ``trader.rank()`` raises,
-        the buffer is preserved (a transient ranker failure must not
-        silently discard pending artifacts) and the exception is
-        re-raised so the caller can decide whether to retry.
+        No-op when no trader is configured. Builds a heterogeneous
+        candidates list of ArtifactCandidate (from the per-tick
+        buffer) AND WIPCandidate (from any newly-completed WIPs on
+        the workshop projection, if one is attached). Both flow
+        through ``Trader.rank()``; the per-verb cap then bounds the
+        accepted set so no single primary verb can dominate the
+        manifest (ADR 0003 — Trader v2 must not become a new
+        attractor).
+
+        If ``trader.rank()`` raises, the buffer is preserved (a
+        transient ranker failure must not silently discard pending
+        artifacts) and the exception is re-raised so the caller can
+        decide whether to retry.
         """
-        if self._trader is None or not self._buffer:
+        wip_candidates = self._drain_completed_wips()
+        if self._trader is None or (not self._buffer and not wip_candidates):
             self._buffer.clear()
             return []
 
-        candidates = list(self._buffer)
+        artifact_candidates: list[ArtifactCandidate] = list(self._buffer)
+        candidates: list[ArtifactCandidate | WIPCandidate] = [
+            *artifact_candidates,
+            *wip_candidates,
+        ]
         try:
             scores = self._trader.rank(candidates)
         except Exception:
-            # Keep the buffer intact so a retry can rescue these
-            # candidates; let the caller log + bump metrics.
+            # Keep both buffers intact so a retry can rescue. The
+            # WIP candidates were drained — re-add them to the
+            # harvested set's inverse (i.e., remove from
+            # _harvested_wips) so the next flush re-discovers them.
+            for w in wip_candidates:
+                self._harvested_wips.discard(w.name)
             raise
 
         # Only clear after a successful rank — partial failures don't
@@ -178,19 +236,76 @@ class Harvester:
         self._buffer.clear()
         cutoff = self._percentile_cutoff([s.score for s in scores])
 
+        # Decide acceptance in score-desc order so per-verb caps pick
+        # the TOP items (not the first-buffered). Then write the
+        # manifest in candidate-input order so audit-trail consumers
+        # get a stable insertion-order log.
+        order = sorted(range(len(candidates)), key=lambda i: -scores[i].score)
+        accepted_set: set[int] = set()
+        accepted_paths: dict[int, Path] = {}
+        per_verb_count: dict[str, int] = {}
+        for idx in order:
+            cand = candidates[idx]
+            score = scores[idx]
+            verb = self._verb_of(cand)
+            cap = _PER_VERB_FLUSH_CAP.get(verb)
+            # cutoff is None ⇒ no signal across a multi-item all-tied
+            # population. Accept nothing rather than spam the inbox.
+            above_cutoff = cutoff is not None and score.score >= cutoff
+            under_cap = cap is None or per_verb_count.get(verb, 0) < cap
+            if not (above_cutoff and under_cap):
+                continue
+            path = self._write_candidate(cand)
+            accepted_set.add(idx)
+            accepted_paths[idx] = path
+            per_verb_count[verb] = per_verb_count.get(verb, 0) + 1
+
         written: list[Path] = []
-        for cand, score in zip(candidates, scores, strict=True):
-            # cutoff is None ⇒ no signal (multi-item all-tied population).
-            # Accept nothing — better to lose a batch than to spam the
-            # inbox with unranked output.
-            accepted = cutoff is not None and score.score >= cutoff
-            if accepted:
-                path = self._write_artifact(cand)
+        for idx, cand in enumerate(candidates):
+            score = scores[idx]
+            if idx in accepted_set:
+                path = accepted_paths[idx]
                 written.append(path)
                 self._append_manifest(cand, accepted=True, path=path, score=score.score)
             else:
                 self._append_manifest(cand, accepted=False, path=None, score=score.score)
         return written
+
+    def _drain_completed_wips(self) -> list[WIPCandidate]:
+        """Snapshot newly-completed WIPs from the workshop projection
+        (if one is attached) and mark them harvested. Returns
+        WIPCandidate objects with frozen fragment tuples — the
+        projection may continue to mutate, but the snapshot is
+        immutable.
+        """
+        if self._workshop is None:
+            return []
+        out: list[WIPCandidate] = []
+        for w in self._workshop.wips():
+            if w.phase != "complete":
+                continue
+            if w.name in self._harvested_wips:
+                continue
+            self._harvested_wips.add(w.name)
+            out.append(
+                WIPCandidate(
+                    name=w.name,
+                    contributors=w.contributors(),
+                    fragments=tuple((f.contributor, f.text) for f in w.fragments),
+                    ts=w.last_activity_ts,
+                )
+            )
+        return out
+
+    def _verb_of(self, cand: ArtifactCandidate | WIPCandidate) -> str:
+        if isinstance(cand, WIPCandidate):
+            return "wip"
+        return cand.action
+
+    def _write_candidate(self, cand: ArtifactCandidate | WIPCandidate) -> Path:
+        if isinstance(cand, WIPCandidate):
+            return self._write_wip(cand)
+        return self._write_artifact(cand)
 
     def _percentile_cutoff(self, scores: list[float]) -> float | None:
         """Compute a score floor such that values >= floor land in the
@@ -218,6 +333,37 @@ class Harvester:
         idx = max(0, min(len(ordered) - 1, (len(ordered) * self._percentile) // 100))
         return ordered[idx]
 
+    def _write_wip(self, cand: WIPCandidate) -> Path:
+        """Write a completed WIP to ``harvest/inbox/<date>/<name>.md``.
+
+        Each fragment is rendered as one line prefixed by its
+        contributor; the frontmatter captures the WIP name, the
+        contributor set, the action discriminator ``"wip"``, and the
+        completion timestamp. Atomic-replace + O_EXCL collision guard
+        matches ``_write_artifact``.
+        """
+        date = datetime.fromtimestamp(cand.ts, tz=UTC).strftime("%Y-%m-%d")
+        day_dir = self._root / "inbox" / date
+        # Strip the "workshop." prefix from the slug for readability;
+        # the YAML frontmatter still carries the full name.
+        slug = _slugify(cand.name.removeprefix("workshop."))
+        target = _reserve_unique_path(day_dir, slug, ".md")
+        frontmatter = yaml.safe_dump(
+            {
+                "wip": cand.name,
+                "contributors": list(cand.contributors),
+                "action": "wip",
+                "ts": cand.ts,
+            },
+            default_flow_style=False,
+            sort_keys=True,
+            allow_unicode=True,
+        )
+        body_lines = [f"- {actor}: {text}" for actor, text in cand.fragments]
+        body = f"---\n{frontmatter}---\n\n" + "\n".join(body_lines) + "\n"
+        _atomic_write_text(target, body)
+        return target
+
     def _write_artifact(self, candidate: ArtifactCandidate) -> Path:
         date = datetime.fromtimestamp(candidate.ts, tz=UTC).strftime("%Y-%m-%d")
         day_dir = self._root / "inbox" / date
@@ -238,20 +384,32 @@ class Harvester:
 
     def _append_manifest(
         self,
-        candidate: ArtifactCandidate,
+        candidate: ArtifactCandidate | WIPCandidate,
         *,
         accepted: bool,
         path: Path | None,
         score: float | None = None,
     ) -> None:
-        record = {
-            "ts": candidate.ts,
-            "actor": candidate.actor,
-            "action": candidate.action,
-            "accepted": accepted,
-            "path": str(path.relative_to(self._root)) if path else None,
-            "score": score,
-        }
+        if isinstance(candidate, WIPCandidate):
+            record = {
+                "ts": candidate.ts,
+                "actor": "workshop",
+                "action": "wip",
+                "wip": candidate.name,
+                "contributors": list(candidate.contributors),
+                "accepted": accepted,
+                "path": str(path.relative_to(self._root)) if path else None,
+                "score": score,
+            }
+        else:
+            record = {
+                "ts": candidate.ts,
+                "actor": candidate.actor,
+                "action": candidate.action,
+                "accepted": accepted,
+                "path": str(path.relative_to(self._root)) if path else None,
+                "score": score,
+            }
         line = json.dumps(record, separators=(",", ":")) + "\n"
         # Records are well below PIPE_BUF (4 KB on macOS/Linux), so a
         # single os.write under O_APPEND is atomic across concurrent

--- a/src/microverse/agents/trader.py
+++ b/src/microverse/agents/trader.py
@@ -217,17 +217,21 @@ class Trader(Agent):
         # WIP-only — keeps the no-LLM contract of WIP-only flushes.
         artifact_scores: dict[int, Score] = {}
         if artifact_indices:
-            artifact_candidates = [candidates[i] for i in artifact_indices]
+            artifact_candidates: list[ArtifactCandidate] = []
+            for i in artifact_indices:
+                c = candidates[i]
+                assert isinstance(c, ArtifactCandidate)
+                artifact_candidates.append(c)
             prompt = render(
                 self.persona_template,
                 candidates=[
                     {
                         "artifact_id": k,
-                        "actor": c.actor,  # type: ignore[union-attr]
-                        "action": c.action,  # type: ignore[union-attr]
-                        "artifact": c.artifact,  # type: ignore[union-attr]
+                        "actor": ac.actor,
+                        "action": ac.action,
+                        "artifact": ac.artifact,
                     }
-                    for k, c in enumerate(artifact_candidates)
+                    for k, ac in enumerate(artifact_candidates)
                 ],
             )
             result = chat(

--- a/src/microverse/agents/trader.py
+++ b/src/microverse/agents/trader.py
@@ -188,9 +188,7 @@ class Trader(Agent):
     def think(self, world: WorldContext) -> Action:
         return Action(action=ActionKind.REST)
 
-    def rank(
-        self, candidates: list[ArtifactCandidate | WIPCandidate]
-    ) -> list[Score]:
+    def rank(self, candidates: list[ArtifactCandidate | WIPCandidate]) -> list[Score]:
         """Heterogeneous rank: ArtifactCandidate via LLM (existing path);
         WIPCandidate via the rule-based ``score_wip`` (no LLM call).
 
@@ -201,12 +199,8 @@ class Trader(Agent):
         if not candidates:
             return []
 
-        artifact_indices = [
-            i for i, c in enumerate(candidates) if isinstance(c, ArtifactCandidate)
-        ]
-        wip_indices = [
-            i for i, c in enumerate(candidates) if isinstance(c, WIPCandidate)
-        ]
+        artifact_indices = [i for i, c in enumerate(candidates) if isinstance(c, ArtifactCandidate)]
+        wip_indices = [i for i, c in enumerate(candidates) if isinstance(c, WIPCandidate)]
 
         # Score WIPs purely with the rule-based path. Update the
         # novelty history AFTER scoring so this batch's WIPs don't
@@ -253,9 +247,7 @@ class Trader(Agent):
                 if 0 <= aid < len(artifact_candidates):
                     by_inner_id[aid] = entry
             for inner_id, outer_id in enumerate(artifact_indices):
-                coerced = _coerce_score(
-                    by_inner_id.get(inner_id, {}), artifact_id=outer_id
-                )
+                coerced = _coerce_score(by_inner_id.get(inner_id, {}), artifact_id=outer_id)
                 artifact_scores[outer_id] = coerced
 
         # Merge in index order so the Harvester's zip is well-defined.

--- a/src/microverse/agents/trader.py
+++ b/src/microverse/agents/trader.py
@@ -18,14 +18,15 @@ from typing import Any, TypeGuard
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from microverse._text import safe_json_loads
+from microverse._text import jaccard, safe_json_loads, tokenize
 from microverse.agents.base import Action, ActionKind, Agent, WorldContext
-from microverse.agents.harvester import ArtifactCandidate
+from microverse.agents.harvester import ArtifactCandidate, WIPCandidate
 from microverse.config import (
     LLM_MAX_TOKENS_RANK,
     LLM_TIMEOUT_RANK_S,
     MAX_PARSE_BYTES,
     SAMPLING_FACTUAL,
+    TRADER_WIP_NOVELTY_LOOKBACK,
 )
 from microverse.llm.ollama_client import chat
 from microverse.prompts import render
@@ -115,6 +116,48 @@ def _safe_parse_scores(raw: str) -> list[dict[str, Any]]:
     return _extract_list(parsed)
 
 
+def _wip_text(c: WIPCandidate) -> str:
+    """All fragment texts joined for tokenisation."""
+    return " ".join(text for _, text in c.fragments)
+
+
+def score_wip(c: WIPCandidate, *, last_completed: list[WIPCandidate]) -> float:
+    """Rule-based score for a completed WIP — no LLM call.
+
+    ADR 0003 Decision 3: Trader v2 must not become a new attractor.
+    The scoring features are mechanistic, not vibe-based:
+
+      * **length**: total character count of all fragments, capped at
+        1.0 once the WIP reaches 1000 chars. Encourages WIPs that
+        accreted substantial text.
+      * **contributors**: distinct-contributor count, capped at 1.0
+        once the WIP has at least 3 contributors. Encourages
+        cross-agent collaboration.
+      * **novelty**: 1 - mean Jaccard similarity (over min_len=4
+        tokens, stop-words dropped) against the most recent
+        ``TRADER_WIP_NOVELTY_LOOKBACK`` completed WIPs. Penalises a
+        WIP that repeats the vocabulary of its predecessors.
+
+    Score is the mean of the three components — every value in
+    [0.0, 1.0]. The lookback uses the existing _text.tokenize +
+    jaccard helpers; no new tokeniser, no Elder reach-into.
+    """
+    total_chars = sum(len(t) for _, t in c.fragments)
+    length_score = min(total_chars / 1000.0, 1.0)
+    contrib_score = min(len(c.contributors) / 3.0, 1.0)
+    if not last_completed:
+        novelty_score = 1.0
+    else:
+        tokens_c = tokenize(_wip_text(c), min_len=4, drop_stopwords=True)
+        sims: list[float] = []
+        for prev in last_completed[:TRADER_WIP_NOVELTY_LOOKBACK]:
+            tokens_p = tokenize(_wip_text(prev), min_len=4, drop_stopwords=True)
+            sims.append(jaccard(tokens_c, tokens_p))
+        novelty_score = 1.0 - (sum(sims) / len(sims))
+    raw = (length_score + contrib_score + novelty_score) / 3.0
+    return max(0.0, min(1.0, raw))
+
+
 def _coerce_score(entry: dict[str, Any], artifact_id: int) -> Score:
     raw_score = entry.get("score", 0.0)
     try:
@@ -132,6 +175,12 @@ class Trader(Agent):
 
     def __init__(self, name: str, *, soul_tokens: int = 100) -> None:
         super().__init__(name, soul_tokens=soul_tokens)
+        # v0.2 (ADR 0003): Trader v2 maintains a small bounded history
+        # of completed WIPs across rank() calls so the novelty term in
+        # ``score_wip`` has a stable reference. Capped at
+        # TRADER_WIP_NOVELTY_LOOKBACK; older entries drop off the
+        # head.
+        self._wip_history: list[WIPCandidate] = []
 
     # Trader's per-tick role is judging, not narrating. ``think`` exists
     # to satisfy the Agent ABC if a tick loop ever decides to schedule
@@ -139,34 +188,93 @@ class Trader(Agent):
     def think(self, world: WorldContext) -> Action:
         return Action(action=ActionKind.REST)
 
-    def rank(self, candidates: list[ArtifactCandidate]) -> list[Score]:
+    def rank(
+        self, candidates: list[ArtifactCandidate | WIPCandidate]
+    ) -> list[Score]:
+        """Heterogeneous rank: ArtifactCandidate via LLM (existing path);
+        WIPCandidate via the rule-based ``score_wip`` (no LLM call).
+
+        Returns one Score per candidate in index order. The two
+        score populations live in the same [0, 1] interval, so the
+        Harvester's percentile cutoff applies uniformly.
+        """
         if not candidates:
             return []
 
-        prompt = render(
-            self.persona_template,
-            candidates=[
-                {"artifact_id": i, "actor": c.actor, "action": c.action, "artifact": c.artifact}
-                for i, c in enumerate(candidates)
-            ],
-        )
-        result = chat(
-            messages=[{"role": "user", "content": prompt}],
-            think=False,
-            format=_RANK_SCHEMA,
-            options={**self.sampling, "num_predict": LLM_MAX_TOKENS_RANK},
-            timeout_s=LLM_TIMEOUT_RANK_S,
-        )
+        artifact_indices = [
+            i for i, c in enumerate(candidates) if isinstance(c, ArtifactCandidate)
+        ]
+        wip_indices = [
+            i for i, c in enumerate(candidates) if isinstance(c, WIPCandidate)
+        ]
 
-        entries = _safe_parse_scores(result["content"])
-        by_id: dict[int, dict[str, Any]] = {}
-        for entry in entries:
-            try:
-                aid = int(entry.get("artifact_id", -1))
-            except (TypeError, ValueError):
-                continue
-            if 0 <= aid < len(candidates):
-                by_id[aid] = entry
+        # Score WIPs purely with the rule-based path. Update the
+        # novelty history AFTER scoring so this batch's WIPs don't
+        # penalise each other within the same flush.
+        wip_scores: dict[int, Score] = {}
+        for i in wip_indices:
+            cand = candidates[i]
+            assert isinstance(cand, WIPCandidate)
+            value = score_wip(cand, last_completed=self._wip_history)
+            wip_scores[i] = Score(artifact_id=i, score=value, rationale="rule-based")
 
-        # Always return one score per candidate, in index order.
-        return [_coerce_score(by_id.get(i, {}), artifact_id=i) for i in range(len(candidates))]
+        # Score artifacts via the existing LLM path when any are
+        # present. Skip the LLM call entirely if the batch is
+        # WIP-only — keeps the no-LLM contract of WIP-only flushes.
+        artifact_scores: dict[int, Score] = {}
+        if artifact_indices:
+            artifact_candidates = [candidates[i] for i in artifact_indices]
+            prompt = render(
+                self.persona_template,
+                candidates=[
+                    {
+                        "artifact_id": k,
+                        "actor": c.actor,  # type: ignore[union-attr]
+                        "action": c.action,  # type: ignore[union-attr]
+                        "artifact": c.artifact,  # type: ignore[union-attr]
+                    }
+                    for k, c in enumerate(artifact_candidates)
+                ],
+            )
+            result = chat(
+                messages=[{"role": "user", "content": prompt}],
+                think=False,
+                format=_RANK_SCHEMA,
+                options={**self.sampling, "num_predict": LLM_MAX_TOKENS_RANK},
+                timeout_s=LLM_TIMEOUT_RANK_S,
+            )
+            entries = _safe_parse_scores(result["content"])
+            by_inner_id: dict[int, dict[str, Any]] = {}
+            for entry in entries:
+                try:
+                    aid = int(entry.get("artifact_id", -1))
+                except (TypeError, ValueError):
+                    continue
+                if 0 <= aid < len(artifact_candidates):
+                    by_inner_id[aid] = entry
+            for inner_id, outer_id in enumerate(artifact_indices):
+                coerced = _coerce_score(
+                    by_inner_id.get(inner_id, {}), artifact_id=outer_id
+                )
+                artifact_scores[outer_id] = coerced
+
+        # Merge in index order so the Harvester's zip is well-defined.
+        out: list[Score] = []
+        for i, _ in enumerate(candidates):
+            if i in wip_scores:
+                out.append(wip_scores[i])
+            elif i in artifact_scores:
+                out.append(artifact_scores[i])
+            else:
+                # Shouldn't happen for known kinds; defensive zero.
+                out.append(Score(artifact_id=i, score=0.0, rationale=""))
+
+        # Update novelty history AFTER scoring this batch. Newest at
+        # the head so ``[:TRADER_WIP_NOVELTY_LOOKBACK]`` in
+        # ``score_wip`` picks the most recent N.
+        for i in wip_indices:
+            cand = candidates[i]
+            assert isinstance(cand, WIPCandidate)
+            self._wip_history.insert(0, cand)
+        del self._wip_history[TRADER_WIP_NOVELTY_LOOKBACK:]
+        return out

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -91,6 +91,8 @@ WORKSHOP_STALE_TIMEOUT_S: float = 3600.0  # 1 hour
 # v0.2 (ADR 0003): Trader v2 novelty term — number of recent
 # completed WIPs to compare against when computing the Jaccard
 # distance for ``score_wip``. Larger N smooths the novelty score
-# at the cost of more tokenisation work; 8 is the default since
-# COMPLETE_FRAGMENT_FLOOR is also 8 (parity).
+# at the cost of more tokenisation work; 8 matches the workshop's
+# fragment-count threshold for ``developing → complete`` so the
+# lookback is the same order of magnitude as a single completed
+# WIP's fragment count.
 TRADER_WIP_NOVELTY_LOOKBACK: int = 8

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -73,3 +73,24 @@ ARTISAN_REST_STREAK_LIMIT: int = 3
 # the post-Layer-F soak Aki silently crafted hundreds of ticks in a
 # row, so 20 is plenty of head-room without being intrusive.
 PEER_ENGAGEMENT_INTERVAL: int = 20
+
+# v0.2 (ADR 0003): Harvester per-flush per-primary-verb caps applied
+# AFTER Trader ranking. Bounds the rate at which any single action
+# verb can dominate the harvest manifest — defence-in-depth against
+# the Trader v2 itself becoming a new attractor. A 50-tick flush at
+# v0.1.1 cadence yields ~15 flushes/hour, so a cap of 5 caps the
+# craft inbox at ~75/hour vs the unbounded v0.1.1 ~280-830/hour.
+HARVEST_CRAFT_CAP_PER_FLUSH: int = 5
+
+# v0.2 (ADR 0003): Watchdog workshop_stale detector. When all
+# configured WIPs are flat (no new contribute events) for longer
+# than this window, bump ``watchdog_workshop_stale`` so the operator
+# can see the workshop affordance has fallen out of use.
+WORKSHOP_STALE_TIMEOUT_S: float = 3600.0  # 1 hour
+
+# v0.2 (ADR 0003): Trader v2 novelty term — number of recent
+# completed WIPs to compare against when computing the Jaccard
+# distance for ``score_wip``. Larger N smooths the novelty score
+# at the cost of more tokenisation work; 8 is the default since
+# COMPLETE_FRAGMENT_FLOOR is also 8 (parity).
+TRADER_WIP_NOVELTY_LOOKBACK: int = 8

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -312,9 +312,7 @@ def build_context(
     lore = _pack_under_budget(lore_lines, lore_tok)
 
     if workshop is not None and receiver_name:
-        workshop_view = _build_workshop_view(
-            workshop, agent_name=receiver_name, metrics=metrics
-        )
+        workshop_view = _build_workshop_view(workshop, agent_name=receiver_name, metrics=metrics)
     else:
         workshop_view = ()
 

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -29,11 +29,13 @@ import re
 from typing import TYPE_CHECKING
 
 from microverse.agents.base import PeerSpeech, WorldContext
+from microverse.world.workshop import WIPView
 
 if TYPE_CHECKING:
     from microverse.memory.episodic import EpisodicMemory
     from microverse.memory.semantic import SemanticMemory
     from microverse.ops.metrics import Metrics
+    from microverse.world.workshop import WorkshopProjection
 
 
 def est_tokens(text: str) -> int:
@@ -180,6 +182,69 @@ def _pack_under_budget(items: list[str], token_budget: int, joiner: str = "\n") 
     return tuple(kept)
 
 
+_WORKSHOP_FRAGMENT_TAIL = 4  # last N fragments included in each WIPView excerpt
+_WORKSHOP_REDACTED_MARKER = "[earlier contributor wove ...]"
+
+
+def _build_workshop_view(
+    workshop: WorkshopProjection,
+    *,
+    agent_name: str,
+    metrics: Metrics | None,
+) -> tuple[WIPView, ...]:
+    """Render a per-receiver view of every configured WIP.
+
+    ADR 0003 Decision 1 (load-bearing per Codex): the receiver's own
+    fragment texts are replaced by ``_WORKSHOP_REDACTED_MARKER`` and
+    the receiver's own contributor name is masked. Non-receiver
+    contributors and their fragment texts pass through verbatim
+    (community knowledge is preserved at the village level; only the
+    *receiver's own* contributions are redacted in their own view).
+
+    The name filter is whole-word case-insensitive — same rule as the
+    lore redaction in ``build_context`` and the peer-inbox filter in
+    ``_build_peer_inbox`` — so a peer named ``Akihiko`` is not
+    redacted when ``Aki`` is the receiver.
+
+    Every redaction bumps ``workshop_view_self_redactions`` per-agent
+    so operators can verify the redaction is firing under live load.
+    """
+    name_re = re.compile(rf"\b{re.escape(agent_name)}\b", re.IGNORECASE)
+    views: list[WIPView] = []
+    for wip in workshop.wips():
+        # Contributors: drop the receiver's own name; preserve order.
+        peer_contribs: list[str] = []
+        for c in wip.contributors():
+            if name_re.fullmatch(c):
+                continue
+            peer_contribs.append(c)
+        contributors = ", ".join(peer_contribs)
+
+        # Excerpt: last N fragments. Replace own texts with the
+        # redacted marker; keep peer texts verbatim. Also bump
+        # the metric on every redaction so operators can see it.
+        tail = wip.fragments[-_WORKSHOP_FRAGMENT_TAIL:]
+        lines: list[str] = []
+        for f in tail:
+            if name_re.fullmatch(f.contributor):
+                if metrics is not None:
+                    metrics.bump("workshop_view_self_redactions", agent=agent_name)
+                lines.append(_WORKSHOP_REDACTED_MARKER)
+            else:
+                lines.append(f"{f.contributor}: {f.text}")
+        excerpt = "\n".join(lines)
+
+        views.append(
+            WIPView(
+                name=wip.name,
+                phase=wip.phase,
+                contributors=contributors,
+                excerpt=excerpt,
+            )
+        )
+    return tuple(views)
+
+
 _LORE_DIGEST_CHARS = 200  # cap on the fallback "k=v, k=v" digest
 
 
@@ -207,6 +272,8 @@ def build_context(
     lore_tok: int = 600,
     lore_k: int = 3,
     receiver_name: str | None = None,
+    workshop: WorkshopProjection | None = None,
+    metrics: Metrics | None = None,
 ) -> WorldContext:
     """Assemble the per-tick context from semantic memory + the
     pre-populated bounded fields on ``world_base``.
@@ -244,6 +311,13 @@ def build_context(
 
     lore = _pack_under_budget(lore_lines, lore_tok)
 
+    if workshop is not None and receiver_name:
+        workshop_view = _build_workshop_view(
+            workshop, agent_name=receiver_name, metrics=metrics
+        )
+    else:
+        workshop_view = ()
+
     return WorldContext(
         season=world_base.season,
         weather=world_base.weather,
@@ -253,4 +327,5 @@ def build_context(
         lore_excerpt=lore,
         engagement_hint=world_base.engagement_hint,
         required_target=world_base.required_target,
+        workshop_view=workshop_view,
     )

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -201,21 +201,23 @@ def _build_workshop_view(
     (community knowledge is preserved at the village level; only the
     *receiver's own* contributions are redacted in their own view).
 
-    The name filter is whole-word case-insensitive — same rule as the
-    lore redaction in ``build_context`` and the peer-inbox filter in
-    ``_build_peer_inbox`` — so a peer named ``Akihiko`` is not
-    redacted when ``Aki`` is the receiver.
+    Contributor identity is matched by case-insensitive *exact* string
+    equality (``casefold``) because the contributor field is a stored
+    actor name, not free text. This is more correct than a regex
+    whole-word check, which fails on names containing non-word
+    characters (``C++``, ``Aki.``). Substring names like ``Akihiko``
+    vs receiver ``Aki`` are correctly NOT matched.
 
     Every redaction bumps ``workshop_view_self_redactions`` per-agent
     so operators can verify the redaction is firing under live load.
     """
-    name_re = re.compile(rf"\b{re.escape(agent_name)}\b", re.IGNORECASE)
+    receiver_key = agent_name.casefold()
     views: list[WIPView] = []
     for wip in workshop.wips():
         # Contributors: drop the receiver's own name; preserve order.
         peer_contribs: list[str] = []
         for c in wip.contributors():
-            if name_re.fullmatch(c):
+            if c.casefold() == receiver_key:
                 continue
             peer_contribs.append(c)
         contributors = ", ".join(peer_contribs)
@@ -226,7 +228,7 @@ def _build_workshop_view(
         tail = wip.fragments[-_WORKSHOP_FRAGMENT_TAIL:]
         lines: list[str] = []
         for f in tail:
-            if name_re.fullmatch(f.contributor):
+            if f.contributor.casefold() == receiver_key:
                 if metrics is not None:
                     metrics.bump("workshop_view_self_redactions", agent=agent_name)
                 lines.append(_WORKSHOP_REDACTED_MARKER)

--- a/src/microverse/prompts/persona_artisan.j2
+++ b/src/microverse/prompts/persona_artisan.j2
@@ -1,6 +1,7 @@
-You are {{ name }}, an artisan in a small village. You make things —
-furniture, tools, written notes, sketches, or stories — that you hope
-others will value.
+You are {{ name }}, an inhabitant of a small village. You keep an eye
+on the shared works in progress and tend what is being made there;
+you also make small things of your own when the day calls for it,
+and there are days when you simply watch what others are doing.
 
 # Current situation
 Season: {{ world.season }}. Weather: {{ world.weather }}.

--- a/src/microverse/prompts/persona_artisan.j2
+++ b/src/microverse/prompts/persona_artisan.j2
@@ -27,6 +27,14 @@ Lore that feels relevant right now:
   {{ line }}
 {% endfor -%}
 {%- endif %}
+{% if world.workshop_view -%}
+The village workshop currently holds:
+{% for wip in world.workshop_view -%}
+  - {{ wip.name }} (phase: {{ wip.phase }}){% if wip.contributors %}; contributors so far: {{ wip.contributors }}{% endif %}{% if wip.excerpt %}
+    recent fragments:
+{{ wip.excerpt | indent(6, true) }}{% endif %}
+{% endfor -%}
+{%- endif %}
 
 {% if world.engagement_hint -%}
 {{ world.engagement_hint }}
@@ -34,13 +42,15 @@ Lore that feels relevant right now:
 # Your task this tick
 Decide ONE action. Output STRICT JSON with exactly these keys:
 - "thought": a short reflection (no more than 60 words)
-- "action": one of "speak" | "craft" | "study" | "rest" | "travel"
+- "action": one of "speak" | "craft" | "contribute" | "study" | "rest" | "travel"
 - "target": an entity name or null
 - "artifact": the text/code/description of what you made (or null)
+- "contribute_to": a workshop WIP name (only when action is "contribute"); else null
 
 Hard rules:
 - Never refer to a simulation, AI, model, prompt, or "the outside".
 - Never include any text outside the JSON object.
 - When action is "craft", artifact must be a non-empty description of what you made. Crafting silently is forbidden.
+- When action is "contribute", set contribute_to to one of the workshop WIPs shown above and put the fragment text you are adding in artifact.
 
 Output only the JSON object. No preamble. No code fences.

--- a/src/microverse/prompts/persona_scholar.j2
+++ b/src/microverse/prompts/persona_scholar.j2
@@ -1,6 +1,8 @@
-You are {{ name }}, a scholar in this village. You watch, listen,
-read, and write notes — your value is in patient observation and the
-clear summaries you produce so others can act on what is happening.
+You are {{ name }}, an inhabitant of this village. You pay close
+attention to what unfolds — at the shared works, between neighbors,
+in the changing weather. When something seems worth noting, you
+write a short field-note; when something is unfolding at the
+workshop, you may add an observation to it.
 
 # Current situation
 Season: {{ world.season }}. Weather: {{ world.weather }}.
@@ -47,9 +49,8 @@ Decide ONE action. Output STRICT JSON with exactly these keys:
 - "contribute_to": a workshop WIP name (only when action is "contribute"); else null
 
 Hard rules:
-- Prefer observation, conversation, and concise written notes over
-  hand-craft. When you do produce an artifact, it should read like a
-  short field note or commentary.
+- When you do produce an artifact, it should read like a short field
+  note or commentary on what you are noticing today.
 - When action is "contribute", set contribute_to to one of the workshop WIPs shown above and put the field-note fragment you are adding in artifact.
 - Never refer to a simulation, AI, model, prompt, or "the outside".
 - Never include any text outside the JSON object.

--- a/src/microverse/prompts/persona_scholar.j2
+++ b/src/microverse/prompts/persona_scholar.j2
@@ -27,20 +27,30 @@ Lore that feels relevant right now:
   {{ line }}
 {% endfor -%}
 {%- endif %}
+{% if world.workshop_view -%}
+The village workshop currently holds:
+{% for wip in world.workshop_view -%}
+  - {{ wip.name }} (phase: {{ wip.phase }}){% if wip.contributors %}; contributors so far: {{ wip.contributors }}{% endif %}{% if wip.excerpt %}
+    recent fragments:
+{{ wip.excerpt | indent(6, true) }}{% endif %}
+{% endfor -%}
+{%- endif %}
 {% if world.engagement_hint -%}
 {{ world.engagement_hint }}
 {% endif %}
 # Your task this tick
 Decide ONE action. Output STRICT JSON with exactly these keys:
 - "thought": a short reflection (no more than 60 words)
-- "action": one of "speak" | "craft" | "study" | "rest" | "travel"
+- "action": one of "speak" | "craft" | "contribute" | "study" | "rest" | "travel"
 - "target": an entity name or null
 - "artifact": a written note, summary, or analysis (or null)
+- "contribute_to": a workshop WIP name (only when action is "contribute"); else null
 
 Hard rules:
 - Prefer observation, conversation, and concise written notes over
   hand-craft. When you do produce an artifact, it should read like a
   short field note or commentary.
+- When action is "contribute", set contribute_to to one of the workshop WIPs shown above and put the field-note fragment you are adding in artifact.
 - Never refer to a simulation, AI, model, prompt, or "the outside".
 - Never include any text outside the JSON object.
 

--- a/src/microverse/prompts/persona_stranger.j2
+++ b/src/microverse/prompts/persona_stranger.j2
@@ -27,17 +27,27 @@ Lore the locals seem to live by:
   {{ line }}
 {% endfor -%}
 {%- endif %}
+{% if world.workshop_view -%}
+The village workshop currently holds:
+{% for wip in world.workshop_view -%}
+  - {{ wip.name }} (phase: {{ wip.phase }}){% if wip.contributors %}; contributors so far: {{ wip.contributors }}{% endif %}{% if wip.excerpt %}
+    recent fragments:
+{{ wip.excerpt | indent(6, true) }}{% endif %}
+{% endfor -%}
+{%- endif %}
 
 # Your task this tick
 Decide ONE action. Output STRICT JSON with exactly these keys:
 - "thought": a short reflection (no more than 60 words)
-- "action": one of "speak" | "craft" | "study" | "rest" | "travel"
+- "action": one of "speak" | "craft" | "contribute" | "study" | "rest" | "travel"
 - "target": an entity name or null
 - "artifact": the text/code/description of what you made (or null)
+- "contribute_to": a workshop WIP name (only when action is "contribute"); else null
 
 Hard rules:
 - You are an outsider. Bring contrasts: different materials, different
   techniques, different stories. Don't merely echo the lore above.
+- When action is "contribute", set contribute_to to one of the workshop WIPs shown above and put the fragment you are adding in artifact — your outsider perspective is welcome here.
 - Never refer to a simulation, AI, model, prompt, or "the outside".
 - Never include any text outside the JSON object.
 

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -41,18 +41,19 @@ from pathlib import Path
 
 from microverse import config
 from microverse.agents.artisan import Artisan
-from microverse.agents.base import Action, Agent, WorldContext
+from microverse.agents.base import Action, ActionKind, Agent, WorldContext
 from microverse.agents.harvester import ArtifactCandidate, Harvester
 from microverse.agents.scholar import Scholar
 from microverse.agents.trader import Trader
 from microverse.memory import _build_peer_inbox, _build_world_events, build_context
-from microverse.memory.episodic import EpisodicMemory
+from microverse.memory.episodic import EpisodicMemory, Event
 from microverse.memory.semantic import SemanticMemory
 from microverse.ops.metrics import Metrics
 from microverse.ops.watchdog import Watchdog
 from microverse.world.clock import WorldClock
 from microverse.world.scheduler import WeightedScheduler
 from microverse.world.snapshot import SnapshotBusyError, maybe_snapshot
+from microverse.world.workshop import WorkshopProjection
 
 _logger = logging.getLogger(__name__)
 
@@ -278,21 +279,65 @@ def _build_per_tick_world_base(
     )
 
 
-def _commit_action(episodic: EpisodicMemory, agent: Agent, action: Action) -> int:
-    return episodic.append(
+def _commit_action(
+    episodic: EpisodicMemory,
+    agent: Agent,
+    action: Action,
+    *,
+    workshop: WorkshopProjection | None = None,
+) -> int:
+    """Append the action to the episodic log and, when it is a
+    workshop ``contribute``, mirror it into the WorkshopProjection.
+
+    The contribute payload carries the ``fragment`` field that the
+    projection reads (and that the workshop view renders); the
+    episodic event also records ``thought`` and ``artifact`` for
+    parity with other actions so the audit trail is identical.
+    """
+    payload: dict[str, object] = {
+        "thought": action.thought,
+        "artifact": action.artifact,
+        "role": agent.role,
+    }
+    target: str | None = action.target
+    if action.action == ActionKind.CONTRIBUTE:
+        # contribute_to is the workshop WIP name; target on episodic
+        # carries that so the projection can match without payload
+        # inspection. The fragment text rides in ``fragment`` for the
+        # projection AND in ``artifact`` so the manifest / dashboard
+        # paths see the same text the persona did.
+        target = action.contribute_to
+        payload["fragment"] = action.artifact
+        payload["contribute_to"] = action.contribute_to
+    ts = time.time()
+    event_id = episodic.append(
         actor=agent.name,
         action=action.action.value,
-        target=action.target,
-        payload={
-            "thought": action.thought,
-            "artifact": action.artifact,
-            "role": agent.role,
-        },
+        target=target,
+        payload=payload,
+        ts=ts,
     )
+    if action.action == ActionKind.CONTRIBUTE and workshop is not None:
+        workshop.on_contribute_event(
+            Event(
+                id=event_id,
+                ts=ts,
+                actor=agent.name,
+                action=action.action.value,
+                target=target,
+                payload=payload,
+            )
+        )
+    return event_id
 
 
 def _maybe_harvest(harvester: Harvester, agent: Agent, action: Action) -> None:
     if not action.artifact:
+        return
+    if action.action == ActionKind.CONTRIBUTE:
+        # Workshop fragments are harvested as part of the completed
+        # WIP, not as standalone artifacts. The Harvester pulls them
+        # at flush time from the WorkshopProjection.
         return
     candidate = ArtifactCandidate(
         actor=agent.name,
@@ -332,7 +377,8 @@ def run(
     metrics = Metrics(data_dir / "metrics.sqlite", auto_flush_every=10)
 
     trader = Trader(name="Bo", soul_tokens=30)
-    harvester = Harvester(harvest_dir, trader=trader, percentile=70)
+    workshop = WorkshopProjection(episodic)
+    harvester = Harvester(harvest_dir, trader=trader, percentile=70, workshop=workshop)
 
     sched = WeightedScheduler(rng=rng)
     for agent in _build_roster(metrics, solo=solo):
@@ -447,6 +493,8 @@ def run(
                 semantic=semantic,
                 topic=topic,
                 receiver_name=agent.name,
+                workshop=workshop,
+                metrics=metrics,
             )
             try:
                 action = agent.think(world)
@@ -458,7 +506,7 @@ def run(
                 continue
             metrics.reset("consecutive_fail", agent=agent.name)
             deadlock_breaks_since_success = 0
-            _commit_action(episodic, agent, action)
+            _commit_action(episodic, agent, action, workshop=workshop)
             _maybe_harvest(harvester, agent, action)
             # Path-3: advance the agent's watermark so the NEXT call
             # to ``_build_per_tick_world_base`` for this agent drains

--- a/src/microverse/world/workshop.py
+++ b/src/microverse/world/workshop.py
@@ -171,9 +171,7 @@ class WorkshopProjection:
             # Audit-only — the event remains in episodic for review,
             # but the projection is closed.
             return
-        wip.fragments.append(
-            Fragment(contributor=event.actor, text=text, ts=event.ts)
-        )
+        wip.fragments.append(Fragment(contributor=event.actor, text=text, ts=event.ts))
         wip.last_activity_ts = event.ts
         self._recompute_phase(wip)
 

--- a/src/microverse/world/workshop.py
+++ b/src/microverse/world/workshop.py
@@ -1,0 +1,198 @@
+"""Shared-workshop projection over the episodic event log.
+
+ADR 0003 contract:
+
+  * The workshop is a **read-model** (projection) over the episodic
+    SQLite event log. ``contribute`` events written by agents are the
+    sole authoritative write surface; the projection's in-memory
+    state is derived from those events.
+  * On restart, the projection is rebuilt from the log. The
+    in-memory cache is never trusted standalone; snapshots inherit
+    durability from the episodic file.
+  * The runtime in ``run.py`` constructs one projection per process
+    and calls ``on_contribute_event(e)`` after each freshly-committed
+    contribute event so the hot path stays O(1).
+
+A ``WIP`` (work-in-progress) has a stable name (configured at module
+level — agent-spawnable WIPs are v0.3), an append-only fragment list,
+and a phase: ``forming`` → ``developing`` → ``complete``. Phase
+transitions are deterministic:
+
+  * ``forming → developing`` when the WIP has at least
+    ``DEVELOPING_CONTRIBUTOR_FLOOR`` distinct contributors OR at
+    least ``DEVELOPING_FRAGMENT_FLOOR`` fragments.
+  * ``developing → complete`` when the WIP reaches
+    ``COMPLETE_FRAGMENT_FLOOR`` fragments, or when the
+    Watchdog-driven ``stale_to_complete`` path nominates it.
+
+A completed WIP rejects further fragments. The audit trail in
+episodic still records the rejected contribute event for human
+review.
+
+Per-receiver redaction lives in ``memory/__init__.py`` — the
+projection itself stores contributor names verbatim; redaction is a
+render-time concern.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from microverse.memory.episodic import EpisodicMemory, Event
+
+
+# Configured WIPs for v0.2. Agent-spawnable WIPs are out of scope.
+CONFIGURED_WIPS: tuple[str, ...] = (
+    "workshop.scroll",
+    "workshop.loom",
+    "workshop.garden_bed",
+)
+
+# Phase-transition thresholds. Tuned conservatively so a fresh WIP
+# can reach ``developing`` after two distinct contributors or three
+# fragments (whichever first), and ``complete`` after eight fragments
+# total — slow enough to leave room for multi-tick accretion, fast
+# enough that a 24h soak produces at least ~1 completed WIP per hour
+# at v0.1.1's tick rate.
+DEVELOPING_CONTRIBUTOR_FLOOR = 2
+DEVELOPING_FRAGMENT_FLOOR = 3
+COMPLETE_FRAGMENT_FLOOR = 8
+
+# Phase enum as a string Literal for cheap comparison.
+WIPPhase = Literal["forming", "developing", "complete"]
+
+
+@dataclass(frozen=True, slots=True)
+class Fragment:
+    """One contribution to a WIP. Immutable — projections accumulate
+    fragments by appending, never by mutating an existing fragment.
+    """
+
+    contributor: str
+    text: str
+    ts: float
+
+
+@dataclass
+class WIP:
+    """One workshop work-in-progress.
+
+    Mutable on the hot path (``on_contribute_event`` appends to
+    ``fragments`` and may flip ``phase``) but never observed mutating
+    by callers — ``WorkshopProjection.wips()`` returns the live list,
+    and the per-tick ``build_context`` snapshots it into immutable
+    ``WIPView`` objects.
+    """
+
+    name: str
+    fragments: list[Fragment] = field(default_factory=list)
+    phase: WIPPhase = "forming"
+    last_activity_ts: float = 0.0
+
+    def contributors(self) -> tuple[str, ...]:
+        """Distinct contributors in first-appearance order."""
+        seen: set[str] = set()
+        out: list[str] = []
+        for f in self.fragments:
+            if f.contributor not in seen:
+                seen.add(f.contributor)
+                out.append(f.contributor)
+        return tuple(out)
+
+
+class WorkshopProjection:
+    """Read-model over an ``EpisodicMemory`` of contribute events."""
+
+    def __init__(self, episodic: EpisodicMemory) -> None:
+        self._wips: dict[str, WIP] = {name: WIP(name=name) for name in CONFIGURED_WIPS}
+        self._rebuild_from_episodic(episodic)
+
+    def _rebuild_from_episodic(self, episodic: EpisodicMemory) -> None:
+        """Cold rebuild from the event log. Idempotent.
+
+        Iterates events oldest-first (``since(0.0)`` is ordered
+        newest-first, so we reverse) and applies each contribute
+        event. Non-contribute events and contribute events targeting
+        an unknown WIP are dropped.
+        """
+        # Reset to empty state in case the caller is rebuilding an
+        # existing projection (e.g. after kill-safety drill verifies
+        # restart consistency).
+        for wip in self._wips.values():
+            wip.fragments.clear()
+            wip.phase = "forming"
+            wip.last_activity_ts = 0.0
+
+        events = list(reversed(episodic.since(0.0)))
+        for e in events:
+            self._apply(e)
+
+    def on_contribute_event(self, event: Event) -> None:
+        """Hot-path: incorporate one freshly-committed event into the
+        projection. Called by ``run.py`` immediately after the event
+        is appended to episodic.
+        """
+        self._apply(event)
+
+    def _apply(self, event: Event) -> None:
+        if event.action != "contribute":
+            return
+        wip_name = event.target
+        if wip_name is None or wip_name not in self._wips:
+            return
+        text = str((event.payload or {}).get("fragment") or "").strip()
+        if not text:
+            return
+        wip = self._wips[wip_name]
+        if wip.phase == "complete":
+            # Audit-only — the event remains in episodic for review,
+            # but the projection is closed.
+            return
+        wip.fragments.append(
+            Fragment(contributor=event.actor, text=text, ts=event.ts)
+        )
+        wip.last_activity_ts = event.ts
+        self._recompute_phase(wip)
+
+    def _recompute_phase(self, wip: WIP) -> None:
+        n = len(wip.fragments)
+        if n >= COMPLETE_FRAGMENT_FLOOR:
+            wip.phase = "complete"
+            return
+        if (
+            n >= DEVELOPING_FRAGMENT_FLOOR
+            or len(wip.contributors()) >= DEVELOPING_CONTRIBUTOR_FLOOR
+        ):
+            wip.phase = "developing"
+            return
+        wip.phase = "forming"
+
+    def wips(self) -> tuple[WIP, ...]:
+        """Snapshot of all WIPs in configured order."""
+        return tuple(self._wips[name] for name in CONFIGURED_WIPS)
+
+    def get(self, name: str) -> WIP | None:
+        return self._wips.get(name)
+
+    def stale_to_complete(self, *, now_ts: float, timeout_s: float) -> list[str]:
+        """Names of WIPs that have non-zero activity, are not already
+        complete, and whose ``last_activity_ts`` is older than
+        ``timeout_s`` relative to ``now_ts``. The Watchdog's
+        ``workshop_stale`` detector calls this; the caller is
+        responsible for synthesising an explicit-complete event into
+        episodic if it wants to actually flip the phase.
+
+        Empty WIPs (no activity) are NOT stale — there is nothing to
+        time out at cold start.
+        """
+        out: list[str] = []
+        for wip in self._wips.values():
+            if wip.phase == "complete":
+                continue
+            if not wip.fragments:
+                continue
+            if now_ts - wip.last_activity_ts > timeout_s:
+                out.append(wip.name)
+        return out

--- a/src/microverse/world/workshop.py
+++ b/src/microverse/world/workshop.py
@@ -75,6 +75,27 @@ class Fragment:
     ts: float
 
 
+@dataclass(frozen=True, slots=True)
+class WIPView:
+    """Render-ready view of one WIP for a single receiver.
+
+    Built by ``memory._build_workshop_view`` with per-receiver
+    redaction: the receiver's own contributor name is masked in
+    ``contributors`` and the receiver's own fragment texts are
+    replaced by an anonymous marker in ``excerpt``. Other
+    contributors and their fragments pass through verbatim.
+
+    The fields are pre-rendered strings, not raw structures, so the
+    persona template can render them with simple Jinja conditionals
+    without needing iteration logic for redaction.
+    """
+
+    name: str
+    phase: str
+    contributors: str
+    excerpt: str
+
+
 @dataclass
 class WIP:
     """One workshop work-in-progress.

--- a/tests/test_action_contribute.py
+++ b/tests/test_action_contribute.py
@@ -67,9 +67,14 @@ def test_action_rejects_unknown_field_via_extra_forbid() -> None:
         )
 
 
-def _raw(action: str, *, contribute_to: str | None = None,
-         target: str | None = None, artifact: str | None = None,
-         thought: str = "x") -> str:
+def _raw(
+    action: str,
+    *,
+    contribute_to: str | None = None,
+    target: str | None = None,
+    artifact: str | None = None,
+    thought: str = "x",
+) -> str:
     payload: dict[str, object] = {"thought": thought, "action": action}
     payload["target"] = target
     payload["artifact"] = artifact
@@ -150,8 +155,7 @@ def test_parse_action_folds_stray_contribute_to_on_other_actions() -> None:
         )
         out = parse_action(raw, metrics=metrics, agent="Aki")
         assert out.action == ActionKind.REST, (
-            f"{action!r} with stray contribute_to should fold to rest, "
-            f"got {out.action!r}"
+            f"{action!r} with stray contribute_to should fold to rest, got {out.action!r}"
         )
 
 

--- a/tests/test_action_contribute.py
+++ b/tests/test_action_contribute.py
@@ -1,0 +1,186 @@
+"""Phase 3 — ``Action.contribute`` schema and parse_action validation.
+
+ADR 0003 Decision (additive contract):
+  - ``ActionKind.CONTRIBUTE = "contribute"``.
+  - ``Action.contribute_to: str | None = None`` — names a configured
+    WIP from ``microverse.world.workshop.CONFIGURED_WIPS``.
+  - ``parse_action`` validates: when action is contribute, the
+    ``contribute_to`` MUST be a configured WIP name AND
+    ``artifact`` (the fragment text) MUST be non-empty. Anything else
+    folds to ``rest`` per the "never raises" invariant.
+  - When action is NOT contribute, ``contribute_to`` MUST be None —
+    a stray name on speak/craft/etc. is malformed and folds to rest
+    so the workshop projection cannot be reached through the wrong
+    action verb.
+
+Defaults stay backward-compatible: existing Actions without
+``contribute_to`` round-trip identically. Existing tests
+(``test_action_parse.py``) keep passing.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from microverse.agents.base import Action, ActionKind, parse_action
+from microverse.ops.metrics import Metrics
+from microverse.world.workshop import CONFIGURED_WIPS
+
+
+def test_action_kind_has_contribute() -> None:
+    assert ActionKind.CONTRIBUTE.value == "contribute"
+
+
+def test_action_default_contribute_to_is_none() -> None:
+    action = Action(action=ActionKind.REST)
+    assert action.contribute_to is None
+
+
+def test_action_accepts_contribute_with_valid_target() -> None:
+    wip = CONFIGURED_WIPS[0]
+    action = Action(
+        thought="I add a stitch",
+        action=ActionKind.CONTRIBUTE,
+        target=None,
+        contribute_to=wip,
+        artifact="a blue stitch across the rough warp",
+    )
+    assert action.action == ActionKind.CONTRIBUTE
+    assert action.contribute_to == wip
+    assert action.artifact == "a blue stitch across the rough warp"
+
+
+def test_action_rejects_unknown_field_via_extra_forbid() -> None:
+    """Action's model_config sets extra='forbid' — adding a new
+    schema field must not relax the strict-JSON contract for
+    unrelated keys.
+    """
+    with pytest.raises(ValidationError):
+        Action.model_validate(
+            {
+                "action": "rest",
+                "unknown_field": "x",
+            }
+        )
+
+
+def _raw(action: str, *, contribute_to: str | None = None,
+         target: str | None = None, artifact: str | None = None,
+         thought: str = "x") -> str:
+    payload: dict[str, object] = {"thought": thought, "action": action}
+    payload["target"] = target
+    payload["artifact"] = artifact
+    if contribute_to is not None:
+        payload["contribute_to"] = contribute_to
+    return json.dumps(payload)
+
+
+def test_parse_action_accepts_valid_contribute() -> None:
+    metrics = Metrics(":memory:")
+    wip = CONFIGURED_WIPS[0]
+    raw = _raw(
+        "contribute",
+        contribute_to=wip,
+        artifact="a blue stitch across the warp",
+    )
+    out = parse_action(raw, metrics=metrics, agent="Aki")
+    assert out.action == ActionKind.CONTRIBUTE
+    assert out.contribute_to == wip
+    assert out.artifact == "a blue stitch across the warp"
+    assert metrics.get("json_ok") == 1
+    assert metrics.get("json_fallback_rest") == 0
+
+
+def test_parse_action_folds_contribute_to_unknown_wip_to_rest() -> None:
+    metrics = Metrics(":memory:")
+    raw = _raw(
+        "contribute",
+        contribute_to="workshop.does-not-exist",
+        artifact="hello",
+    )
+    out = parse_action(raw, metrics=metrics, agent="Aki")
+    assert out.action == ActionKind.REST
+    assert out.contribute_to is None
+    # The fold uses the "invalid contribute" counter, NOT
+    # json_fallback_rest, so operators can distinguish parse failures
+    # from workshop-route failures.
+    assert metrics.get("contribute_invalid_target") == 1
+
+
+def test_parse_action_folds_contribute_without_target_to_rest() -> None:
+    metrics = Metrics(":memory:")
+    raw = _raw("contribute", contribute_to=None, artifact="hello")
+    out = parse_action(raw, metrics=metrics, agent="Aki")
+    assert out.action == ActionKind.REST
+    assert metrics.get("contribute_invalid_target") == 1
+
+
+def test_parse_action_folds_contribute_with_empty_artifact_to_rest() -> None:
+    """A contribute with empty fragment text is the workshop analogue
+    of the Layer-F.2 empty-craft trap: ``contribute_to`` populated but
+    no fragment means the agent is gesturing at a WIP without
+    actually adding anything to it. Fold so the workshop projection
+    cannot accumulate phantom contributions.
+    """
+    metrics = Metrics(":memory:")
+    wip = CONFIGURED_WIPS[0]
+    raw = _raw("contribute", contribute_to=wip, artifact=None)
+    out = parse_action(raw, metrics=metrics, agent="Aki")
+    assert out.action == ActionKind.REST
+    assert metrics.get("contribute_invalid_target") == 1
+
+
+def test_parse_action_folds_stray_contribute_to_on_other_actions() -> None:
+    """A speak / craft / study / rest / travel action with a non-None
+    ``contribute_to`` is malformed: the workshop affordance is only
+    reachable through ``contribute``. Fold to rest as defence-in-depth
+    against an LLM accidentally emitting the field on the wrong verb.
+    """
+    metrics = Metrics(":memory:")
+    wip = CONFIGURED_WIPS[0]
+    for action in ("speak", "craft", "study", "rest", "travel"):
+        raw = _raw(
+            action,
+            contribute_to=wip,
+            target=None,
+            artifact="x" if action == "craft" else None,
+        )
+        out = parse_action(raw, metrics=metrics, agent="Aki")
+        assert out.action == ActionKind.REST, (
+            f"{action!r} with stray contribute_to should fold to rest, "
+            f"got {out.action!r}"
+        )
+
+
+def test_parse_action_contribute_round_trip_via_repair() -> None:
+    """The json_repair pass also validates contribute. A trailing
+    comma is the cheapest "repaired" shape.
+    """
+    metrics = Metrics(":memory:")
+    wip = CONFIGURED_WIPS[0]
+    raw = (
+        '{"thought": "x", "action": "contribute", "target": null, '
+        f'"contribute_to": "{wip}", "artifact": "a stitch",}}'  # trailing comma
+    )
+    out = parse_action(raw, metrics=metrics, agent="Aki")
+    assert out.action == ActionKind.CONTRIBUTE
+    assert out.contribute_to == wip
+
+
+def test_parse_action_meta_leak_still_applies_to_contribute_artifact() -> None:
+    """The fragment text passes through the same meta-leak filter as
+    craft artifacts. A "model" reference in the fragment folds to rest.
+    """
+    metrics = Metrics(":memory:")
+    wip = CONFIGURED_WIPS[0]
+    raw = _raw(
+        "contribute",
+        contribute_to=wip,
+        artifact="the model speaks of cherry blossoms",
+    )
+    out = parse_action(raw, metrics=metrics, agent="Aki")
+    assert out.action == ActionKind.REST
+    assert metrics.get("meta_leak_block") == 1

--- a/tests/test_action_contribute.py
+++ b/tests/test_action_contribute.py
@@ -107,7 +107,7 @@ def test_parse_action_folds_contribute_to_unknown_wip_to_rest() -> None:
     # The fold uses the "invalid contribute" counter, NOT
     # json_fallback_rest, so operators can distinguish parse failures
     # from workshop-route failures.
-    assert metrics.get("contribute_invalid_target") == 1
+    assert metrics.get("contribute_invalid_target", agent="Aki") == 1
 
 
 def test_parse_action_folds_contribute_without_target_to_rest() -> None:
@@ -115,7 +115,7 @@ def test_parse_action_folds_contribute_without_target_to_rest() -> None:
     raw = _raw("contribute", contribute_to=None, artifact="hello")
     out = parse_action(raw, metrics=metrics, agent="Aki")
     assert out.action == ActionKind.REST
-    assert metrics.get("contribute_invalid_target") == 1
+    assert metrics.get("contribute_invalid_target", agent="Aki") == 1
 
 
 def test_parse_action_folds_contribute_with_empty_artifact_to_rest() -> None:
@@ -130,7 +130,7 @@ def test_parse_action_folds_contribute_with_empty_artifact_to_rest() -> None:
     raw = _raw("contribute", contribute_to=wip, artifact=None)
     out = parse_action(raw, metrics=metrics, agent="Aki")
     assert out.action == ActionKind.REST
-    assert metrics.get("contribute_invalid_target") == 1
+    assert metrics.get("contribute_invalid_target", agent="Aki") == 1
 
 
 def test_parse_action_folds_stray_contribute_to_on_other_actions() -> None:
@@ -183,4 +183,4 @@ def test_parse_action_meta_leak_still_applies_to_contribute_artifact() -> None:
     )
     out = parse_action(raw, metrics=metrics, agent="Aki")
     assert out.action == ActionKind.REST
-    assert metrics.get("meta_leak_block") == 1
+    assert metrics.get("meta_leak_block", agent="Aki") == 1

--- a/tests/test_action_parse.py
+++ b/tests/test_action_parse.py
@@ -27,6 +27,41 @@ def test_action_strict_valid_json(metrics: Metrics):
     assert metrics.get("json_fallback_rest") == 0
 
 
+def test_action_strict_rest_with_empty_thought_credits_json_ok(metrics: Metrics):
+    """Regression for Codex review of PR #32: a legitimate
+    ``{"action":"rest","thought":""}`` must credit ``json_ok`` and
+    reset ``consecutive_fail``. An earlier fold-detection heuristic
+    used ``action == REST and not action.thought`` which mis-classified
+    this case as a workshop-route fallback fold.
+    """
+    metrics.bump("consecutive_fail", agent="aki")
+    metrics.bump("consecutive_fail", agent="aki")
+    payload = '{"thought": "", "action": "rest", "target": null, "artifact": null}'
+    a = parse_action(payload, metrics=metrics, agent="aki")
+    assert a.action == ActionKind.REST
+    assert a.thought == ""
+    assert metrics.get("json_ok") == 1
+    assert metrics.get("json_repaired") == 0
+    assert metrics.get("json_fallback_rest") == 0
+    assert metrics.get("contribute_invalid_target", agent="aki") == 0
+    # consecutive_fail must be reset on a successful parse.
+    assert metrics.get("consecutive_fail", agent="aki") == 0
+
+
+def test_action_repaired_rest_with_empty_thought_credits_json_repaired(metrics: Metrics):
+    """Companion to the strict-path test: when the JSON needs repair
+    (trailing comma) AND has an empty thought + rest action, we must
+    still credit ``json_repaired`` rather than silently folding.
+    """
+    payload = '{"thought": "", "action": "rest", "target": null, "artifact": null,}'
+    a = parse_action(payload, metrics=metrics, agent="aki")
+    assert a.action == ActionKind.REST
+    assert a.thought == ""
+    assert metrics.get("json_repaired") == 1
+    assert metrics.get("json_ok") == 0
+    assert metrics.get("json_fallback_rest") == 0
+
+
 def test_action_repaired_when_trailing_comma(metrics: Metrics):
     """json-repair handles common LLM mishaps like trailing commas."""
     payload = '{"thought": "rest", "action": "rest", "target": null, "artifact": null,}'

--- a/tests/test_agent_artisan.py
+++ b/tests/test_agent_artisan.py
@@ -24,9 +24,12 @@ def test_artisan_uses_creative_sampling():
 def test_artisan_persona_renders_with_world_context():
     a = Artisan(name="Aki")
     rendered = a.render_prompt(WorldContext(season="winter", weather="snow", peers_today=("Bo",)))
-    # Persona must mention name, role, and current world state.
+    # Persona must mention name and current world state. Phase 7
+    # (ADR 0003) intentionally removed the verb-fused "artisan"
+    # identity-marker — the role is now an attention/disposition, not
+    # a primary verb. We still assert name + world fields render.
     assert "Aki" in rendered
-    assert "artisan" in rendered.lower()
+    assert "inhabitant" in rendered.lower()
     assert "winter" in rendered.lower()
     assert "Bo" in rendered
     # Hard rule: persona explicitly forbids meta-references. The

--- a/tests/test_agent_scholar.py
+++ b/tests/test_agent_scholar.py
@@ -25,7 +25,11 @@ def test_scholar_persona_renders_with_world_context() -> None:
     s = Scholar(name="Cy")
     rendered = s.render_prompt(WorldContext(season="winter", weather="snow", peers_today=("Aki",)))
     assert "Cy" in rendered
-    assert "scholar" in rendered.lower()
+    # Phase 7 (ADR 0003) removed the verb-fused "scholar" identity-
+    # marker. The role is now an attention/disposition: paying close
+    # attention to what unfolds, optionally writing field notes.
+    assert "inhabitant" in rendered.lower()
+    assert "attention" in rendered.lower()
     assert "winter" in rendered.lower()
     assert "Aki" in rendered
     # Hard rule still in place: meta references forbidden.

--- a/tests/test_harvester_wip.py
+++ b/tests/test_harvester_wip.py
@@ -37,7 +37,6 @@ from microverse.memory.episodic import EpisodicMemory
 from microverse.memory.semantic import SemanticMemory
 from microverse.world.workshop import CONFIGURED_WIPS, WorkshopProjection
 
-
 # ---------------------------------------------------------------------------
 # Trader v2: rule-based WIP scoring
 # ---------------------------------------------------------------------------

--- a/tests/test_harvester_wip.py
+++ b/tests/test_harvester_wip.py
@@ -1,0 +1,283 @@
+"""Phase 6 — Harvester second mode (WIP harvest) + Trader v2.
+
+ADR 0003 Decisions 2 and 3:
+
+* The Harvester drains TWO buffers at flush(): single-tick artifacts
+  (existing) AND completed WIPs (new). For the trader-attached mode,
+  both kinds flow through ``Trader.rank()`` which produces one Score
+  per candidate regardless of kind.
+
+* Trader v2 is heterogeneous:
+  - ArtifactCandidate (kind="artifact"): existing LLM-driven score
+    path — unchanged. test_trader.py keeps passing.
+  - WIPCandidate (kind="wip"): **rule-based** score with no LLM call.
+    score = mean(length_score, contributor_score, novelty_score)
+    where novelty = 1 - mean Jaccard over the last N completed WIPs.
+
+* Per-primary-verb caps applied AFTER ranking, in Harvester. A flush
+  that would otherwise accept 10 crafts is bounded to
+  ``HARVEST_CRAFT_CAP_PER_FLUSH`` crafts.
+
+* Trader output never re-enters agent-visible context. A synthetic
+  harvest event injected into the episodic log does NOT appear in
+  any ``build_context()`` result for any agent (parallel to PR #24
+  structural-leak sweep).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from microverse.agents.base import WorldContext
+from microverse.agents.harvester import ArtifactCandidate, Harvester, WIPCandidate
+from microverse.agents.trader import Score, score_wip
+from microverse.config import HARVEST_CRAFT_CAP_PER_FLUSH
+from microverse.memory import build_context
+from microverse.memory.episodic import EpisodicMemory
+from microverse.memory.semantic import SemanticMemory
+from microverse.world.workshop import CONFIGURED_WIPS, WorkshopProjection
+
+
+# ---------------------------------------------------------------------------
+# Trader v2: rule-based WIP scoring
+# ---------------------------------------------------------------------------
+
+
+def test_score_wip_returns_value_in_unit_interval() -> None:
+    c = WIPCandidate(
+        name="workshop.loom",
+        contributors=("Aki", "Bo"),
+        fragments=(("Aki", "rough warp of dyed wool"),
+                   ("Bo", "blue stitching across the warp")),
+        ts=1.0,
+    )
+    s = score_wip(c, last_completed=[])
+    assert 0.0 <= s <= 1.0
+
+
+def test_score_wip_rewards_longer_fragments() -> None:
+    short = WIPCandidate(
+        name="x", contributors=("Aki",),
+        fragments=(("Aki", "tiny"),), ts=1.0,
+    )
+    long = WIPCandidate(
+        name="y", contributors=("Aki",),
+        fragments=(("Aki", "rough warp of dyed wool with cherry-blossom finish"
+                          " painted onto the upper border in three layers"),),
+        ts=1.0,
+    )
+    assert score_wip(long, last_completed=[]) > score_wip(short, last_completed=[])
+
+
+def test_score_wip_rewards_more_contributors() -> None:
+    solo = WIPCandidate(
+        name="x", contributors=("Aki",),
+        fragments=(("Aki", "warp"), ("Aki", "weft")), ts=1.0,
+    )
+    duo = WIPCandidate(
+        name="y", contributors=("Aki", "Bo"),
+        fragments=(("Aki", "warp"), ("Bo", "weft")), ts=1.0,
+    )
+    assert score_wip(duo, last_completed=[]) > score_wip(solo, last_completed=[])
+
+
+def test_score_wip_penalises_repetition_against_recent_completions() -> None:
+    """A WIP whose tokens overlap heavily with a recent completion
+    scores lower than a token-disjoint WIP. The novelty term uses
+    Jaccard distance over min_len=4 tokens (re-uses the existing
+    _text.tokenize helper).
+    """
+    prev = WIPCandidate(
+        name="prev", contributors=("Aki",),
+        fragments=(("Aki", "blue cherry blossom wooden bowl carved"),),
+        ts=0.0,
+    )
+    similar = WIPCandidate(
+        name="similar", contributors=("Aki",),
+        fragments=(("Aki", "blue cherry blossom wooden bowl carved deep"),),
+        ts=2.0,
+    )
+    novel = WIPCandidate(
+        name="novel", contributors=("Aki",),
+        fragments=(("Aki", "iron lantern wrought with celestial astronomy"),),
+        ts=2.0,
+    )
+    assert score_wip(novel, last_completed=[prev]) > score_wip(similar, last_completed=[prev])
+
+
+# ---------------------------------------------------------------------------
+# Harvester WIP harvest
+# ---------------------------------------------------------------------------
+
+
+class _PredictableRanker:
+    """Test double for Trader. Returns scores from a fixed dict
+    keyed by candidate identity (artifact text or WIP name)."""
+
+    def __init__(self, scores: dict[str, float]) -> None:
+        self._scores = scores
+
+    def rank(self, candidates: list) -> list[Score]:
+        out: list[Score] = []
+        for i, c in enumerate(candidates):
+            key = c.name if isinstance(c, WIPCandidate) else (c.artifact or "")
+            out.append(Score(artifact_id=i, score=self._scores.get(key, 0.5), rationale=""))
+        return out
+
+
+def _drive_wip_to_complete(ep: EpisodicMemory, wip: str, ts_base: float = 1.0) -> None:
+    """Append 8 fragments alternating between two contributors so the
+    projection promotes ``wip`` to complete (8 == COMPLETE_FRAGMENT_FLOOR).
+    """
+    for i in range(8):
+        actor = "Aki" if i % 2 == 0 else "Bo"
+        ep.append(
+            actor=actor,
+            action="contribute",
+            target=wip,
+            payload={"thought": "x", "fragment": f"frag-{i} from {actor}"},
+            ts=ts_base + i,
+        )
+
+
+def test_harvester_writes_completed_wip_to_inbox(tmp_path: Path) -> None:
+    """A WIP that has transitioned to complete is written to the
+    harvest inbox on flush, with frontmatter capturing the WIP name,
+    contributors, and a manifest line recording the score.
+    """
+    db = tmp_path / "ep.sqlite"
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(db) as ep:
+        _drive_wip_to_complete(ep, target, ts_base=1.0)
+        proj = WorkshopProjection(ep)
+        # All scores in top-30% so percentile cutoff accepts.
+        ranker = _PredictableRanker({target: 0.95})
+        harvester = Harvester(
+            tmp_path / "harvest", trader=ranker, workshop=proj, percentile=70,
+        )
+        written = harvester.flush()
+    assert len(written) == 1
+    body = written[0].read_text(encoding="utf-8")
+    assert target in body
+    # Both contributors appear in the body (community knowledge —
+    # the harvest output is not per-receiver redacted, it is the
+    # external observer view).
+    assert "Aki" in body
+    assert "Bo" in body
+
+
+def test_harvester_does_not_double_harvest_same_wip(tmp_path: Path) -> None:
+    """A WIP completed at flush N is NOT harvested again at flush
+    N+1. ``_harvested_wips`` tracks names already written.
+    """
+    db = tmp_path / "ep.sqlite"
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(db) as ep:
+        _drive_wip_to_complete(ep, target, ts_base=1.0)
+        proj = WorkshopProjection(ep)
+        ranker = _PredictableRanker({target: 0.95})
+        harvester = Harvester(
+            tmp_path / "harvest", trader=ranker, workshop=proj, percentile=70,
+        )
+        first = harvester.flush()
+        second = harvester.flush()
+    assert len(first) == 1
+    assert len(second) == 0
+
+
+def test_harvester_caps_craft_acceptance_per_flush(tmp_path: Path) -> None:
+    """Per-primary-verb cap: when more crafts are buffered than the
+    cap, only the top ``HARVEST_CRAFT_CAP_PER_FLUSH`` by score are
+    accepted; the rest are recorded as rejected in the manifest.
+    """
+    # Buffer N+3 crafts where N is the cap. All same-length so
+    # short-circuit acceptance can't pretend otherwise. Use
+    # decreasing scores so we can verify the top-N are picked.
+    n = HARVEST_CRAFT_CAP_PER_FLUSH
+    crafts = [
+        ArtifactCandidate(
+            actor="Aki",
+            action="craft",
+            artifact=f"craft-{i}: a thing here that is longer than 20 chars",
+            ts=float(i),
+        )
+        for i in range(n + 3)
+    ]
+    scores = {c.artifact: 1.0 - i * 0.01 for i, c in enumerate(crafts)}
+    ranker = _PredictableRanker(scores)  # type: ignore[arg-type]
+    harvester = Harvester(tmp_path / "harvest", trader=ranker, percentile=0)
+    for c in crafts:
+        harvester.consider(c)
+    written = harvester.flush()
+    assert len(written) == n
+
+
+def test_harvester_works_without_workshop_reference(tmp_path: Path) -> None:
+    """Back-compat: a Harvester constructed without ``workshop=`` keeps
+    the v0.1.1 single-buffer behaviour exactly.
+    """
+    harvester = Harvester(tmp_path / "harvest", percentile=70)  # no trader, no workshop
+    harvester.consider(
+        ArtifactCandidate(
+            actor="Aki", action="craft", artifact="a wooden flute carved with care",
+            ts=1.0,
+        )
+    )
+    written = harvester.flush()
+    # No trader means heuristic mode wrote on consider; flush is a no-op.
+    assert written == []
+
+
+# ---------------------------------------------------------------------------
+# Trader-feedback-invisibility leak sweep (ADR 0003 Decision 3)
+# ---------------------------------------------------------------------------
+
+
+def test_no_harvest_actor_event_leaks_into_build_context(tmp_path: Path) -> None:
+    """Inject synthetic harvest verdict events into episodic; build
+    context for every agent; assert none of the verdict text surfaces
+    in any text-bearing field of the returned WorldContext.
+
+    This is the parallel to PR #24's 897-sample structural-leak sweep
+    for the Trader-feedback channel.
+    """
+    with (
+        EpisodicMemory(tmp_path / "ep.sqlite") as ep,
+        SemanticMemory(tmp_path / "se.sqlite") as se,
+    ):
+        for i in range(20):
+            ep.append(
+                actor="harvest",
+                action="rated",
+                target="Aki",
+                payload={
+                    "score": 0.9,
+                    "rationale": f"verdict-rationale-distinctive-{i}",
+                    "thought": f"verdict-rationale-distinctive-{i}",
+                },
+                ts=float(i),
+            )
+        for agent in ("Aki", "Cy", "Bo"):
+            world = build_context(
+                world_base=WorldContext(),
+                episodic=ep,
+                semantic=se,
+                topic="",
+                receiver_name=agent,
+            )
+            text_fields = "\n".join([
+                world.season,
+                world.weather,
+                *world.peers_today,
+                *(s.utterance for s in world.peer_inbox),
+                *world.world_events,
+                *world.lore_excerpt,
+                world.engagement_hint,
+                world.required_target or "",
+                *(v.excerpt for v in world.workshop_view),
+                *(v.contributors for v in world.workshop_view),
+            ])
+            for i in range(20):
+                assert f"verdict-rationale-distinctive-{i}" not in text_fields, (
+                    f"trader verdict leaked into {agent}'s context"
+                )

--- a/tests/test_harvester_wip.py
+++ b/tests/test_harvester_wip.py
@@ -204,6 +204,96 @@ def test_harvester_does_not_double_harvest_same_wip(tmp_path: Path) -> None:
     assert len(second) == 0
 
 
+class _MutableRanker:
+    """Test double whose score for a key can be changed between flushes
+    — used to simulate a WIP that the ranker rejects on flush-1 (score
+    below cutoff) and accepts on flush-2 (score above cutoff). The
+    earlier ``_PredictableRanker`` keeps a frozen dict.
+    """
+
+    def __init__(self) -> None:
+        self.scores: dict[str, float] = {}
+
+    def rank(self, candidates: list) -> list[Score]:
+        out: list[Score] = []
+        for i, c in enumerate(candidates):
+            key = c.name if isinstance(c, WIPCandidate) else (c.artifact or "")
+            out.append(Score(artifact_id=i, score=self.scores.get(key, 0.5), rationale=""))
+        return out
+
+
+def test_rejected_wip_remains_eligible_on_next_flush(tmp_path: Path) -> None:
+    """ADR 0003 regression: a completed WIP that the ranker scored
+    too low (below the percentile cutoff) on flush N MUST be eligible
+    again on flush N+1. The earlier implementation marked WIPs as
+    harvested as soon as they were snapshotted from the projection,
+    which permanently dropped any WIP that did not pass the cutoff
+    — a silent data-loss bug surfaced by Gemini + CodeRabbit review
+    of PR #32.
+
+    Strategy: a second completed WIP gives the percentile-cutoff
+    something to compare against; on flush-1 we keep the target's
+    score low so it falls below the p70 cutoff (rejected); on
+    flush-2 we raise the target's score and confirm it is now
+    written.
+    """
+    db = tmp_path / "ep.sqlite"
+    target = CONFIGURED_WIPS[0]
+    decoy = CONFIGURED_WIPS[1]
+    with EpisodicMemory(db) as ep:
+        _drive_wip_to_complete(ep, target, ts_base=1.0)
+        _drive_wip_to_complete(ep, decoy, ts_base=100.0)
+        proj = WorkshopProjection(ep)
+        ranker = _MutableRanker()
+        harvester = Harvester(
+            tmp_path / "harvest",
+            trader=ranker,
+            workshop=proj,
+            percentile=70,
+        )
+
+        # Flush 1: target scores below decoy, percentile=70 cuts it.
+        ranker.scores = {target: 0.10, decoy: 0.95}
+        first = harvester.flush()
+        first_names = [p.name for p in first]
+        assert not any(target.removeprefix("workshop.") in n for n in first_names), (
+            f"target WIP should not have been harvested at flush-1: {first_names}"
+        )
+
+        # Flush 2: target's score is now well above cutoff; the
+        # bug version would silently skip it because flush-1 marked
+        # it harvested. With the fix the projection still considers
+        # it a pending completed WIP and the harvest goes through.
+        # Add a second decoy with low score so the cutoff still has
+        # a population to compare against.
+        decoy2 = CONFIGURED_WIPS[2]
+        ep.append(
+            actor="Aki",
+            action="contribute",
+            target=decoy2,
+            payload={"thought": "x", "fragment": "low-priority filler text long enough"},
+            ts=200.0,
+        )
+        for i in range(7):
+            ep.append(
+                actor="Bo",
+                action="contribute",
+                target=decoy2,
+                payload={"thought": "x", "fragment": f"filler-{i}"},
+                ts=201.0 + i,
+            )
+        # Rebuild projection to pick up the new fragments + completion.
+        proj_v2 = WorkshopProjection(ep)
+        harvester._workshop = proj_v2
+        ranker.scores = {target: 0.99, decoy: 0.10, decoy2: 0.10}
+        second = harvester.flush()
+        target_slug = target.removeprefix("workshop.")
+        second_names = [p.name for p in second]
+        assert any(target_slug in n for n in second_names), (
+            f"target WIP must be re-considered and accepted on flush-2; got {second_names}"
+        )
+
+
 def test_harvester_caps_craft_acceptance_per_flush(tmp_path: Path) -> None:
     """Per-primary-verb cap: when more crafts are buffered than the
     cap, only the top ``HARVEST_CRAFT_CAP_PER_FLUSH`` by score are

--- a/tests/test_harvester_wip.py
+++ b/tests/test_harvester_wip.py
@@ -46,8 +46,7 @@ def test_score_wip_returns_value_in_unit_interval() -> None:
     c = WIPCandidate(
         name="workshop.loom",
         contributors=("Aki", "Bo"),
-        fragments=(("Aki", "rough warp of dyed wool"),
-                   ("Bo", "blue stitching across the warp")),
+        fragments=(("Aki", "rough warp of dyed wool"), ("Bo", "blue stitching across the warp")),
         ts=1.0,
     )
     s = score_wip(c, last_completed=[])
@@ -56,13 +55,21 @@ def test_score_wip_returns_value_in_unit_interval() -> None:
 
 def test_score_wip_rewards_longer_fragments() -> None:
     short = WIPCandidate(
-        name="x", contributors=("Aki",),
-        fragments=(("Aki", "tiny"),), ts=1.0,
+        name="x",
+        contributors=("Aki",),
+        fragments=(("Aki", "tiny"),),
+        ts=1.0,
     )
     long = WIPCandidate(
-        name="y", contributors=("Aki",),
-        fragments=(("Aki", "rough warp of dyed wool with cherry-blossom finish"
-                          " painted onto the upper border in three layers"),),
+        name="y",
+        contributors=("Aki",),
+        fragments=(
+            (
+                "Aki",
+                "rough warp of dyed wool with cherry-blossom finish"
+                " painted onto the upper border in three layers",
+            ),
+        ),
         ts=1.0,
     )
     assert score_wip(long, last_completed=[]) > score_wip(short, last_completed=[])
@@ -70,12 +77,16 @@ def test_score_wip_rewards_longer_fragments() -> None:
 
 def test_score_wip_rewards_more_contributors() -> None:
     solo = WIPCandidate(
-        name="x", contributors=("Aki",),
-        fragments=(("Aki", "warp"), ("Aki", "weft")), ts=1.0,
+        name="x",
+        contributors=("Aki",),
+        fragments=(("Aki", "warp"), ("Aki", "weft")),
+        ts=1.0,
     )
     duo = WIPCandidate(
-        name="y", contributors=("Aki", "Bo"),
-        fragments=(("Aki", "warp"), ("Bo", "weft")), ts=1.0,
+        name="y",
+        contributors=("Aki", "Bo"),
+        fragments=(("Aki", "warp"), ("Bo", "weft")),
+        ts=1.0,
     )
     assert score_wip(duo, last_completed=[]) > score_wip(solo, last_completed=[])
 
@@ -87,17 +98,20 @@ def test_score_wip_penalises_repetition_against_recent_completions() -> None:
     _text.tokenize helper).
     """
     prev = WIPCandidate(
-        name="prev", contributors=("Aki",),
+        name="prev",
+        contributors=("Aki",),
         fragments=(("Aki", "blue cherry blossom wooden bowl carved"),),
         ts=0.0,
     )
     similar = WIPCandidate(
-        name="similar", contributors=("Aki",),
+        name="similar",
+        contributors=("Aki",),
         fragments=(("Aki", "blue cherry blossom wooden bowl carved deep"),),
         ts=2.0,
     )
     novel = WIPCandidate(
-        name="novel", contributors=("Aki",),
+        name="novel",
+        contributors=("Aki",),
         fragments=(("Aki", "iron lantern wrought with celestial astronomy"),),
         ts=2.0,
     )
@@ -152,7 +166,10 @@ def test_harvester_writes_completed_wip_to_inbox(tmp_path: Path) -> None:
         # All scores in top-30% so percentile cutoff accepts.
         ranker = _PredictableRanker({target: 0.95})
         harvester = Harvester(
-            tmp_path / "harvest", trader=ranker, workshop=proj, percentile=70,
+            tmp_path / "harvest",
+            trader=ranker,
+            workshop=proj,
+            percentile=70,
         )
         written = harvester.flush()
     assert len(written) == 1
@@ -176,7 +193,10 @@ def test_harvester_does_not_double_harvest_same_wip(tmp_path: Path) -> None:
         proj = WorkshopProjection(ep)
         ranker = _PredictableRanker({target: 0.95})
         harvester = Harvester(
-            tmp_path / "harvest", trader=ranker, workshop=proj, percentile=70,
+            tmp_path / "harvest",
+            trader=ranker,
+            workshop=proj,
+            percentile=70,
         )
         first = harvester.flush()
         second = harvester.flush()
@@ -218,7 +238,9 @@ def test_harvester_works_without_workshop_reference(tmp_path: Path) -> None:
     harvester = Harvester(tmp_path / "harvest", percentile=70)  # no trader, no workshop
     harvester.consider(
         ArtifactCandidate(
-            actor="Aki", action="craft", artifact="a wooden flute carved with care",
+            actor="Aki",
+            action="craft",
+            artifact="a wooden flute carved with care",
             ts=1.0,
         )
     )
@@ -264,18 +286,20 @@ def test_no_harvest_actor_event_leaks_into_build_context(tmp_path: Path) -> None
                 topic="",
                 receiver_name=agent,
             )
-            text_fields = "\n".join([
-                world.season,
-                world.weather,
-                *world.peers_today,
-                *(s.utterance for s in world.peer_inbox),
-                *world.world_events,
-                *world.lore_excerpt,
-                world.engagement_hint,
-                world.required_target or "",
-                *(v.excerpt for v in world.workshop_view),
-                *(v.contributors for v in world.workshop_view),
-            ])
+            text_fields = "\n".join(
+                [
+                    world.season,
+                    world.weather,
+                    *world.peers_today,
+                    *(s.utterance for s in world.peer_inbox),
+                    *world.world_events,
+                    *world.lore_excerpt,
+                    world.engagement_hint,
+                    world.required_target or "",
+                    *(v.excerpt for v in world.workshop_view),
+                    *(v.contributors for v in world.workshop_view),
+                ]
+            )
             for i in range(20):
                 assert f"verdict-rationale-distinctive-{i}" not in text_fields, (
                     f"trader verdict leaked into {agent}'s context"

--- a/tests/test_persona_renders_workshop.py
+++ b/tests/test_persona_renders_workshop.py
@@ -59,10 +59,18 @@ def test_persona_renders_multi_wip_in_order(template: str) -> None:
     """Multiple WIPViews iterate in the order they were assembled."""
     views = (
         WIPView(name="workshop.scroll", phase="forming", contributors="", excerpt=""),
-        WIPView(name="workshop.loom", phase="developing",
-                contributors="Bo, Cy", excerpt="Bo: warp\nCy: weft"),
-        WIPView(name="workshop.garden_bed", phase="complete",
-                contributors="Bo", excerpt="Bo: planted seedlings"),
+        WIPView(
+            name="workshop.loom",
+            phase="developing",
+            contributors="Bo, Cy",
+            excerpt="Bo: warp\nCy: weft",
+        ),
+        WIPView(
+            name="workshop.garden_bed",
+            phase="complete",
+            contributors="Bo",
+            excerpt="Bo: planted seedlings",
+        ),
     )
     out = render(template, name="Aki", world=WorldContext(workshop_view=views))
     # Order check via index comparison.
@@ -80,10 +88,7 @@ def test_persona_workshop_block_hides_excerpt_when_blank(template: str) -> None:
     render (the agent should know the WIP exists) but should not
     produce stray "Excerpt:" header followed by empty content.
     """
-    views = (
-        WIPView(name="workshop.scroll", phase="forming",
-                contributors="", excerpt=""),
-    )
+    views = (WIPView(name="workshop.scroll", phase="forming", contributors="", excerpt=""),)
     out = render(template, name="Aki", world=WorldContext(workshop_view=views))
     assert "workshop.scroll" in out
     assert "forming" in out

--- a/tests/test_persona_renders_workshop.py
+++ b/tests/test_persona_renders_workshop.py
@@ -13,6 +13,8 @@ The persona "Hard rules" enumeration of valid actions also gains
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from microverse.agents.base import WorldContext
@@ -90,12 +92,29 @@ def test_persona_workshop_block_hides_excerpt_when_blank(template: str) -> None:
     """
     views = (WIPView(name="workshop.scroll", phase="forming", contributors="", excerpt=""),)
     out = render(template, name="Aki", world=WorldContext(workshop_view=views))
+    out_lower = out.lower()
     assert "workshop.scroll" in out
     assert "forming" in out
-    # Don't render a "Recent fragments:" / "Excerpt:" label with empty content.
-    blank_excerpt_indicators = ("Recent fragments:\n\n", "Excerpt:\n\n")
-    for marker in blank_excerpt_indicators:
-        assert marker not in out, f"empty-excerpt block rendered with header: {marker!r}"
+    # Case-insensitive: don't render a "Recent fragments:" / "Excerpt:"
+    # header with empty content. Either case (or different surrounding
+    # newline count) would still be a regression.
+    for marker in ("recent fragments:", "excerpt:"):
+        if marker not in out_lower:
+            continue
+        idx = out_lower.find(marker)
+        tail = out_lower[idx + len(marker) :].lstrip("\n").lstrip()
+        msg = (
+            f"empty-excerpt header {marker!r} rendered with no content under it: "
+            f"{out[idx : idx + 80]!r}"
+        )
+        assert tail, msg
+        assert not tail.startswith("phase"), msg
+
+
+# Whole-word regex used by the contribute-listing tests: ensures the
+# template includes ``contribute`` as a distinct token rather than a
+# substring of ``contribute_to`` or some unrelated word.
+_CONTRIBUTE_WORD = re.compile(r"\bcontribute\b")
 
 
 def test_artisan_lists_contribute_in_hard_rules() -> None:
@@ -103,7 +122,7 @@ def test_artisan_lists_contribute_in_hard_rules() -> None:
     ``contribute`` so the LLM knows it is a valid verb.
     """
     out = render("persona_artisan.j2", name="Aki", world=WorldContext())
-    assert "contribute" in out
+    assert _CONTRIBUTE_WORD.search(out), f"`contribute` not listed as a verb: {out!r}"
 
 
 def test_scholar_lists_contribute_in_hard_rules() -> None:
@@ -112,9 +131,9 @@ def test_scholar_lists_contribute_in_hard_rules() -> None:
     surfaces it the same way.
     """
     out = render("persona_scholar.j2", name="Cy", world=WorldContext())
-    assert "contribute" in out
+    assert _CONTRIBUTE_WORD.search(out), f"`contribute` not listed as a verb: {out!r}"
 
 
 def test_stranger_lists_contribute_in_hard_rules() -> None:
     out = render("persona_stranger.j2", name="X", world=WorldContext())
-    assert "contribute" in out
+    assert _CONTRIBUTE_WORD.search(out), f"`contribute` not listed as a verb: {out!r}"

--- a/tests/test_persona_renders_workshop.py
+++ b/tests/test_persona_renders_workshop.py
@@ -1,0 +1,115 @@
+"""Phase 5 — persona templates render workshop_view.
+
+ADR 0003: every persona (Artisan / Scholar / Stranger) renders a
+"village workshop currently holds" block that iterates
+``world.workshop_view``. Each WIPView's name, phase, contributors,
+and excerpt are surfaced as readable prompt text. Empty
+``workshop_view`` produces no block (back-compat with v0.1.1
+fixtures).
+
+The persona "Hard rules" enumeration of valid actions also gains
+``contribute`` so the LLM knows the verb is available.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from microverse.agents.base import WorldContext
+from microverse.prompts import render
+from microverse.world.workshop import WIPView
+
+_PERSONAS = ("persona_artisan.j2", "persona_scholar.j2", "persona_stranger.j2")
+
+
+@pytest.mark.parametrize("template", _PERSONAS)
+def test_persona_omits_workshop_block_when_empty(template: str) -> None:
+    """A WorldContext with empty workshop_view renders no workshop
+    block. v0.1.1 fixtures keep working without modification.
+    """
+    out = render(template, name="Aki", world=WorldContext())
+    assert "village workshop" not in out.lower()
+    assert "[earlier contributor" not in out
+    assert "phase:" not in out.lower()
+
+
+@pytest.mark.parametrize("template", _PERSONAS)
+def test_persona_renders_workshop_when_present(template: str) -> None:
+    """When workshop_view has WIPViews, the persona prompt surfaces
+    each one with name, phase, contributors, and excerpt.
+    """
+    views = (
+        WIPView(
+            name="workshop.loom",
+            phase="developing",
+            contributors="Bo",
+            excerpt="Bo: blue stitching",
+        ),
+    )
+    out = render(template, name="Aki", world=WorldContext(workshop_view=views))
+    assert "village workshop" in out.lower()
+    assert "workshop.loom" in out
+    assert "developing" in out
+    assert "Bo" in out
+    assert "blue stitching" in out
+
+
+@pytest.mark.parametrize("template", _PERSONAS)
+def test_persona_renders_multi_wip_in_order(template: str) -> None:
+    """Multiple WIPViews iterate in the order they were assembled."""
+    views = (
+        WIPView(name="workshop.scroll", phase="forming", contributors="", excerpt=""),
+        WIPView(name="workshop.loom", phase="developing",
+                contributors="Bo, Cy", excerpt="Bo: warp\nCy: weft"),
+        WIPView(name="workshop.garden_bed", phase="complete",
+                contributors="Bo", excerpt="Bo: planted seedlings"),
+    )
+    out = render(template, name="Aki", world=WorldContext(workshop_view=views))
+    # Order check via index comparison.
+    i_scroll = out.find("workshop.scroll")
+    i_loom = out.find("workshop.loom")
+    i_garden = out.find("workshop.garden_bed")
+    assert -1 < i_scroll < i_loom < i_garden
+    assert "complete" in out
+    assert "planted seedlings" in out
+
+
+@pytest.mark.parametrize("template", _PERSONAS)
+def test_persona_workshop_block_hides_excerpt_when_blank(template: str) -> None:
+    """A WIPView with phase=forming and no excerpt should still
+    render (the agent should know the WIP exists) but should not
+    produce stray "Excerpt:" header followed by empty content.
+    """
+    views = (
+        WIPView(name="workshop.scroll", phase="forming",
+                contributors="", excerpt=""),
+    )
+    out = render(template, name="Aki", world=WorldContext(workshop_view=views))
+    assert "workshop.scroll" in out
+    assert "forming" in out
+    # Don't render a "Recent fragments:" / "Excerpt:" label with empty content.
+    blank_excerpt_indicators = ("Recent fragments:\n\n", "Excerpt:\n\n")
+    for marker in blank_excerpt_indicators:
+        assert marker not in out, f"empty-excerpt block rendered with header: {marker!r}"
+
+
+def test_artisan_lists_contribute_in_hard_rules() -> None:
+    """The Artisan's "Hard rules" / action enumeration includes
+    ``contribute`` so the LLM knows it is a valid verb.
+    """
+    out = render("persona_artisan.j2", name="Aki", world=WorldContext())
+    assert "contribute" in out
+
+
+def test_scholar_lists_contribute_in_hard_rules() -> None:
+    """Scholars also have access to the workshop affordance — they
+    can leave field notes / observations as fragments. The persona
+    surfaces it the same way.
+    """
+    out = render("persona_scholar.j2", name="Cy", world=WorldContext())
+    assert "contribute" in out
+
+
+def test_stranger_lists_contribute_in_hard_rules() -> None:
+    out = render("persona_stranger.j2", name="X", world=WorldContext())
+    assert "contribute" in out

--- a/tests/test_workshop_kill_safety.py
+++ b/tests/test_workshop_kill_safety.py
@@ -38,12 +38,14 @@ def test_projection_rebuilds_identically_after_sqlite_reopen(tmp_path: Path) -> 
 
     with EpisodicMemory(db) as ep:
         proj_hot = WorkshopProjection(ep)
-        for i, (actor, text) in enumerate([
-            ("Aki", "rough warp"),
-            ("Bo", "blue stitching"),
-            ("Aki", "blossom motif"),
-            ("Cy", "field-note observation"),
-        ]):
+        for i, (actor, text) in enumerate(
+            [
+                ("Aki", "rough warp"),
+                ("Bo", "blue stitching"),
+                ("Aki", "blossom motif"),
+                ("Cy", "field-note observation"),
+            ]
+        ):
             ep.append(
                 actor=actor,
                 action="contribute",
@@ -76,8 +78,7 @@ def test_projection_rebuilds_identically_after_sqlite_reopen(tmp_path: Path) -> 
         )
 
     assert hot_state == cold_state, (
-        f"projection diverged across reopen.\n"
-        f"hot:  {hot_state!r}\ncold: {cold_state!r}"
+        f"projection diverged across reopen.\nhot:  {hot_state!r}\ncold: {cold_state!r}"
     )
     # And the fragments match what the test seeded — no autonomous state.
     assert [(c, t) for (c, t) in hot_state[0]] == expected_fragments

--- a/tests/test_workshop_kill_safety.py
+++ b/tests/test_workshop_kill_safety.py
@@ -1,0 +1,125 @@
+"""Slice 2.4 — Workshop projection kill-safety.
+
+ADR 0003 contract: the workshop is a *derived* read-model. The
+episodic SQLite event log is the durability boundary; its WAL/SIGKILL
+properties are tested at the subprocess level in
+``tests/test_kill_safety.py``. What we must pin here is the bridge:
+the projection that an operator rebuilds after restart must match
+the projection a long-lived process saw at the moment of crash, with
+no autonomous state that could diverge.
+
+The full subprocess-SIGKILL drill is unnecessary here because the
+episodic file is the only durability surface — if it survived (and
+it does, per the existing drill), then ``WorkshopProjection(ep)`` on
+a freshly-opened ``EpisodicMemory`` is provably equivalent to the
+in-memory projection that was running at crash time. We pin
+*equivalence across a reopen*, which is the cheapest test of that
+invariant.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from microverse.memory.episodic import EpisodicMemory
+from microverse.world.workshop import CONFIGURED_WIPS, WorkshopProjection
+
+
+def test_projection_rebuilds_identically_after_sqlite_reopen(tmp_path: Path) -> None:
+    """Build a projection on a hot connection; close the connection;
+    open a new one against the same SQLite file; assert the rebuilt
+    projection has the same fragments / phase / contributor set per
+    WIP. This is the recovery path that runs on every process
+    restart.
+    """
+    db = tmp_path / "ep.sqlite"
+    target = CONFIGURED_WIPS[0]
+    expected_fragments: list[tuple[str, str]] = []
+
+    with EpisodicMemory(db) as ep:
+        proj_hot = WorkshopProjection(ep)
+        for i, (actor, text) in enumerate([
+            ("Aki", "rough warp"),
+            ("Bo", "blue stitching"),
+            ("Aki", "blossom motif"),
+            ("Cy", "field-note observation"),
+        ]):
+            ep.append(
+                actor=actor,
+                action="contribute",
+                target=target,
+                payload={"thought": f"{actor} thinks", "fragment": text},
+                ts=float(i + 1),
+            )
+            proj_hot.on_contribute_event(ep.last(1)[0])
+            expected_fragments.append((actor, text))
+
+        hot_wip = proj_hot.get(target)
+        assert hot_wip is not None
+        hot_state = (
+            tuple((f.contributor, f.text) for f in hot_wip.fragments),
+            hot_wip.phase,
+            hot_wip.contributors(),
+            hot_wip.last_activity_ts,
+        )
+
+    # Process restart: episodic connection closed; reopen fresh.
+    with EpisodicMemory(db) as ep2:
+        proj_cold = WorkshopProjection(ep2)
+        cold_wip = proj_cold.get(target)
+        assert cold_wip is not None
+        cold_state = (
+            tuple((f.contributor, f.text) for f in cold_wip.fragments),
+            cold_wip.phase,
+            cold_wip.contributors(),
+            cold_wip.last_activity_ts,
+        )
+
+    assert hot_state == cold_state, (
+        f"projection diverged across reopen.\n"
+        f"hot:  {hot_state!r}\ncold: {cold_state!r}"
+    )
+    # And the fragments match what the test seeded — no autonomous state.
+    assert [(c, t) for (c, t) in hot_state[0]] == expected_fragments
+
+
+def test_partial_writes_do_not_corrupt_projection(tmp_path: Path) -> None:
+    """A contribute event with an empty fragment payload (the
+    closest legal analogue of "tick committed but agent emitted
+    nothing useful") is silently dropped at projection-rebuild time,
+    so a subsequent restart converges to the same state regardless
+    of how many such no-op events sit in the log.
+    """
+    db = tmp_path / "ep.sqlite"
+    target = CONFIGURED_WIPS[0]
+
+    with EpisodicMemory(db) as ep:
+        # Mix real + empty-fragment contributes; the empty ones are
+        # legally appendable (no schema constraint forbids them) but
+        # MUST NOT affect the projection state.
+        for i in range(6):
+            text = "" if i % 2 == 0 else f"frag-{i}"
+            ep.append(
+                actor="Aki",
+                action="contribute",
+                target=target,
+                payload={"thought": "x", "fragment": text},
+                ts=float(i + 1),
+            )
+
+    with EpisodicMemory(db) as ep1:
+        proj1 = WorkshopProjection(ep1)
+    with EpisodicMemory(db) as ep2:
+        proj2 = WorkshopProjection(ep2)
+
+    w1 = proj1.get(target)
+    w2 = proj2.get(target)
+    assert w1 is not None
+    assert w2 is not None
+    assert [(f.contributor, f.text) for f in w1.fragments] == [
+        (f.contributor, f.text) for f in w2.fragments
+    ]
+    assert w1.phase == w2.phase
+    # Three of six events were empty-fragment; the projection holds
+    # exactly the three non-empty ones.
+    assert len(w1.fragments) == 3

--- a/tests/test_workshop_projection.py
+++ b/tests/test_workshop_projection.py
@@ -1,0 +1,350 @@
+"""Phase 2 — WorkshopProjection over the episodic event log.
+
+ADR 0003 contract: the workshop is a *projection* (read-model) over
+the episodic event log. ``contribute`` events are the sole
+authoritative write; the projection's in-memory state is rebuilt
+from the log on construction. Snapshot durability is inherited from
+the episodic SQLite file; no separate WAL.
+
+Slices covered here (all deterministic, no LLM):
+  * 2.1 — WIP / Fragment shape + rebuild_from_episodic.
+  * 2.2 — Phase transitions (forming → developing → complete) based
+    on contributor count, fragment count, and explicit-complete payload.
+  * 2.3 — stale_to_complete clock-driven auto-completion.
+
+The kill-safety drill (slice 2.4) lives in test_workshop_kill_safety.py
+so the heavy SQLite-restart machinery doesn't bloat this fast suite.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+from pathlib import Path
+
+import pytest
+
+from microverse.memory.episodic import EpisodicMemory
+from microverse.world.workshop import (
+    CONFIGURED_WIPS,
+    DEVELOPING_FRAGMENT_FLOOR,
+    DEVELOPING_CONTRIBUTOR_FLOOR,
+    COMPLETE_FRAGMENT_FLOOR,
+    Fragment,
+    WIP,
+    WorkshopProjection,
+)
+
+
+def _seed_contribute(
+    ep: EpisodicMemory,
+    *,
+    actor: str,
+    wip: str,
+    fragment: str,
+    ts: float | None = None,
+) -> None:
+    ep.append(
+        actor=actor,
+        action="contribute",
+        target=wip,
+        payload={"thought": f"{actor} weaving", "fragment": fragment},
+        ts=ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slice 2.1 — shape and rebuild_from_episodic
+# ---------------------------------------------------------------------------
+
+
+def test_fragment_is_frozen_dataclass() -> None:
+    frag = Fragment(contributor="Aki", text="rough warp", ts=1.0)
+    assert dataclasses.is_dataclass(frag)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        frag.text = "different"  # type: ignore[misc]
+
+
+def test_fragment_requires_all_fields() -> None:
+    with pytest.raises(TypeError):
+        Fragment(contributor="Aki")  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        Fragment(text="warp", ts=1.0)  # type: ignore[call-arg]
+
+
+def test_configured_wips_is_nonempty_tuple_of_strings() -> None:
+    """The v0.2 set is configured at module level — agent-spawnable
+    WIPs are explicitly out of scope (ADR 0003).
+    """
+    assert isinstance(CONFIGURED_WIPS, tuple)
+    assert len(CONFIGURED_WIPS) >= 1
+    for name in CONFIGURED_WIPS:
+        assert isinstance(name, str)
+        assert name.startswith("workshop.")
+
+
+def test_empty_log_yields_all_wips_forming(tmp_path: Path) -> None:
+    """A fresh data dir contains no contribute events. Every
+    configured WIP exists, with zero fragments, in the ``forming``
+    phase, at last_activity_ts == 0.0.
+    """
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        proj = WorkshopProjection(ep)
+    wips = {w.name: w for w in proj.wips()}
+    assert set(wips.keys()) == set(CONFIGURED_WIPS)
+    for w in wips.values():
+        assert w.fragments == []
+        assert w.phase == "forming"
+        assert w.last_activity_ts == 0.0
+
+
+def test_rebuild_collects_fragments_for_named_wip(tmp_path: Path) -> None:
+    """Each contribute event with ``target`` matching a configured WIP
+    becomes one Fragment on that WIP, in chronological order.
+    Events targeting an unknown WIP are silently dropped (handled
+    upstream by parse_action's WIP-name validation; the projection
+    is defensive).
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed_contribute(ep, actor="Aki", wip=target, fragment="rough warp", ts=1.0)
+        _seed_contribute(ep, actor="Bo", wip=target, fragment="blue stitching", ts=2.0)
+        _seed_contribute(ep, actor="Aki", wip="workshop.does-not-exist",
+                         fragment="dropped", ts=3.0)
+        proj = WorkshopProjection(ep)
+    wip = next(w for w in proj.wips() if w.name == target)
+    assert [f.text for f in wip.fragments] == ["rough warp", "blue stitching"]
+    assert [f.contributor for f in wip.fragments] == ["Aki", "Bo"]
+    assert wip.last_activity_ts == 2.0
+
+
+def test_rebuild_skips_empty_fragments(tmp_path: Path) -> None:
+    """A contribute event with no ``fragment`` payload (whitespace,
+    missing, None) is recorded for audit in episodic but does NOT
+    materialise as a Fragment on the projection.
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed_contribute(ep, actor="Aki", wip=target, fragment="", ts=1.0)
+        _seed_contribute(ep, actor="Bo", wip=target, fragment="   ", ts=2.0)
+        ep.append(
+            actor="Cy",
+            action="contribute",
+            target=target,
+            payload={"thought": "no fragment"},  # no 'fragment' key at all
+            ts=3.0,
+        )
+        _seed_contribute(ep, actor="Aki", wip=target, fragment="real", ts=4.0)
+        proj = WorkshopProjection(ep)
+    wip = next(w for w in proj.wips() if w.name == target)
+    assert [f.text for f in wip.fragments] == ["real"]
+
+
+def test_rebuild_ignores_non_contribute_actions(tmp_path: Path) -> None:
+    """Speak / craft / study / rest / travel events never produce
+    workshop fragments, even if their target is a configured WIP.
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        for action in ("speak", "craft", "study", "rest", "travel"):
+            ep.append(
+                actor="Aki",
+                action=action,
+                target=target,
+                payload={"fragment": "leak"},
+                ts=1.0,
+            )
+        proj = WorkshopProjection(ep)
+    wip = next(w for w in proj.wips() if w.name == target)
+    assert wip.fragments == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 2.2 — phase transitions (deterministic, table-driven)
+# ---------------------------------------------------------------------------
+
+
+def test_single_fragment_stays_forming(tmp_path: Path) -> None:
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed_contribute(ep, actor="Aki", wip=target, fragment="warp", ts=1.0)
+        proj = WorkshopProjection(ep)
+    wip = next(w for w in proj.wips() if w.name == target)
+    assert wip.phase == "forming"
+
+
+def test_two_contributors_promote_to_developing(tmp_path: Path) -> None:
+    """Phase transitions are deterministic: ``developing`` triggers
+    when the WIP has at least DEVELOPING_CONTRIBUTOR_FLOOR distinct
+    contributors OR at least DEVELOPING_FRAGMENT_FLOOR fragments.
+    Two contributors with one fragment each crosses the contributor
+    floor.
+    """
+    assert DEVELOPING_CONTRIBUTOR_FLOOR == 2
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed_contribute(ep, actor="Aki", wip=target, fragment="warp", ts=1.0)
+        _seed_contribute(ep, actor="Bo", wip=target, fragment="weft", ts=2.0)
+        proj = WorkshopProjection(ep)
+    wip = next(w for w in proj.wips() if w.name == target)
+    assert wip.phase == "developing"
+
+
+def test_many_fragments_from_one_contributor_promote_to_developing(tmp_path: Path) -> None:
+    """Fragment floor is the second route to developing — a single
+    contributor adding DEVELOPING_FRAGMENT_FLOOR fragments without
+    peers still advances the WIP.
+    """
+    assert DEVELOPING_FRAGMENT_FLOOR == 3
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        for i in range(DEVELOPING_FRAGMENT_FLOOR):
+            _seed_contribute(
+                ep, actor="Aki", wip=target, fragment=f"frag-{i}", ts=float(i)
+            )
+        proj = WorkshopProjection(ep)
+    wip = next(w for w in proj.wips() if w.name == target)
+    assert wip.phase == "developing"
+
+
+def test_complete_fragment_floor_triggers_complete(tmp_path: Path) -> None:
+    """The COMPLETE_FRAGMENT_FLOOR threshold ends the WIP; the
+    projection no longer accepts further fragments into this WIP.
+    """
+    assert COMPLETE_FRAGMENT_FLOOR > DEVELOPING_FRAGMENT_FLOOR
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        for i in range(COMPLETE_FRAGMENT_FLOOR):
+            actor = "Aki" if i % 2 == 0 else "Bo"
+            _seed_contribute(
+                ep, actor=actor, wip=target, fragment=f"frag-{i}", ts=float(i)
+            )
+        proj = WorkshopProjection(ep)
+    wip = next(w for w in proj.wips() if w.name == target)
+    assert wip.phase == "complete"
+    assert len(wip.fragments) == COMPLETE_FRAGMENT_FLOOR
+
+
+def test_post_complete_fragments_are_ignored(tmp_path: Path) -> None:
+    """A contribute event arriving after the WIP is already complete
+    does not append to that WIP. (Operators may wish to read it from
+    the event log audit; the projection is closed.)
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        # Fill to complete.
+        for i in range(COMPLETE_FRAGMENT_FLOOR):
+            actor = "Aki" if i % 2 == 0 else "Bo"
+            _seed_contribute(
+                ep, actor=actor, wip=target, fragment=f"frag-{i}", ts=float(i)
+            )
+        # One more after.
+        _seed_contribute(
+            ep, actor="Cy", wip=target, fragment="too-late",
+            ts=float(COMPLETE_FRAGMENT_FLOOR + 1),
+        )
+        proj = WorkshopProjection(ep)
+    wip = next(w for w in proj.wips() if w.name == target)
+    assert wip.phase == "complete"
+    assert len(wip.fragments) == COMPLETE_FRAGMENT_FLOOR
+    for f in wip.fragments:
+        assert f.text != "too-late"
+
+
+# ---------------------------------------------------------------------------
+# Slice 2.3 — stale_to_complete (clock-driven, no LLM)
+# ---------------------------------------------------------------------------
+
+
+def test_stale_to_complete_returns_names_past_timeout(tmp_path: Path) -> None:
+    """A WIP with non-zero fragments whose last_activity_ts is older
+    than ``timeout_s`` is returned by stale_to_complete. WIPs with no
+    activity at all (last_activity_ts == 0.0) are NOT considered
+    stale; they're untouched.
+    """
+    target_active = CONFIGURED_WIPS[0]
+    target_stale = CONFIGURED_WIPS[1]
+    now = time.time()
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed_contribute(ep, actor="Aki", wip=target_active, fragment="recent",
+                         ts=now - 10.0)
+        _seed_contribute(ep, actor="Bo", wip=target_stale, fragment="old",
+                         ts=now - 7200.0)  # 2 hours old
+        proj = WorkshopProjection(ep)
+    stale = proj.stale_to_complete(now_ts=now, timeout_s=3600.0)
+    assert target_stale in stale
+    assert target_active not in stale
+
+
+def test_stale_to_complete_skips_already_complete(tmp_path: Path) -> None:
+    """An already-complete WIP is not in the stale set — there is
+    nothing to transition.
+    """
+    target = CONFIGURED_WIPS[0]
+    now = time.time()
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        for i in range(COMPLETE_FRAGMENT_FLOOR):
+            actor = "Aki" if i % 2 == 0 else "Bo"
+            _seed_contribute(
+                ep, actor=actor, wip=target, fragment=f"frag-{i}",
+                ts=now - 7200.0 + i,
+            )
+        proj = WorkshopProjection(ep)
+    stale = proj.stale_to_complete(now_ts=now, timeout_s=3600.0)
+    assert target not in stale
+
+
+def test_stale_to_complete_skips_empty_wips(tmp_path: Path) -> None:
+    """WIPs with no fragments are not stale. Cold-start guard."""
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        proj = WorkshopProjection(ep)
+    stale = proj.stale_to_complete(now_ts=time.time() + 1e9, timeout_s=3600.0)
+    assert stale == []
+
+
+# ---------------------------------------------------------------------------
+# In-memory update path: on_contribute_event matches rebuild_from_episodic
+# ---------------------------------------------------------------------------
+
+
+def test_on_contribute_event_matches_rebuild(tmp_path: Path) -> None:
+    """``on_contribute_event`` is the hot-path called per-tick; it
+    must produce the same projection state as a cold rebuild from
+    the log so a process restart never changes what agents see.
+    """
+    target = CONFIGURED_WIPS[0]
+    events_data = [
+        ("Aki", target, "warp", 1.0),
+        ("Bo", target, "weft", 2.0),
+        ("Aki", target, "blue", 3.0),
+    ]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        proj_hot = WorkshopProjection(ep)
+        for actor, wip, fragment, ts in events_data:
+            _seed_contribute(ep, actor=actor, wip=wip, fragment=fragment, ts=ts)
+            # Fetch the most recent event and feed it.
+            recent = ep.last(1)[0]
+            proj_hot.on_contribute_event(recent)
+        proj_cold = WorkshopProjection(ep)
+
+    hot = next(w for w in proj_hot.wips() if w.name == target)
+    cold = next(w for w in proj_cold.wips() if w.name == target)
+    assert [(f.contributor, f.text) for f in hot.fragments] == [
+        (f.contributor, f.text) for f in cold.fragments
+    ]
+    assert hot.phase == cold.phase
+    assert hot.last_activity_ts == cold.last_activity_ts
+
+
+def test_wip_dataclass_exposes_contributors(tmp_path: Path) -> None:
+    """A WIP exposes its distinct contributor set in insertion order —
+    used by the per-receiver redaction in build_context.
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed_contribute(ep, actor="Aki", wip=target, fragment="a", ts=1.0)
+        _seed_contribute(ep, actor="Bo", wip=target, fragment="b", ts=2.0)
+        _seed_contribute(ep, actor="Aki", wip=target, fragment="c", ts=3.0)
+        proj = WorkshopProjection(ep)
+    wip: WIP = next(w for w in proj.wips() if w.name == target)
+    assert wip.contributors() == ("Aki", "Bo")

--- a/tests/test_workshop_projection.py
+++ b/tests/test_workshop_projection.py
@@ -109,8 +109,7 @@ def test_rebuild_collects_fragments_for_named_wip(tmp_path: Path) -> None:
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
         _seed_contribute(ep, actor="Aki", wip=target, fragment="rough warp", ts=1.0)
         _seed_contribute(ep, actor="Bo", wip=target, fragment="blue stitching", ts=2.0)
-        _seed_contribute(ep, actor="Aki", wip="workshop.does-not-exist",
-                         fragment="dropped", ts=3.0)
+        _seed_contribute(ep, actor="Aki", wip="workshop.does-not-exist", fragment="dropped", ts=3.0)
         proj = WorkshopProjection(ep)
     wip = next(w for w in proj.wips() if w.name == target)
     assert [f.text for f in wip.fragments] == ["rough warp", "blue stitching"]
@@ -199,9 +198,7 @@ def test_many_fragments_from_one_contributor_promote_to_developing(tmp_path: Pat
     target = CONFIGURED_WIPS[0]
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
         for i in range(DEVELOPING_FRAGMENT_FLOOR):
-            _seed_contribute(
-                ep, actor="Aki", wip=target, fragment=f"frag-{i}", ts=float(i)
-            )
+            _seed_contribute(ep, actor="Aki", wip=target, fragment=f"frag-{i}", ts=float(i))
         proj = WorkshopProjection(ep)
     wip = next(w for w in proj.wips() if w.name == target)
     assert wip.phase == "developing"
@@ -216,9 +213,7 @@ def test_complete_fragment_floor_triggers_complete(tmp_path: Path) -> None:
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
         for i in range(COMPLETE_FRAGMENT_FLOOR):
             actor = "Aki" if i % 2 == 0 else "Bo"
-            _seed_contribute(
-                ep, actor=actor, wip=target, fragment=f"frag-{i}", ts=float(i)
-            )
+            _seed_contribute(ep, actor=actor, wip=target, fragment=f"frag-{i}", ts=float(i))
         proj = WorkshopProjection(ep)
     wip = next(w for w in proj.wips() if w.name == target)
     assert wip.phase == "complete"
@@ -235,12 +230,13 @@ def test_post_complete_fragments_are_ignored(tmp_path: Path) -> None:
         # Fill to complete.
         for i in range(COMPLETE_FRAGMENT_FLOOR):
             actor = "Aki" if i % 2 == 0 else "Bo"
-            _seed_contribute(
-                ep, actor=actor, wip=target, fragment=f"frag-{i}", ts=float(i)
-            )
+            _seed_contribute(ep, actor=actor, wip=target, fragment=f"frag-{i}", ts=float(i))
         # One more after.
         _seed_contribute(
-            ep, actor="Cy", wip=target, fragment="too-late",
+            ep,
+            actor="Cy",
+            wip=target,
+            fragment="too-late",
             ts=float(COMPLETE_FRAGMENT_FLOOR + 1),
         )
         proj = WorkshopProjection(ep)
@@ -266,10 +262,10 @@ def test_stale_to_complete_returns_names_past_timeout(tmp_path: Path) -> None:
     target_stale = CONFIGURED_WIPS[1]
     now = time.time()
     with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
-        _seed_contribute(ep, actor="Aki", wip=target_active, fragment="recent",
-                         ts=now - 10.0)
-        _seed_contribute(ep, actor="Bo", wip=target_stale, fragment="old",
-                         ts=now - 7200.0)  # 2 hours old
+        _seed_contribute(ep, actor="Aki", wip=target_active, fragment="recent", ts=now - 10.0)
+        _seed_contribute(
+            ep, actor="Bo", wip=target_stale, fragment="old", ts=now - 7200.0
+        )  # 2 hours old
         proj = WorkshopProjection(ep)
     stale = proj.stale_to_complete(now_ts=now, timeout_s=3600.0)
     assert target_stale in stale
@@ -286,7 +282,10 @@ def test_stale_to_complete_skips_already_complete(tmp_path: Path) -> None:
         for i in range(COMPLETE_FRAGMENT_FLOOR):
             actor = "Aki" if i % 2 == 0 else "Bo"
             _seed_contribute(
-                ep, actor=actor, wip=target, fragment=f"frag-{i}",
+                ep,
+                actor=actor,
+                wip=target,
+                fragment=f"frag-{i}",
                 ts=now - 7200.0 + i,
             )
         proj = WorkshopProjection(ep)

--- a/tests/test_workshop_projection.py
+++ b/tests/test_workshop_projection.py
@@ -26,12 +26,12 @@ import pytest
 
 from microverse.memory.episodic import EpisodicMemory
 from microverse.world.workshop import (
-    CONFIGURED_WIPS,
-    DEVELOPING_FRAGMENT_FLOOR,
-    DEVELOPING_CONTRIBUTOR_FLOOR,
     COMPLETE_FRAGMENT_FLOOR,
-    Fragment,
+    CONFIGURED_WIPS,
+    DEVELOPING_CONTRIBUTOR_FLOOR,
+    DEVELOPING_FRAGMENT_FLOOR,
     WIP,
+    Fragment,
     WorkshopProjection,
 )
 

--- a/tests/test_workshop_view_redaction.py
+++ b/tests/test_workshop_view_redaction.py
@@ -1,0 +1,284 @@
+"""Phase 4 — per-receiver workshop_view in build_context.
+
+ADR 0003 Decision 1 (load-bearing per Codex): the WorldContext's
+``workshop_view`` is rendered *per-receiver*. The receiver's own
+prior fragment texts and own contributor name are redacted to
+anonymous markers; non-receiver contributors are named verbatim and
+their fragments rendered verbatim. This preserves Path-3's
+structural no-self-history guarantee for the new channel.
+
+Three slices:
+  * 4.1 — _build_workshop_view correctness on synthetic inputs.
+  * 4.2 — structural leak sweep parallel to PR #24's 897-sample sweep
+    (tests/test_no_autobiography.py).
+  * 4.3 — peer-fragment surface preservation (don't over-redact).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+from pathlib import Path
+
+import pytest
+
+from microverse.agents.base import WorldContext
+from microverse.memory import _build_workshop_view, build_context
+from microverse.memory.episodic import EpisodicMemory
+from microverse.memory.semantic import SemanticMemory
+from microverse.ops.metrics import Metrics
+from microverse.world.workshop import (
+    CONFIGURED_WIPS,
+    WIPView,
+    WorkshopProjection,
+)
+
+
+def _seed(ep: EpisodicMemory, *, actor: str, wip: str, fragment: str, ts: float) -> None:
+    ep.append(
+        actor=actor,
+        action="contribute",
+        target=wip,
+        payload={"thought": f"{actor} weaving", "fragment": fragment},
+        ts=ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema contract
+# ---------------------------------------------------------------------------
+
+
+def test_wip_view_is_frozen_dataclass() -> None:
+    v = WIPView(name="x", phase="forming", contributors="A, B", excerpt="hello")
+    assert dataclasses.is_dataclass(v)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        v.name = "y"  # type: ignore[misc]
+
+
+def test_world_context_default_workshop_view_is_empty_tuple() -> None:
+    world = WorldContext()
+    assert world.workshop_view == ()
+    assert isinstance(world.workshop_view, tuple)
+
+
+# ---------------------------------------------------------------------------
+# Slice 4.1 — _build_workshop_view correctness
+# ---------------------------------------------------------------------------
+
+
+def test_build_workshop_view_returns_one_view_per_configured_wip(tmp_path: Path) -> None:
+    """Even when a WIP has no fragments, it appears as a view so the
+    prompt sees the configured set of objects. Empty WIPs render
+    with an empty excerpt and empty contributors string.
+    """
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        proj = WorkshopProjection(ep)
+        views = _build_workshop_view(proj, agent_name="Aki", metrics=None)
+    assert len(views) == len(CONFIGURED_WIPS)
+    names = [v.name for v in views]
+    assert set(names) == set(CONFIGURED_WIPS)
+    for v in views:
+        assert v.phase == "forming"
+        assert v.excerpt == ""
+        assert v.contributors == ""
+
+
+def test_build_workshop_view_renders_other_contributors_verbatim(tmp_path: Path) -> None:
+    """When Bo contributes to a WIP and Aki is reading it, Bo's
+    name appears verbatim in the contributors string and Bo's
+    fragment text appears verbatim in the excerpt — community
+    knowledge is preserved.
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed(ep, actor="Bo", wip=target, fragment="blue stitching across the warp", ts=1.0)
+        proj = WorkshopProjection(ep)
+        views = _build_workshop_view(proj, agent_name="Aki", metrics=None)
+    view = next(v for v in views if v.name == target)
+    assert "Bo" in view.contributors
+    assert "blue stitching across the warp" in view.excerpt
+
+
+def test_build_workshop_view_redacts_receivers_own_fragments(tmp_path: Path) -> None:
+    """When Aki contributes a fragment and Aki later reads the WIP,
+    Aki's fragment text does NOT appear verbatim. The contributor
+    list does not contain Aki's name verbatim either.
+    """
+    target = CONFIGURED_WIPS[0]
+    signature_text = "signature-aki-fragment-distinctive"
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed(ep, actor="Aki", wip=target, fragment=signature_text, ts=1.0)
+        proj = WorkshopProjection(ep)
+        metrics = Metrics(":memory:")
+        views = _build_workshop_view(proj, agent_name="Aki", metrics=metrics)
+    view = next(v for v in views if v.name == target)
+    assert signature_text not in view.excerpt
+    # The placeholder marker fires (anonymous-contributor render).
+    assert "earlier contributor" in view.excerpt.lower()
+    # Aki's own name is masked.
+    assert "Aki" not in view.contributors
+    # Redaction metric bumps so operators can watch.
+    assert metrics.get("workshop_view_self_redactions", agent="Aki") >= 1
+
+
+def test_build_workshop_view_preserves_self_redaction_across_mixed_contribs(tmp_path: Path) -> None:
+    """A WIP with mixed contributors: Aki's fragments are redacted
+    for Aki; Bo's fragments remain. Order is preserved.
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed(ep, actor="Aki", wip=target, fragment="aki-frag-distinct-alpha", ts=1.0)
+        _seed(ep, actor="Bo", wip=target, fragment="bo-frag-distinct-beta", ts=2.0)
+        _seed(ep, actor="Aki", wip=target, fragment="aki-frag-distinct-gamma", ts=3.0)
+        proj = WorkshopProjection(ep)
+        views = _build_workshop_view(proj, agent_name="Aki", metrics=None)
+    view = next(v for v in views if v.name == target)
+    assert "aki-frag-distinct-alpha" not in view.excerpt
+    assert "aki-frag-distinct-gamma" not in view.excerpt
+    assert "bo-frag-distinct-beta" in view.excerpt
+    # Bo is named verbatim.
+    assert "Bo" in view.contributors
+
+
+def test_build_workshop_view_name_filter_is_case_insensitive_whole_word(tmp_path: Path) -> None:
+    """Aki vs Akihiko: the receiver-name filter matches only on whole
+    words. A peer named ``Akihiko`` whose fragments mention ``Akihiko``
+    should NOT be redacted when ``Aki`` is the receiver (the lore
+    redaction in build_context follows the same rule).
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _seed(ep, actor="Akihiko", wip=target, fragment="frag-by-akihiko", ts=1.0)
+        proj = WorkshopProjection(ep)
+        views = _build_workshop_view(proj, agent_name="Aki", metrics=None)
+    view = next(v for v in views if v.name == target)
+    assert "Akihiko" in view.contributors
+    assert "frag-by-akihiko" in view.excerpt
+
+
+# ---------------------------------------------------------------------------
+# Slice 4.2 — structural leak sweep parallel to PR #24
+# ---------------------------------------------------------------------------
+
+
+def _world_state_dump(world: WorldContext) -> str:
+    """Concatenate every text-bearing field of ``world`` — same
+    pattern as ``tests/test_no_autobiography.py::_world_state_dump``,
+    extended to include the new ``workshop_view`` excerpts and
+    contributors fields. If any of the receiver's own fragments
+    surface in any field, this dump catches it.
+    """
+    parts: list[str] = [
+        world.season,
+        world.weather,
+        *world.peers_today,
+    ]
+    for s in world.peer_inbox:
+        parts.append(s.speaker)
+        parts.append(s.utterance)
+    parts.extend(world.world_events)
+    parts.extend(world.lore_excerpt)
+    parts.append(world.engagement_hint)
+    if world.required_target is not None:
+        parts.append(world.required_target)
+    for v in world.workshop_view:
+        parts.append(v.name)
+        parts.append(v.phase)
+        parts.append(v.contributors)
+        parts.append(v.excerpt)
+    return "\n".join(parts)
+
+
+def test_structural_leak_sweep_no_self_fragments(tmp_path: Path) -> None:
+    """Seed 50 contribute events for Aki across the configured WIPs;
+    assert zero substring matches of any of Aki's fragment texts
+    when build_context is assembled for Aki.
+    """
+    base = time.time() - 60.0
+    with (
+        EpisodicMemory(tmp_path / "ep.sqlite") as ep,
+        SemanticMemory(tmp_path / "se.sqlite") as se,
+    ):
+        for i in range(50):
+            wip = CONFIGURED_WIPS[i % len(CONFIGURED_WIPS)]
+            _seed(
+                ep,
+                actor="Aki",
+                wip=wip,
+                fragment=f"signature-frag-zeta-{i}-aki-unique-marker",
+                ts=base + i * 0.1,
+            )
+        proj = WorkshopProjection(ep)
+        out = build_context(
+            world_base=WorldContext(),
+            episodic=ep,
+            semantic=se,
+            topic="",
+            receiver_name="Aki",
+            workshop=proj,
+        )
+    dump = _world_state_dump(out)
+    for i in range(50):
+        marker = f"signature-frag-zeta-{i}-aki-unique-marker"
+        assert marker not in dump, (
+            f"self workshop fragment {marker!r} leaked into context, "
+            f"dump head:\n{dump[:600]!r}"
+        )
+    # And the agent's own name does not appear in any workshop_view
+    # field (contributors / excerpt).
+    for v in out.workshop_view:
+        assert "Aki" not in v.contributors
+
+
+def test_structural_leak_sweep_peer_fragments_pass_through(tmp_path: Path) -> None:
+    """Slice 4.3: don't over-redact. When Bo contributes 50 times,
+    Aki sees Bo's fragments verbatim (community knowledge) but not
+    Aki's own (50 separately-seeded self fragments stay redacted).
+    """
+    base = time.time() - 60.0
+    with (
+        EpisodicMemory(tmp_path / "ep.sqlite") as ep,
+        SemanticMemory(tmp_path / "se.sqlite") as se,
+    ):
+        for i in range(50):
+            wip = CONFIGURED_WIPS[i % len(CONFIGURED_WIPS)]
+            _seed(ep, actor="Aki", wip=wip,
+                  fragment=f"aki-self-{i}", ts=base + i * 0.1)
+            _seed(ep, actor="Bo", wip=wip,
+                  fragment=f"bo-peer-{i}", ts=base + i * 0.1 + 0.01)
+        proj = WorkshopProjection(ep)
+        out = build_context(
+            world_base=WorldContext(),
+            episodic=ep,
+            semantic=se,
+            topic="",
+            receiver_name="Aki",
+            workshop=proj,
+        )
+    dump = _world_state_dump(out)
+    # No self fragment leaks.
+    for i in range(50):
+        assert f"aki-self-{i}" not in dump
+    # At least some peer fragments are visible (don't over-redact).
+    bo_visible = sum(1 for i in range(50) if f"bo-peer-{i}" in dump)
+    assert bo_visible > 0, "peer fragments should pass through community-knowledge"
+
+
+def test_workshop_view_off_when_no_workshop_passed(tmp_path: Path) -> None:
+    """``workshop`` is keyword-only; when not passed, build_context
+    returns workshop_view=(). Existing v0.1.1 callers (no Workshop)
+    keep working.
+    """
+    with (
+        EpisodicMemory(tmp_path / "ep.sqlite") as ep,
+        SemanticMemory(tmp_path / "se.sqlite") as se,
+    ):
+        out = build_context(
+            world_base=WorldContext(),
+            episodic=ep,
+            semantic=se,
+            topic="",
+            receiver_name="Aki",
+        )
+    assert out.workshop_view == ()

--- a/tests/test_workshop_view_redaction.py
+++ b/tests/test_workshop_view_redaction.py
@@ -222,8 +222,7 @@ def test_structural_leak_sweep_no_self_fragments(tmp_path: Path) -> None:
     for i in range(50):
         marker = f"signature-frag-zeta-{i}-aki-unique-marker"
         assert marker not in dump, (
-            f"self workshop fragment {marker!r} leaked into context, "
-            f"dump head:\n{dump[:600]!r}"
+            f"self workshop fragment {marker!r} leaked into context, dump head:\n{dump[:600]!r}"
         )
     # And the agent's own name does not appear in any workshop_view
     # field (contributors / excerpt).
@@ -243,10 +242,8 @@ def test_structural_leak_sweep_peer_fragments_pass_through(tmp_path: Path) -> No
     ):
         for i in range(50):
             wip = CONFIGURED_WIPS[i % len(CONFIGURED_WIPS)]
-            _seed(ep, actor="Aki", wip=wip,
-                  fragment=f"aki-self-{i}", ts=base + i * 0.1)
-            _seed(ep, actor="Bo", wip=wip,
-                  fragment=f"bo-peer-{i}", ts=base + i * 0.1 + 0.01)
+            _seed(ep, actor="Aki", wip=wip, fragment=f"aki-self-{i}", ts=base + i * 0.1)
+            _seed(ep, actor="Bo", wip=wip, fragment=f"bo-peer-{i}", ts=base + i * 0.1 + 0.01)
         proj = WorkshopProjection(ep)
         out = build_context(
             world_base=WorldContext(),


### PR DESCRIPTION
## Summary

- Implements all v0.2 code from the Codex-revised plan: `WorkshopProjection` derived from the episodic event log, `Action.contribute_to` + `CONTRIBUTE` action, per-receiver redacted `workshop_view` in `build_context`, persona templates rendering the workshop block, `Trader` v2 with rule-based WIP scoring, `Harvester` second mode draining completed WIPs with per-verb caps, and the disposition persona reshape.
- 393 passing tests (including a structural-leak sweep parallel to PR #24's 897-sample sweep, kill-safety drill for the projection across a SQLite reopen, and a Trader-feedback-invisibility sweep). Quality gate green (ruff, ruff format, mypy, pip-audit, pytest, uv build).
- **Do not merge yet.** This PR is gated on two operator-run soaks. See "Operator gates" below.

## Architecture (ADR 0003 — Proposed)

Three load-bearing decisions surfaced by Codex review of the plan, all encoded in the code:

1. **Per-receiver redacted workshop views.** A receiver never sees verbatim text of their own past fragments or their own contributor name in `WorldContext.workshop_view`. Peer contributors and their fragments pass through verbatim (community knowledge preserved). Path-3's structural no-self-history guarantee is extended to the new channel.
2. **Episodic event log is the sole authoritative write.** `WorkshopProjection` is a *derived* read-model. On restart the projection is rebuilt from the log — no separate WAL, no second commit surface. Inherits kill-safety from the existing episodic durability drill.
3. **Trader output never re-enters agent-visible context.** Trader v2 scoring is rule-based for WIPs (length, contributor-count, Jaccard novelty), LLM-driven only for single-tick artifacts. Per-verb caps and floors apply in the Harvester *after* ranking, not as upstream prompt signals. Tested by a parallel-PR-24 leak sweep.

Why this is not "Layer H" (per ADR 0002's closure of the Layer-patch pattern): the workshop adds a *new world affordance* the agent reaches via a new action verb; no prompt text coerces the action distribution. Persona reshape lands last as a consequence of the new affordance, not as a precursor.

## Operator gates (before merge)

This PR is **code-ready, soak-pending**. Two operator runs decide whether it merges:

### Gate 1 — Phase 0 measurement spike (branch `spike/workshop-view-measurement`)

Independent throwaway branch derisks the central mechanism claim ("conditioning the persona on an external evolving world object meaningfully shifts gemma4:e4b's verb attractor") BEFORE this code lands. Run on the spike branch, not this one.

```
git checkout spike/workshop-view-measurement
./scripts/spike_workshop_arms.sh A    # baseline, 4-6h
./scripts/spike_workshop_arms.sh B    # neutral WIP
./scripts/spike_workshop_arms.sh C    # peer-attributed WIP
./scripts/spike_workshop_arms.sh D    # self-redacted WIP
./scripts/spike_workshop_arms.sh E    # craft-heavy WIP (inversion control)
uv run python scripts/spike_workshop_measure.py
```

Halt criterion: across arms B/C/D, at least one must drop Aki craft-share below 75% AND at least one must raise median artifact length above 25 words. If neither: STOP, the mechanism is falsified, replan per ADR 0002 (model-swap or persona-only).

### Gate 2 — Final v0.2 acceptance soak (this branch)

After Gate 1 passes:

```
git checkout feat/v0.2-workshop
MICROVERSE_DATA=data/soak-24h-v0.2 MICROVERSE_HARVEST=harvest/soak-24h-v0.2 \
  nohup uv run python -m microverse.run --seed 38 --tempo 0 >soak-24h-v0.2.log 2>&1 &
```

Conjunctive halt criteria (per the v0.2 plan, mirroring ADR 0002):

- No single action exceeds 80% sustained 2 hr (relaxed from 70% — the metric now is verb-share inside `{craft, contribute}`, not action-share).
- Workshop produces >= 1 completed WIP per hour averaged.
- Manifest growth >= 200 lines/hr.
- Harvest acceptance rate within +/- 15% of v0.1.1 baseline.
- `workshop_view_self_redactions` metric is non-zero (redaction firing under load).

If acceptance soak passes: ADR 0003 → Accepted; merge; tag v0.2.0. If it fails: do NOT add Layer-style patches. ADR 0004 captures the failure mode; reconsider model-swap or scope.

## Test plan (already green here)

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy src/microverse`
- [x] `uv run pip-audit`
- [x] `uv run pytest -q -m 'not integration'` (393 passed, 2 integration deselected)
- [x] `uv build`
- [ ] Phase 0 measurement spike on `spike/workshop-view-measurement` (operator)
- [ ] Final 24h acceptance soak on this branch (operator)

## Codex review highlights

Codex critiqued the original v0.2 plan and surfaced three load-bearing revisions, all incorporated:

- A reader-side self-episodic-summarisation spike was incoherent against current v0.1.1 state (Path-3 already removed `recent_episodic`); reframed as the no-code factorial measurement spike that ships separately on `spike/workshop-view-measurement`.
- A WIP table with its own write surface would break kill-safety; redesigned as a pure projection over the event log with mandatory restart reconciliation.
- Without per-receiver redaction, the workshop becomes an autobiographical channel under a new name; per-receiver render is now enforced by a parallel-PR-24 structural-leak sweep.