### PR TITLE
ci: ignore 6 ollama-server CVEs in pip-audit (Python client unaffected)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,19 @@ jobs:
         run: uv run mypy src/microverse
 
       - name: Audit dependencies
-        run: uv run pip-audit
+        # The six ignored advisories all describe vulnerabilities in
+        # the Ollama *server* (Go daemon), not the Python client.
+        # OSV maps both under PyPI name "ollama" and pip-audit cannot
+        # disambiguate. None list a fix_version for the Python client;
+        # review when ollama 0.6.3+ ships.
+        run: >-
+          uv run pip-audit
+          --ignore-vuln PYSEC-2025-144
+          --ignore-vuln PYSEC-2025-145
+          --ignore-vuln PYSEC-2025-146
+          --ignore-vuln PYSEC-2025-147
+          --ignore-vuln PYSEC-2026-101
+          --ignore-vuln PYSEC-2026-102
 
       - name: Test
         run: uv run pytest -q -m 'not integration'


### PR DESCRIPTION
## Summary
Unblocks `main` CI. Six advisories that pip-audit attributes to the ``ollama`` PyPI package — PYSEC-2025-144 through -147 and PYSEC-2026-101/-102 — all describe vulnerabilities in the **Ollama server** (Go daemon), not the Python client this project depends on.

OSV maps both projects under the PyPI name ``ollama`` and pip-audit cannot disambiguate, so every CI run on the current ``uv.lock`` fails on advisories that don't apply to us. None of the six advisories list a ``fix_versions`` entry for the Python client, and ``ollama==0.6.2`` is the latest on PyPI.

Re-evaluate when ``ollama`` 0.6.3+ ships and the advisory metadata can be retired.

## Test plan
- [x] Local run of the updated ``pip-audit`` command emits ``No known vulnerabilities found, 6 ignored``.
- [x] Inspected upstream advisory references (e.g. CVE-2025-44779 → arbitrary-file delete via the server's ``/api/pull`` endpoint) — none describe Python-client behavior.
- [ ] CI on this branch is green.

## Context
- `main` started failing CI immediately after PR #25 merged (2026-05-20T13:57). The advisories were published after the previous successful main run, so this is not a regression introduced by any of yesterday's merges.
- After this lands we can unblock the remaining open PRs (#26, #36 — they are CI-failing for the same reason).