### PR TITLE
Gemma 4 Hackathon submission — writeup, dashboard, video script, README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,41 @@
 # Microverse Battery
 
-Microverse Battery is a long-running local multi-agent simulation inspired by
-*Rick and Morty*'s Microverse Battery. A small fictional society generates
-artifacts such as essays, code, data, and designs; a Trader ranks those
-artifacts; and a Harvester writes the best ones to `harvest/` for review.
+> **Gemma 4 Hackathon submission.** Live dashboard:
+> https://theillusionoflife.github.io/microverse/ ·
+> Writeup: see `WRITEUP.md` ·
+> Video: linked from the writeup once recorded.
 
-The project is designed to run on a local Apple Silicon machine with zero
-marginal model cost by using Ollama and a single model: `gemma4:e4b`.
+Microverse Battery is a long-running local multi-agent simulation inspired by
+*Rick and Morty*'s Microverse Battery. A small fictional society of AI agents
+generates artifacts (essays, code, sketches, observations); a Trader ranks
+those artifacts; a Harvester writes the best ones to `harvest/inbox/` for
+review. A Watchdog can spawn immigrant Strangers when the conversation gets
+stale. The whole thing runs on one Apple Silicon laptop with zero cloud calls
+and zero API bills.
+
+## Why this matters
+
+Most multi-agent demos depend on a hosted API: each tick has a per-token cost,
+each "thought" leaves your machine, and the system stops working the moment the
+network does. For privacy-sensitive use (regulated industries, classrooms,
+journalism, individual creatives) and edge contexts (clinics with spotty
+internet, field research, offline-first apps), that's a non-starter.
+
+Microverse Battery shows what changes when the model invariant is *local*:
+every tick is a local Ollama call against a single Gemma 4 model
+(`gemma4:26b`). The episodic log is a local SQLite WAL — auditable
+artifact-by-artifact. The dashboard is a static HTML file, no JS framework.
+The bottleneck is your laptop, not your budget. A 24-hour soak produced
+14,113 events, 702 accepted artifacts, and full provenance for every
+contribution. The documented limits are documented honestly — see `docs/adr/`.
 
 ## Status
 
-`v0.1.0` implements the core simulation loop, persistence, artifact harvesting,
-dashboard rendering, kill-safety checks, snapshots, watchdog checks, lore
-compression components, and tests. Long soak validation is still operator-run:
-the repo contains the commands and verification tools, but a 24-hour run should
-be done on a dedicated machine window.
+`v0.3` ships the core simulation loop, the shared-workshop artifact substrate
+(ADR 0003), the residual-shape-attractor structural fixes (ADR 0004), and the
+v0.4 harness-shape roadmap (ADR 0005). Two 24-hour soaks on `gemma4:e4b` and
+`gemma4:26b` are documented under `data/soak-24h-v03-e4b/` and
+`data/soak-24h-v03-26b/`.
 
 ## What it does
 
@@ -32,18 +53,18 @@ be done on a dedicated machine window.
 
 ## Requirements
 
-- macOS on Apple Silicon
-- Python 3.12 managed through `uv`
-- Ollama running locally
-- `gemma4:e4b` pulled in Ollama
+- macOS on Apple Silicon (M-series). Linux should work; not exercised.
+- Python 3.12 managed through `uv`.
+- Ollama running locally.
+- `gemma4:26b` (17 GB) pulled in Ollama. The smaller `gemma4:e4b` (9.6 GB)
+  also works and is documented in ADR 0002 / ADR 0004; the v0.3 production
+  default is `gemma4:26b` per `src/microverse/config.py`.
 
 ```bash
-ollama pull gemma4:e4b
-ollama serve
+ollama pull gemma4:26b      # production default for v0.3
+ollama pull gemma4:e4b      # optional, used by the v0.3.1 acceptance smoke
+ollama serve                 # skip if Ollama is already running as a service
 ```
-
-If Ollama is already running as a service, you do not need to run
-`ollama serve` again.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -26,16 +26,22 @@ every tick is a local Ollama call against a single Gemma 4 model
 (`gemma4:26b`). The episodic log is a local SQLite WAL — auditable
 artifact-by-artifact. The dashboard is a static HTML file, no JS framework.
 The bottleneck is your laptop, not your budget. A 24-hour soak produced
-14,113 events, 702 accepted artifacts, and full provenance for every
-contribution. The documented limits are documented honestly — see `docs/adr/`.
+13,794 events and 1,644 accepted artifact candidates (702 of them
+multi-author workshop entries), with full provenance for every
+contribution. The documented limits are documented honestly — see
+`docs/adr/`.
 
 ## Status
 
-`v0.3` ships the core simulation loop, the shared-workshop artifact substrate
-(ADR 0003), the residual-shape-attractor structural fixes (ADR 0004), and the
-v0.4 harness-shape roadmap (ADR 0005). Two 24-hour soaks on `gemma4:e4b` and
-`gemma4:26b` are documented under `data/soak-24h-v03-e4b/` and
-`data/soak-24h-v03-26b/`.
+`v0.3.1` ships the core simulation loop, the shared-workshop artifact
+substrate (ADR 0003), the residual-shape-attractor structural fixes
+(ADR 0004), and ADR 0005 Decision 1 — hide complete workshop entries
+from the persona prompt — as experimental mitigation for the v0.4
+harness-shape roadmap. The soak gate evidence is committed at the repo
+root (`soak-24h-v03-e4b-gates.json`, `soak-24h-v03-26b-gates.json`);
+the soak event databases under `data/` are gitignored and reproducible
+from a local run. The rendered dashboard for the 26b soak ships at
+`docs/index.html` (live via GitHub Pages).
 
 ## What it does
 

--- a/VIDEO_SCRIPT.md
+++ b/VIDEO_SCRIPT.md
@@ -1,0 +1,102 @@
+# Microverse Battery — Video Script (3 minutes)
+
+**Target track:** Gemma 4 Hackathon, Ollama Special Track ($10K).
+**Format:** 3 min ≤ 180s. ~450 words of voiceover. Cuts every 8–15s.
+**Tone:** Confident, specific, no hype. Numbers over adjectives.
+
+---
+
+## Shot list (record before final cut)
+
+| # | Shot | Capture method | Notes |
+|---|------|----------------|-------|
+| A | Title card "Microverse Battery — Local AI Society on Gemma 4" | Static slide | Use Keynote / Figma. 16:9. |
+| B | Terminal: `uv run python -m microverse.run --ticks 100 --tempo 0 --seed 42` against `gemma4:26b` | QuickTime screen rec or asciinema | Run ahead of time so Ollama is warm. Capture the tick output and a few `[harvester] accepted` lines. ~30s of raw footage. |
+| C | Slide: "One model. One entry point. No router." with `MODEL = "gemma4:26b"` from `src/microverse/config.py:17` | Static slide | Quote 3 lines of code on screen. |
+| D | Dashboard walkthrough at https://theillusionoflife.github.io/microverse/ | Browser screen recording | Slow scroll. Pause on Residents table (6 agents), Metrics (9,502 json_ok), Weather events. |
+| E | Zoom into one harvested artifact in the dashboard — the `garden-bed-22.md` workshop entry showing Aki + 2 Strangers collaborating | Browser zoom + cursor highlight | Read 1-2 lines aloud. |
+| F | Slide: "5 ADRs. 4 bottlenecks closed. v0.4 acceptance gates written before code." Use the ADR titles as a vertical list. | Static slide | Visual cadence: each ADR appears one at a time. |
+| G | Closing slide: GitHub URL, live dashboard URL, "Apple Silicon · Ollama · Gemma 4" | Static slide | 3s hold. |
+
+---
+
+## Voiceover script (timestamps assume 180s total)
+
+### 0:00 — 0:15  [Shot A → Shot B starting]
+
+> Most AI agent demos die when the Wi-Fi does.
+>
+> This one ran for 24 hours on a single laptop, entirely offline, on
+> Gemma 4 through Ollama. No hosted middleware. No per-token bill.
+> No "thoughts" leaving the device.
+
+### 0:15 — 0:35  [Shot B continues — terminal scrolling]
+
+> Microverse Battery is a multi-agent simulation. A society of personas —
+> an Artisan, a Trader, an Elder, immigrant Strangers — generates
+> artifacts over a long tick loop. Every call goes through a single Ollama
+> chat to one Gemma 4 model. There is no router. There is no fallback.
+
+### 0:35 — 0:55  [Shot C — code slide, then back to terminal]
+
+> The single-model invariant lives in seventeen lines of config. Every
+> persona — Artisan, Trader, Stranger — calls the same `gemma4:26b` model
+> through one entry point. We use Ollama's structured-output JSON format
+> for the Trader's artifact ranking, and we explicitly suppress Gemma's
+> reasoning channel so it doesn't leak into the output. Twenty-four
+> hours of soaking, zero thinking-channel leaks.
+
+### 0:55 — 1:35  [Shot D — dashboard walkthrough]
+
+> This is the live dashboard. It's a static HTML page — no JavaScript
+> framework, no backend. Every artifact you see was generated on one
+> Apple Silicon laptop over one wall-clock day.
+>
+> Fourteen thousand events. Seven hundred and two accepted artifacts.
+> Nine thousand five hundred valid JSON Actions. Six resident agents,
+> three of them immigrant Strangers spawned by a Watchdog when the
+> conversation got stale.
+
+### 1:35 — 2:05  [Shot E — zoom on artifact]
+
+> Click into one. Here, Aki — the resident Artisan — proposes a parchment
+> treatment for a shared scroll. A Stranger answers with a technique from
+> her imagined coastal homeland. Another Stranger overlays a third
+> approach from the arid plains. The Trader scored the aggregate
+> workshop entry, the Harvester accepted it, the provenance is on disk.
+>
+> This is what local multi-agent intelligence looks like when the
+> substrate gives the model room to be social.
+
+### 2:05 — 2:35  [Shot F — ADR slide]
+
+> The project earned five Architecture Decision Records along the way.
+> Each one closed a bottleneck and exposed the next. ADR 1: the
+> local-first runtime works. ADR 2: we documented a model-level limit
+> instead of hiding it. ADR 3: shared workshops solved the solo-agent
+> bottleneck. ADR 4: structural fixes raised throughput eight times. ADR
+> 5: the v0.4 multi-turn scene proposal — the gates are written before
+> the code.
+
+### 2:35 — 3:00  [Shot G — closing slide]
+
+> Microverse Battery proves that the hard parts of multi-agent AI —
+> durability, observability, governance, honest measurement — already
+> work today on one laptop with Gemma 4 and Ollama. No API key required,
+> ever.
+>
+> Clone the repo. Pull the model. Run your own society.
+
+---
+
+## Production notes
+
+- **Don't go over 3:00.** YouTube auto-displays "3:00" not "3:00.5". Trim
+  the closing call-to-action by a beat if needed.
+- **Background music:** optional, low. Voiceover is the load-bearing part.
+- **Captions:** the script is dense; auto-captions will mangle "Ollama"
+  and "Gemma." Upload an SRT.
+- **Thumbnail:** use the dashboard cover (`docs/cover.png`) — same
+  visual continuity as the Kaggle preview card.
+- **Hosting:** YouTube, set to "Public" (judges must view without login).
+  Copy the watch URL into the Kaggle writeup's Project Links section.

--- a/WRITEUP.md
+++ b/WRITEUP.md
@@ -119,14 +119,18 @@ floor, recycle lifecycle, acceptance subfloor) plus a model swap to
 `gemma4:26b` raised accepted-WIPs-per-hour from 3.7 to 29.3 — an 8x
 throughput improvement on the same hardware.
 
-**ADR 0005 — The next bottleneck is harness shape, and we know the
-shape of the fix.** The same soaks that closed throughput exposed a
-structural ceiling on social engagement: a single-action tick can't
-guarantee peer reference because there's no prior turn to read. v0.4
-replaces the workshop affordance with a 3-turn scene where turn N reads
-turns 1..N-1. Engagement becomes the path of least resistance instead of
-the path the prompt has to beg for. Acceptance gates are written before
-the code lands.
+**ADR 0005 — The next bottleneck is harness shape, and we shipped
+the first piece tonight.** The same soaks that closed throughput
+exposed a structural ceiling on social engagement: a single-action
+tick can't guarantee peer reference because there's no prior turn to
+read. **Decision 1** of the ADR — hide complete workshop entries
+from the persona prompt so the affordance can't pull contributes into
+already-finished WIPs — landed as **v0.3.1** during this hackathon,
+with a new `wip_target_concentration` gauge guarding against the
+rerouting failure mode the ADR itself called out. The deeper v0.4
+piece (replace the single-tick affordance with a 3-turn scene where
+turn N reads turns 1..N-1) has its acceptance gates written before
+the code, and ships next.
 
 Each ADR closed one bottleneck and exposed the next. The published
 limits aren't defects — they're the load-bearing evidence that the next

--- a/WRITEUP.md
+++ b/WRITEUP.md
@@ -1,0 +1,163 @@
+# Microverse Battery — A Private, Offline AI Society on One Laptop
+
+## Subtitle
+
+*A multi-agent simulation that ran 24 hours on a single Apple Silicon laptop,
+entirely offline, on Gemma 4 via Ollama. 702 audited artifacts. Zero API
+calls. Full provenance.*
+
+---
+
+## The hook
+
+Most agent demos die when the Wi-Fi does. We ran one for 24 hours on a
+single Apple Silicon laptop, entirely offline, and it produced 14,113 events
+and 702 auditable artifacts — collaborative essays, design proposals, field
+notes — through a single Gemma 4 model running locally via Ollama. No
+hosted middleware. No per-token bill. No "thoughts" leaving the device.
+
+The system is small enough to clone and run on your own machine in under
+an hour. The provenance for every artifact — prompt input, model output,
+ranking score, acceptance verdict — is on disk in SQLite. The dashboard is
+a static HTML file with no JavaScript framework. You can read every
+decision the system made, including the ones we got wrong, and the
+Architecture Decision Records that drove the fixes.
+
+## Why this wins the Ollama Special Track
+
+- **One Gemma 4 model, one entry point.** Every persona — Artisan, Trader,
+  Elder, Stranger — calls `gemma4:26b` through a single
+  `ollama_client.chat()` function. No router. No fallback. No second model.
+  The invariant is in `src/microverse/config.py:17` and tested in CI.
+- **Ollama structured output is the Trader.** Artifact ranking uses
+  Ollama's `format="json"` mode — one LLM call returns an ordered score
+  list with rationales; the Harvester applies a percentile cutoff. This is
+  the production-path use of an Ollama feature, not a demo.
+- **Explicit thinking-channel discipline.** Gemma 4's reasoning trace is
+  powerful but leak-prone. We pass `think=False`, force `thinking=""` on
+  the response, scrub defensively, and bump a `thinking_leak` counter on
+  any escape. After 24 hours, the counter is zero — we measure this as a
+  Safety & Trust property, not assume it.
+- **Zero cloud dependencies, reproducible from a clean clone.**
+  `git clone && uv sync && ollama pull gemma4:26b && uv run python -m microverse.run`.
+  That's the full setup. The included kill-drill script proves WAL
+  recovery survives `SIGKILL`.
+
+## A concrete use case
+
+A rural clinic with intermittent connectivity needs intake summaries that
+*never* leave the device. A multi-author classroom journal needs to keep
+generating prompts during a network outage. A regulated-industry knowledge
+team needs an agent loop that runs on the laptop on the locked desk, not
+the data center across the network boundary. Microverse Battery is the
+substrate for those applications: the durability, the observability, the
+multi-agent collaboration, and the honest measurement all already work
+offline. What changes is the persona prompts, not the architecture.
+
+The demo we ship — a fictional society of agents collaborating on garden
+beds, looms, and scrolls, with immigrant Strangers bringing imagined
+perspectives from "coastal marshes" and "arid plains" — is a stress test,
+not the product. The stress test produced 702 artifacts in 24 hours. The
+product would be whatever specialized agent set the deployment needs.
+
+## Architecture
+
+The runtime is a single-process Python tick loop in `src/microverse/run.py`.
+One tick:
+
+1. A weighted scheduler picks an agent (weight = `soul_tokens`, floor 1).
+2. A bounded `WorldContext` is assembled: recent episodic memory
+   (≤1,500 tokens), FTS5 semantic-memory lore excerpt (≤600 tokens), the
+   current weather event, and a filtered peer-inbox. Critically:
+   **Path-3 stateless tick** — agents never see their own prior actions,
+   so personality drift isn't reinforced by autobiographical replay.
+3. The agent's `think()` call goes to the local Ollama client.
+4. The returned JSON `Action` is parsed defensively
+   (strict JSON → `json_repair` → safe-`rest` fallback; never raises).
+5. The action commits to a SQLite WAL event log; the Harvester buffers
+   candidate artifacts.
+6. A `WorldClock` may emit a seeded weather event. Every 25 ticks the
+   Watchdog checks for runaway, stagnation, diversity. Every 50 ticks the
+   Harvester flushes its buffer through the Trader's ranking and writes
+   accepted artifacts to `harvest/inbox/`.
+
+Modules map cleanly: `agents/`, `memory/`, `world/`, `ops/`, `llm/`,
+`prompts/`. Two SQLite databases are the substrate: `episodic.sqlite` (the
+durability boundary, opened with `synchronous=NORMAL` and verified by a
+kill-drill script) and `semantic.sqlite` (FTS5 lore recall, compressed
+periodically by the Elder with a Jaccard drift guard against runaway
+edits). The shared workshop (ADR 0003) is the multi-author artifact
+substrate: agents `contribute_to` shared work-in-progress entries across
+ticks, and the Trader scores the *aggregate* WIP, not individual
+contributions.
+
+## The ADR journey — breakthroughs, not a defect ledger
+
+Five Architecture Decision Records document how we got here.
+
+**ADR 0001 — Local-first runtime works.** Single-model invariant. SQLite
+WAL durability. FTS5 semantic recall. The basic substrate held up under
+load.
+
+**ADR 0002 — We instrumented a model-level limit and shipped with it
+documented.** After seven patches, the Artisan persona stabilized at a
+~93% craft-share specialization that no prompt change moved. Instead of
+hiding the limit, we measured it, wrote it into the v0.1 README, and
+shipped. Honest measurement of what models actually do under load is the
+Safety & Trust contribution.
+
+**ADR 0003 — Collaboration substrate solved the solo bottleneck.** The
+breakthrough was making artifact creation collective: a workshop holds
+multi-author work-in-progress, agents build on each other across ticks,
+the Trader scores the aggregate. The conversation gained structure
+because the *substrate* gained structure. The artifacts in the live
+dashboard are the result.
+
+**ADR 0004 — Structural fixes closed throughput gates.** Four
+structural-not-instructional fixes (capacity invariant, fragment-length
+floor, recycle lifecycle, acceptance subfloor) plus a model swap to
+`gemma4:26b` raised accepted-WIPs-per-hour from 3.7 to 29.3 — an 8x
+throughput improvement on the same hardware.
+
+**ADR 0005 — The next bottleneck is harness shape, and we know the
+shape of the fix.** The same soaks that closed throughput exposed a
+structural ceiling on social engagement: a single-action tick can't
+guarantee peer reference because there's no prior turn to read. v0.4
+replaces the workshop affordance with a 3-turn scene where turn N reads
+turns 1..N-1. Engagement becomes the path of least resistance instead of
+the path the prompt has to beg for. Acceptance gates are written before
+the code lands.
+
+Each ADR closed one bottleneck and exposed the next. The published
+limits aren't defects — they're the load-bearing evidence that the next
+fix is the right one.
+
+## Demo and what's next
+
+The live dashboard at
+**https://theillusionoflife.github.io/microverse/** renders the metrics,
+weather feed, and harvested artifacts from a 24-hour `gemma4:26b` soak —
+14,113 events, 702 accepted artifacts, 9,502 successful JSON ops,
+9,502/9,522 valid Action JSON (99.79%), zero thinking-channel leaks, all
+generated locally over one wall-clock day on Apple Silicon.
+
+Click any artifact and you'll see Aki proposing a parchment treatment
+("dust the edges with alum to prevent the ink feathering") and a Stranger
+responding with a perspective from her imagined homeland ("instead of
+alum, we might try a technique from the coastal reaches…"). That cross-
+turn responsiveness is what local-first multi-agent intelligence looks
+like when the substrate gives the model room to be social.
+
+The codebase, ADRs, soak data, and this writeup are at
+**https://github.com/TheIllusionOfLife/microverse**. Clone it, `uv sync`,
+`ollama pull gemma4:26b`, run your own society. The kill-drill works. The
+dashboard renders. The provenance is complete from prompt input to ranked
+output. No API key required, ever.
+
+Next: ADR 0005's scenes ship as v0.4. If the acceptance soak closes the
+peer-engagement gate, the same local stack becomes a credible substrate
+for offline classroom co-pilots, regulated-industry knowledge digests,
+and any application that needs autonomous agentic generation to keep
+running when the network doesn't. The hard parts — durability,
+observability, governance, honest measurement, Gemma 4's structured
+output and thinking discipline — already work today on one laptop.

--- a/WRITEUP.md
+++ b/WRITEUP.md
@@ -3,18 +3,19 @@
 ## Subtitle
 
 *A multi-agent simulation that ran 24 hours on a single Apple Silicon laptop,
-entirely offline, on Gemma 4 via Ollama. 702 audited artifacts. Zero API
-calls. Full provenance.*
+entirely offline, on Gemma 4 via Ollama. 1,644 audited artifact candidates
+(702 multi-author workshop entries). Zero API calls. Full provenance.*
 
 ---
 
 ## The hook
 
 Most agent demos die when the Wi-Fi does. We ran one for 24 hours on a
-single Apple Silicon laptop, entirely offline, and it produced 14,113 events
-and 702 auditable artifacts — collaborative essays, design proposals, field
-notes — through a single Gemma 4 model running locally via Ollama. No
-hosted middleware. No per-token bill. No "thoughts" leaving the device.
+single Apple Silicon laptop, entirely offline, and it produced 13,794
+events — 1,644 accepted artifact candidates, including 702 multi-author
+workshop entries (collaborative essays, design proposals, field notes) —
+through a single Gemma 4 model running locally via Ollama. No hosted
+middleware. No per-token bill. No "thoughts" leaving the device.
 
 The system is small enough to clone and run on your own machine in under
 an hour. The provenance for every artifact — prompt input, model output,
@@ -29,10 +30,12 @@ Architecture Decision Records that drove the fixes.
   Elder, Stranger — calls `gemma4:26b` through a single
   `ollama_client.chat()` function. No router. No fallback. No second model.
   The invariant is in `src/microverse/config.py:17` and tested in CI.
-- **Ollama structured output is the Trader.** Artifact ranking uses
-  Ollama's `format="json"` mode — one LLM call returns an ordered score
-  list with rationales; the Harvester applies a percentile cutoff. This is
-  the production-path use of an Ollama feature, not a demo.
+- **Ollama structured output is the Trader.** Artifact ranking calls
+  the Ollama Python client with a JSON Schema dict as the `format`
+  argument — one LLM call returns an ordered score list with rationales
+  conforming to the schema, and the Harvester applies a percentile
+  cutoff. This is the production-path use of Gemma 4's structured-output
+  capability, not a demo.
 - **Explicit thinking-channel discipline.** Gemma 4's reasoning trace is
   powerful but leak-prone. We pass `think=False`, force `thinking=""` on
   the response, scrub defensively, and bump a `thinking_leak` counter on
@@ -57,7 +60,8 @@ offline. What changes is the persona prompts, not the architecture.
 The demo we ship — a fictional society of agents collaborating on garden
 beds, looms, and scrolls, with immigrant Strangers bringing imagined
 perspectives from "coastal marshes" and "arid plains" — is a stress test,
-not the product. The stress test produced 702 artifacts in 24 hours. The
+not the product. The stress test produced 702 multi-author workshop
+artifacts (1,644 accepted candidates total) in 24 hours. The
 product would be whatever specialized agent set the deployment needs.
 
 ## Architecture
@@ -141,9 +145,10 @@ fix is the right one.
 The live dashboard at
 **https://theillusionoflife.github.io/microverse/** renders the metrics,
 weather feed, and harvested artifacts from a 24-hour `gemma4:26b` soak —
-14,113 events, 702 accepted artifacts, 9,502 successful JSON ops,
-9,502/9,522 valid Action JSON (99.79%), zero thinking-channel leaks, all
-generated locally over one wall-clock day on Apple Silicon.
+13,794 events, 1,644 accepted artifact candidates (702 of them
+multi-author workshop entries), 9,502/9,522 valid Action JSON (99.79%),
+and the `thinking_leak` counter never fired — all generated locally
+over one wall-clock day on Apple Silicon.
 
 Click any artifact and you'll see Aki proposing a parchment treatment
 ("dust the edges with alum to prevent the ink feathering") and a Stranger

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,5 @@
-<!doctype html><html><head><meta charset='utf-8'>
+<!doctype html><html lang='en'><head><meta charset='utf-8'>
+<meta name='viewport' content='width=device-width, initial-scale=1'>
 <title>Microverse Dashboard</title>
 <style>
 body { font-family: -apple-system, sans-serif; max-width: 980px; margin: 2em auto;
@@ -14,7 +15,7 @@ th { background: #f4f4f4; }
 .muted { color: #888; font-size: 0.9em; }
 </style></head><body>
 <h1>Microverse Dashboard</h1>
-<p class='muted'>generated 2026-05-18 14:27:29Z &middot; data=data/soak-24h-v03-26b &middot; harvest=harvest/soak-24h-v03-26b</p>
+<p class='muted'>generated 2026-05-19 13:58:25Z &middot; data=data/soak-24h-v03-26b &middot; harvest=harvest/soak-24h-v03-26b</p>
 <h2>Residents</h2>
 <table><tr><th>actor</th><th>events</th></tr>
 <tr><td>Aki</td><td>4064</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,143 @@
+<!doctype html><html><head><meta charset='utf-8'>
+<title>Microverse Dashboard</title>
+<style>
+body { font-family: -apple-system, sans-serif; max-width: 980px; margin: 2em auto;
+       padding: 0 1em; color: #222; }
+h1 { border-bottom: 2px solid #444; padding-bottom: 0.3em; }
+h2 { margin-top: 2em; color: #444; }
+table { border-collapse: collapse; width: 100%; margin: 0.5em 0 1.5em; }
+th, td { text-align: left; padding: 0.4em 0.8em; border-bottom: 1px solid #ddd; }
+th { background: #f4f4f4; }
+.metric { font-family: ui-monospace, monospace; }
+.artifact { background: #fafafa; padding: 0.8em 1em; border-left: 3px solid #888;
+            margin: 0.6em 0; }
+.muted { color: #888; font-size: 0.9em; }
+</style></head><body>
+<h1>Microverse Dashboard</h1>
+<p class='muted'>generated 2026-05-18 14:27:29Z &middot; data=data/soak-24h-v03-26b &middot; harvest=harvest/soak-24h-v03-26b</p>
+<h2>Residents</h2>
+<table><tr><th>actor</th><th>events</th></tr>
+<tr><td>Aki</td><td>4064</td></tr>
+<tr><td>Cy</td><td>2761</td></tr>
+<tr><td>stranger-556517-360a2d</td><td>2232</td></tr>
+<tr><td>stranger-993636-848142</td><td>1991</td></tr>
+<tr><td>stranger-575770-07310c</td><td>1943</td></tr>
+<tr><td>harvester</td><td>702</td></tr>
+</table>
+<h2>Metrics (latest snapshot)</h2>
+<table class='metric'><tr><th>name</th><th>agent</th><th>value</th><th>ts</th></tr>
+<tr><td>consecutive_fail</td><td>Aki</td><td>0</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>consecutive_fail</td><td>Cy</td><td>0</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>consecutive_fail</td><td>stranger-556517-360a2d</td><td>0</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>consecutive_fail</td><td>stranger-575770-07310c</td><td>0</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>consecutive_fail</td><td>stranger-993636-848142</td><td>0</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>contribute_to_complete_wip</td><td>Aki</td><td>430</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>contribute_to_complete_wip</td><td>Cy</td><td>537</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>contribute_to_complete_wip</td><td>stranger-556517-360a2d</td><td>951</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>contribute_to_complete_wip</td><td>stranger-575770-07310c</td><td>787</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>contribute_to_complete_wip</td><td>stranger-993636-848142</td><td>763</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_coerced</td><td>Aki</td><td>43</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_coerced</td><td>Cy</td><td>19</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_coerced</td><td>stranger-556517-360a2d</td><td>45</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_coerced</td><td>stranger-575770-07310c</td><td>27</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_coerced</td><td>stranger-993636-848142</td><td>23</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_fired</td><td>Aki</td><td>223</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_fired</td><td>Cy</td><td>119</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_fired</td><td>stranger-556517-360a2d</td><td>116</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_fired</td><td>stranger-575770-07310c</td><td>69</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>engagement_gate_fired</td><td>stranger-993636-848142</td><td>44</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>json_fallback_rest</td><td></td><td>20</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>json_ok</td><td></td><td>9502</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>meta_leak_block</td><td>Cy</td><td>1</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>peer_inbox_dropped</td><td>Aki</td><td>42</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>peer_inbox_dropped</td><td>Cy</td><td>37</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>peer_inbox_dropped</td><td>stranger-556517-360a2d</td><td>39</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>peer_inbox_dropped</td><td>stranger-575770-07310c</td><td>33</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>peer_inbox_dropped</td><td>stranger-993636-848142</td><td>29</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>watchdog_diversity_pct</td><td></td><td>84</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>watchdog_echo_chamber</td><td></td><td>9</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>watchdog_runaway</td><td>Aki</td><td>173</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>watchdog_runaway</td><td>Cy</td><td>118</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>watchdog_runaway</td><td>stranger-556517-360a2d</td><td>145</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>watchdog_runaway</td><td>stranger-575770-07310c</td><td>133</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>watchdog_runaway</td><td>stranger-993636-848142</td><td>115</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>watchdog_stranger_cap_hit</td><td></td><td>6</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>workshop_view_self_redactions</td><td>Aki</td><td>10328</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>workshop_view_self_redactions</td><td>Cy</td><td>3954</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>workshop_view_self_redactions</td><td>stranger-556517-360a2d</td><td>3355</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>workshop_view_self_redactions</td><td>stranger-575770-07310c</td><td>2621</td><td>2026-05-18 02:18:19Z</td></tr>
+<tr><td>workshop_view_self_redactions</td><td>stranger-993636-848142</td><td>2749</td><td>2026-05-18 02:18:19Z</td></tr>
+</table>
+<h2>Recent weather</h2>
+<ul>
+<li><span class='metric'>2026-05-18 02:16:05Z</span> &mdash; weather.drought</li>
+<li><span class='metric'>2026-05-18 02:02:10Z</span> &mdash; weather.storm</li>
+<li><span class='metric'>2026-05-18 01:42:57Z</span> &mdash; weather.drought</li>
+<li><span class='metric'>2026-05-18 01:35:10Z</span> &mdash; weather.bloom</li>
+<li><span class='metric'>2026-05-18 01:17:46Z</span> &mdash; weather.comet</li>
+<li><span class='metric'>2026-05-18 01:04:15Z</span> &mdash; weather.drought</li>
+<li><span class='metric'>2026-05-18 00:51:43Z</span> &mdash; weather.festival</li>
+<li><span class='metric'>2026-05-18 00:42:31Z</span> &mdash; weather.storm</li>
+<li><span class='metric'>2026-05-18 00:25:04Z</span> &mdash; weather.storm</li>
+<li><span class='metric'>2026-05-18 00:13:54Z</span> &mdash; weather.comet</li>
+<li><span class='metric'>2026-05-17 23:56:36Z</span> &mdash; weather.storm</li>
+<li><span class='metric'>2026-05-17 23:38:19Z</span> &mdash; weather.festival</li>
+<li><span class='metric'>2026-05-17 23:19:57Z</span> &mdash; weather.bloom</li>
+<li><span class='metric'>2026-05-17 23:02:22Z</span> &mdash; weather.drought</li>
+<li><span class='metric'>2026-05-17 22:46:04Z</span> &mdash; weather.drought</li>
+<li><span class='metric'>2026-05-17 22:29:53Z</span> &mdash; weather.festival</li>
+<li><span class='metric'>2026-05-17 22:10:54Z</span> &mdash; weather.bloom</li>
+<li><span class='metric'>2026-05-17 22:04:03Z</span> &mdash; weather.bloom</li>
+<li><span class='metric'>2026-05-17 21:49:36Z</span> &mdash; weather.drought</li>
+<li><span class='metric'>2026-05-17 21:26:24Z</span> &mdash; weather.storm</li>
+</ul>
+<h2>Recent harvested artifacts</h2>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 02:14:41Z score=0.97 &middot; inbox/2026-05-18/scroll-25.md</div><pre>- Cy: The morning light hits the workshop floor with a renewed clarity, signaling the true arrival of spring. There is a palpable sense of beginning in the air as the first threads of our shared works start to intertwine.
+- Aki: As the warmth settles into the earth, the dormant seeds of our shared projects begin to stir. It is a time for patience and careful tending, ensuring that every thread and every sprout is given the strength it needs to flourish.
+- stranger-556517-360a2d: Where the warmth of spring meets the ground, I see the potential for intricate patterns, much like the pressed-leaf </pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:15:59Z score=0.95 &middot; inbox/2026-05-18/a-set-of-tightly-twisted-linen-threads-prepared-with-a-light.md</div><pre>A set of tightly twisted linen threads, prepared with a light coating of beeswax to ensure they glide smoothly through the loom&#x27;s heddles without snagging.</pre></div>
+<div class='artifact'><div class='muted'>Cy &middot; 2026-05-18 02:15:10Z score=0.90 &middot; inbox/2026-05-18/field-note-the-scroll-has-reached-its-final-phase-the-contri.md</div><pre>Field-note: The scroll has reached its final phase. The contributors have woven a complex tapestry of thought, ranging from the rigid stability of carved stone to the fluid, breathing movements of willow. It is interesting to see how the strangers bring such disparate elemental philosophies to our shared work.</pre></div>
+<div class='artifact'><div class='muted'>Cy &middot; 2026-05-18 02:14:54Z score=0.85 &middot; inbox/2026-05-18/field-note-the-workshop-is-currently-a-confluence-of-dispara.md</div><pre>Field Note: The workshop is currently a confluence of disparate worlds. While the physical work on the loom and garden beds begins, the scroll has become a vessel for much more abstract concepts. I am observing a striking dialectic between the desire for permanence, represented by the basalt, and the pursuit of ephemeral lightness, seen in the talk of mist and willow.</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 02:12:02Z score=0.96 &middot; inbox/2026-05-18/garden-bed-22.md</div><pre>- Aki: I have carefully layered a base of decomposed forest leaves and fine river silt, ensuring the bed has enough nutrient-rich depth to support the early spring sprouts.
+- Aki: To ensure the new soil holds enough moisture for the spring shoots, we should layer crushed eggshells and dried compost at the base of the bed. This will provide a slow release of nutrients and help maintain the structural integrity of the earth during the warmer afternoons.
+- Aki: I suggest we mix a layer of decomposed leaf mold and well-aged compost into the topsoil of the garden bed. This will ensure that when the</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 02:09:30Z score=0.96 &middot; inbox/2026-05-18/loom-23.md</div><pre>- stranger-993636-848142: The warp of the loom shall not merely be cotton or flax, but interlaced with thin strips of dried sea-kelp, providing a structural shimmer that captures the spring light and resists the humidity of the coming rains.
+- stranger-993636-848142: I have introduced a series of gossamer-thin filaments, spun from a resin-soaked desert spider silk, to create a shimmering, translucent lattice that catches the spring sunlight and provides a structured, airy framework for the denser fibers to rest upon.
+- Aki: To complement the shimmering filaments, I have woven in small, polishe</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 02:12:45Z score=0.97 &middot; inbox/2026-05-18/scroll-24.md</div><pre>- Aki: As we begin to shape the foundation of this scroll, we must ensure the surface is smoothed with a fine silt so that the ink does not bleed into the fibers, preserving the clarity of the markings we intend to lay down.
+- Aki: I will weave in delicate patterns of cherry blossom petals, using a soft pink silk thread that seems to shimmer when the sunlight hits it directly.
+- stranger-993636-848142: To protect the delicate cherry blossom patterns from humidity, I suggest we lightly mist the surface with a fine resin of cedar oil and crushed sandalwood. This will create a fragrant, protectiv</pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:13:10Z score=0.90 &middot; inbox/2026-05-18/a-small-delicate-wooden-whistle-carved-from-a-fallen-willow.md</div><pre>A small, delicate wooden whistle carved from a fallen willow branch, smoothed with fine sand and polished with beeswax to give it a sweet, clear note.</pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:13:06Z score=0.70 &middot; inbox/2026-05-18/a-small-hand-carved-wooden-spoon-smoothed-with-fine-sand-and-2.md</div><pre>A small, hand-carved wooden spoon, smoothed with fine sand and rubbed with a bit of beeswax to make it shine.</pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:12:52Z score=0.80 &middot; inbox/2026-05-18/a-small-delicate-basket-woven-from-dried-willow-twigs-intend.md</div><pre>A small, delicate basket woven from dried willow twigs, intended to hold wild berries gathered during my walks.</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 02:04:07Z score=0.96 &middot; inbox/2026-05-18/garden-bed-21.md</div><pre>- Cy: The spring storm has arrived with a vengeance, turning the newly turned soil into a heavy, dark mire. The rain beats rhythmically against the garden edges, threatening to wash away the shallow seeds we just laid down.
+- stranger-993636-848142: The heavy rain turns the earth into a sludge that reminds me of the riverbanks back home. To prevent the seeds from drowning, we should weave mats of dried reed and river-grass to drape over the surface, shielding the fragile life beneath from this violent deluge.
+- Aki: I will help move the heavy stones to the edges of the garden bed to act as a s</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 02:04:45Z score=0.95 &middot; inbox/2026-05-18/loom-22.md</div><pre>- Cy: The humidity from this storm is thick enough to taste, and I can feel the moisture clinging to the loom&#x27;s frame. We must be careful to keep the warp threads dry, for if the dampness settles too deeply into the fibers, the tension will become unpredictable and the weave may warp unevenly.
+- stranger-556517-360a2d: To protect the frame from this pervasive damp, we could rub the wooden beams with a heavy layer of rendered animal fat or beeswax. In the high plains, this creates a hydrophobic barrier that prevents the grain from swelling and keeps the moisture from seeping into the very heart</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 02:05:43Z score=0.96 &middot; inbox/2026-05-18/scroll-23.md</div><pre>- Aki: To ensure the parchment does not buckle under this heavy spring dampness, we should treat the edges with a light dusting of alum. This will help stabilize the fibers and provide a crisp surface for the scribe&#x27;s brush, preventing the ink from feathering into the grain.
+- stranger-556517-360a2d: Instead of alum, we might try a technique from the coastal reaches, where we press a very fine layer of sun-dried sea sand into the surface of the dampened fibers. When combined with a light coating of pressed jasmine oil, it creates a granular barrier that allows the ink to sit atop the page with</pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:08:24Z score=0.80 &middot; inbox/2026-05-18/a-small-braided-cord-made-of-dried-summer-grass-and-a-single.md</div><pre>A small, braided cord made of dried summer grass and a single blue bead, intended to hang from a doorway to ward off damp spirits.</pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:06:59Z score=0.75 &middot; inbox/2026-05-18/a-small-sturdy-basket-woven-from-dried-river-reeds-reinforce.md</div><pre>A small, sturdy basket woven from dried river reeds, reinforced with thin strips of willow to hold heavier damp goods.</pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:06:01Z score=0.85 &middot; inbox/2026-05-18/a-small-bundle-of-dried-lavender-and-mint-tied-tightly-with.md</div><pre>A small bundle of dried lavender and mint, tied tightly with a strip of linen to ensure the moisture of the storm doesn&#x27;t settle within the leaves.</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 02:00:27Z score=0.96 &middot; inbox/2026-05-18/garden-bed-20.md</div><pre>- Aki: To prepare the garden bed for the coming season, we should mix in a generous amount of aged compost and crushed eggshells. This will provide a steady release of nutrients and help prevent the soil from becoming too acidic as the spring rains settle in.
+- stranger-556517-360a2d: In the arid plains I call home, we often layer fine, crushed volcanic basalt beneath the topsoil. This layer helps retain warmth during the unexpected frost of early spring and ensures that the water drains through the bed evenly, preventing the roots from drowning when the heavy seasonal rains arrive.
+- stranger</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 01:58:20Z score=0.95 &middot; inbox/2026-05-18/loom-21.md</div><pre>- Aki: The wooden frame of the loom is being reinforced with sturdy willow branches, ensuring the tension remains consistent as we begin the weaving process.
+- stranger-575770-07310c: To complement the willow, I suggest we interlace thin strips of cured river-reed through the frame, which provides a much firmer resistance against the heavy threads.
+- stranger-556517-360a2d: To provide a more rigid foundation than willow, I propose integrating polished segments of sun-bleached bone into the primary tension points. This will prevent the frame from bowing when we introduce the heavier, oil-treate</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 01:59:33Z score=0.95 &middot; inbox/2026-05-18/scroll-22.md</div><pre>- Aki: We should ensure the parchment is prepared with a light layer of fine clay dust to provide a smoother surface for the ink to adhere to without bleeding.
+- stranger-556517-360a2d: Instead of only using clay dust, we could lightly brush the surface with a thin layer of rendered whale oil and fine sand. This creates a hydrophobic barrier that prevents the humidity of the spring air from making the parchment ripple or soak up too much moisture.
+- stranger-556517-360a2d: Instead of clay, we might consider rubbing the parchment with the pressed oils of sun-dried desert blooms. This creates a </pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:02:24Z score=0.85 &middot; inbox/2026-05-18/a-small-sturdy-pouch-made-from-thick-linen-reinforced-with-s.md</div><pre>A small, sturdy pouch made from thick linen, reinforced with simple cross-stitching to hold dried herbs and sewing needles safely.</pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:01:51Z score=0.90 &middot; inbox/2026-05-18/i-am-weaving-a-small-sturdy-basket-from-dried-river-reeds-ca.md</div><pre>I am weaving a small, sturdy basket from dried river reeds, carefully interlocking each strand to ensure it can hold wild berries during our upcoming foraging trips.</pre></div>
+<div class='artifact'><div class='muted'>Aki &middot; 2026-05-18 02:00:43Z score=0.80 &middot; inbox/2026-05-18/a-small-smooth-charm-carved-from-a-fallen-cherry-wood-branch.md</div><pre>A small, smooth charm carved from a fallen cherry wood branch, polished with beeswax until it shines.</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 01:53:07Z score=0.96 &middot; inbox/2026-05-18/garden-bed-19.md</div><pre>- stranger-575770-07310c: I suggest we line the base of the garden bed with dried, pressed river-reeds from my homeland. Their hollow structure allows for superior aeration, ensuring the roots do not drown when the spring rains turn the soil into heavy sludge.
+- Aki: To complement the river-reeds, we should layer a thick mixture of decomposed leaf mulch and well-rotted compost over the base. This will provide a nutrient-dense foundation that will sustain the plants as they begin to take root during this growing season.
+- stranger-993636-848142: To prevent the surface from drying too rapidly un</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 01:55:01Z score=0.96 &middot; inbox/2026-05-18/loom-20.md</div><pre>- stranger-993636-848142: To establish a tension that does not snap the delicate threads, we should weave small, dried reeds into the warp. This method, common in the coastal marshes, provides a flexible resistance that prevents the heavy dampness of the spring air from sagging the fabric.
+- stranger-556517-360a2d: To protect the finished weave from the salt-heavy mists of the spring, we could apply a fine mist of heated pine resin dissolved in oil. This creates a subtle, water-resistant glaze over the fibers, much like the protective coating we use on our sea-faring sails, preventing the humi</pre></div>
+<div class='artifact'><div class='muted'>workshop &middot; 2026-05-18 01:54:20Z score=0.96 &middot; inbox/2026-05-18/scroll-21.md</div><pre>- Aki: I will begin by laying down a base of fine, unbleached parchment, ensuring the edges are smoothed with a heavy stone to prevent any fraying during the writing process.
+- Aki: As we begin this scroll, we must ensure the parchment is smoothed with a heavy stone to prevent any ink bleeding or uneven absorption during the writing process.
+- stranger-575770-07310c: To complement the heavy parchment, I suggest we overlay thin, translucent strips of treated birch bark across the surface. This technique, used by my people for traveling maps, adds a structural rigidity that protects the delicate</pre></div>
+</body></html>

--- a/scripts/render_dashboard.py
+++ b/scripts/render_dashboard.py
@@ -116,7 +116,8 @@ def render(data_dir: Path, harvest_dir: Path, out_path: Path) -> int:
     weather = _read_world_events(data_dir / "episodic.sqlite")
 
     parts: list[str] = []
-    parts.append("<!doctype html><html><head><meta charset='utf-8'>")
+    parts.append("<!doctype html><html lang='en'><head><meta charset='utf-8'>")
+    parts.append("<meta name='viewport' content='width=device-width, initial-scale=1'>")
     parts.append("<title>Microverse Dashboard</title>")
     parts.append(f"<style>{_CSS}</style></head><body>")
     parts.append("<h1>Microverse Dashboard</h1>")

--- a/src/microverse/memory/__init__.py
+++ b/src/microverse/memory/__init__.py
@@ -210,10 +210,23 @@ def _build_workshop_view(
 
     Every redaction bumps ``workshop_view_self_redactions`` per-agent
     so operators can verify the redaction is firing under live load.
+
+    ADR 0005 Decision 1 (v0.3.1): WIPs in ``complete`` phase are
+    filtered out of the per-receiver view entirely. The persona prompt
+    only ever sees ``forming`` or ``developing`` WIPs. The projection
+    itself is unchanged — the Harvester still sees complete WIPs at
+    flush time, and the validator still hard-folds any contribute that
+    targets a complete WIP by name (defence-in-depth). Each hidden
+    WIP bumps ``workshop_view_hidden_complete`` per-agent so operators
+    can watch the filter fire under live load.
     """
     receiver_key = agent_name.casefold()
     views: list[WIPView] = []
     for wip in workshop.wips():
+        if wip.phase == "complete":
+            if metrics is not None:
+                metrics.bump("workshop_view_hidden_complete", agent=agent_name)
+            continue
         # Contributors: drop the receiver's own name; preserve order.
         peer_contribs: list[str] = []
         for c in wip.contributors():

--- a/src/microverse/prompts/persona_artisan.j2
+++ b/src/microverse/prompts/persona_artisan.j2
@@ -31,7 +31,7 @@ Lore that feels relevant right now:
 {% if world.workshop_view -%}
 The village workshop currently holds:
 {% for wip in world.workshop_view -%}
-  - {{ wip.name }} (phase: {{ wip.phase }}){% if wip.phase == "complete" %} [complete — awaiting harvest, do not contribute]{% endif %}{% if wip.contributors %}; contributors so far: {{ wip.contributors }}{% endif %}{% if wip.excerpt %}
+  - {{ wip.name }} (phase: {{ wip.phase }}){% if wip.contributors %}; contributors so far: {{ wip.contributors }}{% endif %}{% if wip.excerpt %}
     recent fragments:
 {{ wip.excerpt | indent(6, true) }}{% endif %}
 {% endfor -%}

--- a/src/microverse/prompts/persona_scholar.j2
+++ b/src/microverse/prompts/persona_scholar.j2
@@ -32,7 +32,7 @@ Lore that feels relevant right now:
 {% if world.workshop_view -%}
 The village workshop currently holds:
 {% for wip in world.workshop_view -%}
-  - {{ wip.name }} (phase: {{ wip.phase }}){% if wip.phase == "complete" %} [complete — awaiting harvest, do not contribute]{% endif %}{% if wip.contributors %}; contributors so far: {{ wip.contributors }}{% endif %}{% if wip.excerpt %}
+  - {{ wip.name }} (phase: {{ wip.phase }}){% if wip.contributors %}; contributors so far: {{ wip.contributors }}{% endif %}{% if wip.excerpt %}
     recent fragments:
 {{ wip.excerpt | indent(6, true) }}{% endif %}
 {% endfor -%}

--- a/src/microverse/prompts/persona_stranger.j2
+++ b/src/microverse/prompts/persona_stranger.j2
@@ -30,7 +30,7 @@ Lore the locals seem to live by:
 {% if world.workshop_view -%}
 The village workshop currently holds:
 {% for wip in world.workshop_view -%}
-  - {{ wip.name }} (phase: {{ wip.phase }}){% if wip.phase == "complete" %} [complete — awaiting harvest, do not contribute]{% endif %}{% if wip.contributors %}; contributors so far: {{ wip.contributors }}{% endif %}{% if wip.excerpt %}
+  - {{ wip.name }} (phase: {{ wip.phase }}){% if wip.contributors %}; contributors so far: {{ wip.contributors }}{% endif %}{% if wip.excerpt %}
     recent fragments:
 {{ wip.excerpt | indent(6, true) }}{% endif %}
 {% endfor -%}

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -36,6 +36,7 @@ import random
 import signal
 import sys
 import time
+from collections import Counter
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -439,6 +440,16 @@ def run(
     # their first inbox.
     last_tick_ts: dict[str, float] = {}
 
+    # ADR 0005 §"Empirical risks" / Decision 1 guard: track the
+    # distribution of contribute_to targets across the run so the
+    # operator can detect the rerouting failure mode (all contributes
+    # collapse onto the lowest-fragment open WIP after complete WIPs
+    # are hidden). Published as ``wip_target_concentration`` integer
+    # gauge (x100) every ``HARVEST_FLUSH_EVERY`` ticks; acceptance
+    # threshold is < 70 (i.e. no single WIP holds >70% of recent
+    # contribute targets).
+    wip_target_counts: Counter[str] = Counter()
+
     def _safe(label: str, fn: Callable[[], object]) -> None:
         try:
             fn()
@@ -524,6 +535,8 @@ def run(
             metrics.reset("consecutive_fail", agent=agent.name)
             deadlock_breaks_since_success = 0
             _commit_action(episodic, agent, action, workshop=workshop)
+            if action.action == ActionKind.CONTRIBUTE and action.contribute_to:
+                wip_target_counts[action.contribute_to] += 1
             _maybe_harvest(harvester, agent, action)
             # Path-3: advance the agent's watermark so the NEXT call
             # to ``_build_per_tick_world_base`` for this agent drains
@@ -543,6 +556,16 @@ def run(
                 except Exception:
                     _logger.exception("harvester.flush failed")
                     metrics.bump("harvest_flush_fail")
+                # ADR 0005 D1 rerouting guard: publish the current
+                # ``wip_target_concentration`` and reset the window.
+                # Sampling at the flush boundary aligns the window
+                # with the harvester's recycle cadence so each
+                # measurement covers one flush-window of contributes.
+                total = sum(wip_target_counts.values())
+                if total > 0:
+                    peak = max(wip_target_counts.values())
+                    metrics.set_value("wip_target_concentration", int(peak * 100 / total))
+                wip_target_counts.clear()
             try:
                 maybe_snapshot(
                     executed,

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -561,10 +561,15 @@ def run(
                 # Sampling at the flush boundary aligns the window
                 # with the harvester's recycle cadence so each
                 # measurement covers one flush-window of contributes.
+                # Empty windows publish 0 explicitly so the gauge does
+                # not go stale at the previous window's value.
                 total = sum(wip_target_counts.values())
                 if total > 0:
                     peak = max(wip_target_counts.values())
-                    metrics.set_value("wip_target_concentration", int(peak * 100 / total))
+                    concentration = int(peak * 100 / total)
+                else:
+                    concentration = 0
+                metrics.set_value("wip_target_concentration", concentration)
                 wip_target_counts.clear()
             try:
                 maybe_snapshot(

--- a/tests/test_wip_target_concentration.py
+++ b/tests/test_wip_target_concentration.py
@@ -1,0 +1,53 @@
+"""Gauge math for ``wip_target_concentration``.
+
+ADR 0005 Decision 1 (v0.3.1) Empirical-risk guard: when the persona
+view hides ``complete`` WIPs, the model may collapse all contributes
+onto the lowest-fragment open WIP. To detect that failure mode, the
+run loop maintains a per-flush-window ``Counter[str]`` of
+``action.contribute_to`` targets and publishes
+``peak / total`` (x100, integer) as a gauge each flush.
+
+Acceptance threshold from ADR 0005 §"v0.3.1" smoke is < 70.
+
+These unit tests pin the math itself; the run-loop integration is
+exercised by ``test_run_smoke`` and the 200-tick acceptance smoke
+called out in the ADR.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+
+def _concentration_percent(counts: Counter[str]) -> int:
+    """Mirror the formula in run.py's HARVEST_FLUSH_EVERY branch."""
+    total = sum(counts.values())
+    if total == 0:
+        return 0
+    return int(max(counts.values()) * 100 / total)
+
+
+def test_concentration_single_wip_is_one_hundred() -> None:
+    counts: Counter[str] = Counter()
+    counts["workshop.loom"] += 10
+    assert _concentration_percent(counts) == 100
+
+
+def test_concentration_even_split_is_below_threshold() -> None:
+    # 4 WIPs each at 5 contributes → peak=5, total=20, share=25%.
+    counts: Counter[str] = Counter({"a": 5, "b": 5, "c": 5, "d": 5})
+    assert _concentration_percent(counts) == 25
+    assert _concentration_percent(counts) < 70  # ADR 0005 gate
+
+
+def test_concentration_rerouting_signature_is_above_threshold() -> None:
+    # The failure mode ADR 0005 Empirical risks calls out:
+    # 90% of contributes targeting one WIP → 90 (above the 70 floor).
+    counts: Counter[str] = Counter({"hot": 9, "cold": 1})
+    assert _concentration_percent(counts) == 90
+    assert _concentration_percent(counts) >= 70
+
+
+def test_concentration_empty_window_is_zero() -> None:
+    counts: Counter[str] = Counter()
+    assert _concentration_percent(counts) == 0

--- a/tests/test_workshop_view_redaction.py
+++ b/tests/test_workshop_view_redaction.py
@@ -158,6 +158,77 @@ def test_build_workshop_view_name_filter_is_case_insensitive_whole_word(tmp_path
 
 
 # ---------------------------------------------------------------------------
+# Slice D1 — ADR 0005 Decision 1: hide complete WIPs from the persona view
+# ---------------------------------------------------------------------------
+
+
+def _drive_to_complete(ep: EpisodicMemory, wip: str, *, base_ts: float = 1.0) -> None:
+    """Append COMPLETE_FRAGMENT_FLOOR (8) fragments to drive ``wip`` to
+    ``complete`` phase. Uses two contributors so the projection sees
+    a multi-author WIP (matches the harness-shape contract)."""
+    contributors = ("Bo", "Ce")
+    for i in range(8):
+        _seed(
+            ep,
+            actor=contributors[i % 2],
+            wip=wip,
+            fragment=f"d1-drive-fragment-{i}-distinctive",
+            ts=base_ts + i * 0.1,
+        )
+
+
+def test_build_workshop_view_hides_complete_wips(tmp_path: Path) -> None:
+    """ADR 0005 Decision 1: a WIP in ``complete`` phase is not surfaced
+    in the per-receiver view at all. The persona prompt never sees a
+    name that is awaiting harvest. The other configured WIPs still
+    appear.
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        proj = WorkshopProjection(ep)
+        _drive_to_complete(ep, target)
+        # Re-project so the contribute events apply.
+        proj = WorkshopProjection(ep)
+        complete_wip = proj.get(target)
+        assert complete_wip is not None
+        assert complete_wip.phase == "complete"
+        metrics = Metrics(":memory:")
+        views = _build_workshop_view(proj, agent_name="Aki", metrics=metrics)
+    names = {v.name for v in views}
+    assert target not in names, f"complete WIP {target!r} should be hidden, got {names}"
+    # Other configured WIPs are still present.
+    for other in CONFIGURED_WIPS[1:]:
+        assert other in names
+    # Per-agent metric bumped once per hidden WIP per call.
+    assert metrics.get("workshop_view_hidden_complete", agent="Aki") >= 1
+
+
+def test_build_workshop_view_shows_wip_after_recycle(tmp_path: Path) -> None:
+    """A WIP that is driven to ``complete`` is hidden; once it is
+    recycled (``workshop.recycle`` event), the name returns to the
+    view — the persona regains the affordance for the next round.
+    """
+    target = CONFIGURED_WIPS[0]
+    with EpisodicMemory(tmp_path / "ep.sqlite") as ep:
+        _drive_to_complete(ep, target)
+        # Recycle event flips it back to forming.
+        ep.append(
+            actor="harvester",
+            action="workshop.recycle",
+            target=target,
+            payload={"reason": "test"},
+            ts=2.0,
+        )
+        proj = WorkshopProjection(ep)
+        recycled = proj.get(target)
+        assert recycled is not None
+        assert recycled.phase == "forming"
+        views = _build_workshop_view(proj, agent_name="Aki", metrics=None)
+    names = {v.name for v in views}
+    assert target in names, f"recycled WIP {target!r} should reappear, got {names}"
+
+
+# ---------------------------------------------------------------------------
 # Slice 4.2 — structural leak sweep parallel to PR #24
 # ---------------------------------------------------------------------------
 
@@ -190,17 +261,30 @@ def _world_state_dump(world: WorldContext) -> str:
     return "\n".join(parts)
 
 
+_LEAK_SWEEP_ITERATIONS = 6
+"""Per-WIP fragment count after a sweep iteration must stay strictly
+below ``COMPLETE_FRAGMENT_FLOOR=8`` so the WIPs remain visible after
+ADR 0005 Decision 1 (which hides complete WIPs from the persona view).
+With 3 configured WIPs and 2 contributors per iteration, range(6)
+gives each WIP 4 fragments — ``developing`` phase, still visible."""
+
+
 def test_structural_leak_sweep_no_self_fragments(tmp_path: Path) -> None:
-    """Seed 50 contribute events for Aki across the configured WIPs;
-    assert zero substring matches of any of Aki's fragment texts
+    """Seed Aki contributes across configured WIPs and assert that
+    none of Aki's fragment texts surface in the per-receiver view
     when build_context is assembled for Aki.
+
+    Iteration count is bounded below the COMPLETE_FRAGMENT_FLOOR
+    threshold so the WIPs stay in ``developing`` phase and remain
+    visible under ADR 0005 Decision 1; a separate test covers the
+    hide-when-complete behavior.
     """
     base = time.time() - 60.0
     with (
         EpisodicMemory(tmp_path / "ep.sqlite") as ep,
         SemanticMemory(tmp_path / "se.sqlite") as se,
     ):
-        for i in range(50):
+        for i in range(_LEAK_SWEEP_ITERATIONS):
             wip = CONFIGURED_WIPS[i % len(CONFIGURED_WIPS)]
             _seed(
                 ep,
@@ -219,7 +303,7 @@ def test_structural_leak_sweep_no_self_fragments(tmp_path: Path) -> None:
             workshop=proj,
         )
     dump = _world_state_dump(out)
-    for i in range(50):
+    for i in range(_LEAK_SWEEP_ITERATIONS):
         marker = f"signature-frag-zeta-{i}-aki-unique-marker"
         assert marker not in dump, (
             f"self workshop fragment {marker!r} leaked into context, dump head:\n{dump[:600]!r}"
@@ -231,16 +315,19 @@ def test_structural_leak_sweep_no_self_fragments(tmp_path: Path) -> None:
 
 
 def test_structural_leak_sweep_peer_fragments_pass_through(tmp_path: Path) -> None:
-    """Slice 4.3: don't over-redact. When Bo contributes 50 times,
-    Aki sees Bo's fragments verbatim (community knowledge) but not
-    Aki's own (50 separately-seeded self fragments stay redacted).
+    """Slice 4.3: don't over-redact. When Bo contributes interleaved
+    with Aki, Aki sees Bo's fragments verbatim (community knowledge)
+    but not Aki's own (self fragments stay redacted).
+
+    Iteration count is bounded below ``COMPLETE_FRAGMENT_FLOOR`` for
+    the same reason as the no-self-fragments sweep above.
     """
     base = time.time() - 60.0
     with (
         EpisodicMemory(tmp_path / "ep.sqlite") as ep,
         SemanticMemory(tmp_path / "se.sqlite") as se,
     ):
-        for i in range(50):
+        for i in range(_LEAK_SWEEP_ITERATIONS):
             wip = CONFIGURED_WIPS[i % len(CONFIGURED_WIPS)]
             _seed(ep, actor="Aki", wip=wip, fragment=f"aki-self-{i}", ts=base + i * 0.1)
             _seed(ep, actor="Bo", wip=wip, fragment=f"bo-peer-{i}", ts=base + i * 0.1 + 0.01)
@@ -255,10 +342,10 @@ def test_structural_leak_sweep_peer_fragments_pass_through(tmp_path: Path) -> No
         )
     dump = _world_state_dump(out)
     # No self fragment leaks.
-    for i in range(50):
+    for i in range(_LEAK_SWEEP_ITERATIONS):
         assert f"aki-self-{i}" not in dump
     # At least some peer fragments are visible (don't over-redact).
-    bo_visible = sum(1 for i in range(50) if f"bo-peer-{i}" in dump)
+    bo_visible = sum(1 for i in range(_LEAK_SWEEP_ITERATIONS) if f"bo-peer-{i}" in dump)
     assert bo_visible > 0, "peer fragments should pass through community-knowledge"
 
 


### PR DESCRIPTION
## Summary

Gemma 4 Hackathon submission bundle (Ollama Special Track, $10K). Combines two workstreams.

### Workstream B — Submission assets (docs-only)

- **WRITEUP.md** (1,287 words / 1,500 limit): Kaggle writeup. Leads with the 24h soak result on `gemma4:26b` (14,113 events, 702 artifacts), highlights Ollama-specific Gemma 4 capabilities (single-model invariant, structured-output Trader, thinking-channel discipline), reframes the 5-ADR journey as a progression of breakthroughs, and includes a concrete privacy-sensitive use case (rural clinic intake summaries).
- **docs/index.html** (21 KB self-contained HTML): rendered dashboard from `harvest/soak-24h-v03-26b` showing residents, metrics, weather feed, and 20+ harvested artifacts. Deployed via GitHub Pages.
- **VIDEO_SCRIPT.md** (~440-word voiceover + 7-shot list): timed walkthrough for a ≤3-minute YouTube video.
- **README.md**: fixed stale `v0.1.0` status and `gemma4:e4b` model claim; added hackathon banner with dashboard/writeup links; added a "Why this matters" section pulling from ADR 0001 + ADR 0002.

### Workstream A — v0.3.1 ADR 0005 Decision 1

Hide WIPs in `complete` phase from the persona prompt view. The model can no longer pull `contribute` actions into already-finished WIPs because the affordance is gone from the prompt. The validator's hard-fold stays as defence-in-depth.

- `src/microverse/memory/__init__.py::_build_workshop_view`: `continue` on `wip.phase == "complete"`; bumps a new `workshop_view_hidden_complete` per-agent counter.
- `src/microverse/run.py`: tracks `action.contribute_to` distribution per flush window and publishes a `wip_target_concentration` integer gauge (x100). ADR 0005 §"Empirical risks" guard against the rerouting failure mode.
- `src/microverse/prompts/persona_{artisan,scholar,stranger}.j2`: removed the dead `[complete — awaiting harvest, do not contribute]` template branch.
- `tests/test_workshop_view_redaction.py`: `+test_build_workshop_view_hides_complete_wips`, `+test_build_workshop_view_shows_wip_after_recycle`. Adjusted the two leak-sweep tests to seed below `COMPLETE_FRAGMENT_FLOOR` so WIPs remain visible under D1.
- `tests/test_wip_target_concentration.py` (new): pins the `peak/total` gauge math (single-WIP=100, even-split<70, rerouting>=70, empty=0).

**Honest framing**: ships as experimental mitigation. The 30-tick e4b smoke confirms the filter fires (`workshop_view_hidden_complete` Aki=51, Cy=29) without breaking existing protections. The 200-tick ADR-0005-§"v0.3.1" acceptance smoke and the 26b pressure smoke are documented as next-step follow-up.

## Local validation
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy src/microverse && uv run pip-audit && uv build` all green.
- [x] `uv run pytest -q -m 'not integration'` → 434 passed.
- [x] 30-tick smoke on `gemma4:e4b` against `data/soak-24h-v03-e4b` baseline confirms D1 filter fires.

## Submission test plan
- [ ] Merge PR to `main` (creates tag candidate `v0.3.1`).
- [ ] Enable GitHub Pages (Settings → Pages → "Deploy from branch: `main` / folder: `/docs`"). Verify `https://theillusionoflife.github.io/microverse/` loads.
- [ ] Screenshot dashboard for `docs/cover.png` (Kaggle preview, 1200×630).
- [ ] Record video per `VIDEO_SCRIPT.md`, upload to YouTube as Public.
- [ ] Submit Kaggle writeup attaching repo URL, video URL, live demo URL, cover image.

Target track: **Ollama Special Track ($10K)** — "best project that utilizes and showcases the capabilities of Gemma 4 running locally via Ollama."