### PR TITLE
feat(economy): action-economy diagnostic spike (re-diagnose ADR 0008 halt)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ ignore = []
 "scripts/render_dashboard.py" = ["T20"]
 "scripts/spike_workshop_measure.py" = ["T20"]
 "scripts/verify_kill_drill.py" = ["T20"]
+"scripts/replay_economy.py" = ["T20"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/scripts/replay_economy.py
+++ b/scripts/replay_economy.py
@@ -51,17 +51,29 @@ def _entropy_norm(counts: Counter, *, k: int = 6) -> float:
     return h / math.log2(k)
 
 
-def replay_executor(events: list[tuple[str, str, str]], *, ledger: EnergyLedger) -> dict:
-    """Run a chronological ``(actor, role, chosen_verb)`` trace through the
-    executor. Per event: resolve (afford-or-substitute) at the current pool,
-    deduct the executed verb, then regen the actor (per-actor approximation of
-    the live whole-roster per-tick regen). Returns chosen/executed counts and
-    the substitution rate."""
+def replay_executor(
+    events: list[tuple[str, str, str]] | list[tuple[str, str, str, bool]],
+    *,
+    ledger: EnergyLedger,
+) -> dict:
+    """Run a chronological ``(actor, role, chosen_verb[, forced])`` trace
+    through the executor. Per event: resolve (afford-or-substitute) at the
+    current pool, deduct the executed verb, then regen the actor (per-actor
+    approximation of the live whole-roster per-tick regen). Returns
+    chosen/executed counts and the substitution rate.
+
+    ``forced`` (4th element, default False) marks a scene turn (ADR 0006). Live
+    scene contributes are NEVER substituted (the lever skips scene turns), so a
+    forced event is deducted at its chosen verb without substitution — otherwise
+    the offline estimate would predict substitutions that cannot happen live and
+    inflate the substitution rate (review)."""
     chosen: Counter = Counter()
     executed: Counter = Counter()
     subs = 0
-    for actor, role, verb in events:
-        ex = ledger.resolve_executed_verb(actor, role, verb)
+    for event in events:
+        actor, role, verb, *rest = event
+        forced = bool(rest[0]) if rest else False
+        ex = verb if forced else ledger.resolve_executed_verb(actor, role, verb)
         ledger.deduct(actor, role, ex)
         ledger.regen(actor)
         chosen[verb] += 1
@@ -82,10 +94,12 @@ def replay_executor(events: list[tuple[str, str, str]], *, ledger: EnergyLedger)
     }
 
 
-def _trace_from_episodic(path: Path) -> list[tuple[str, str, str]]:
-    """Chronological ``(actor, role, chosen_verb)`` from a committed run. The
-    chosen verb is ``payload.parsed_verb`` when present (an economy-on run),
-    else the executed action (an economy-off run — the model's own choice)."""
+def _trace_from_episodic(path: Path) -> list[tuple[str, str, str, bool]]:
+    """Chronological ``(actor, role, chosen_verb, forced)`` from a committed
+    run. The chosen verb is ``payload.parsed_verb`` when present (an economy-on
+    run), else the executed action (an economy-off run — the model's own
+    choice). ``forced`` is True for scene turns (``payload.scene_id``), which the
+    executor must deduct without substituting (review)."""
     conn = sqlite3.connect(str(path))
     try:
         rows = conn.execute(
@@ -94,15 +108,16 @@ def _trace_from_episodic(path: Path) -> list[tuple[str, str, str]]:
         ).fetchall()
     finally:
         conn.close()
-    out: list[tuple[str, str, str]] = []
+    out: list[tuple[str, str, str, bool]] = []
     for actor, action, payload_json in rows:
         if action not in _VERBS:
             continue
         payload = json.loads(payload_json) if payload_json else {}
         role = str(payload.get("role", ""))
         chosen = payload.get("parsed_verb") or action
+        forced = bool(payload.get("scene_id"))
         if role and chosen in _VERBS:
-            out.append((actor, role, chosen))
+            out.append((actor, role, chosen, forced))
     return out
 
 
@@ -170,7 +185,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--data", help="Stage 0: data dir with episodic.sqlite to replay")
     p.add_argument("--synthetic", action="store_true", help="Stage 1: run synthetic policies")
-    p.add_argument("--mode", default="1", help="economy cost-table mode (1/flat)")
+    p.add_argument(
+        "--mode",
+        default="1",
+        choices=("1", "flat", "sub", "throttle"),
+        help="economy cost-table mode (role-advantage for all but 'flat')",
+    )
     p.add_argument("--ticks", type=int, default=2000, help="Stage 1 tick budget")
     p.add_argument("--seed", type=int, default=42, help="Stage 1 RNG seed")
     return p.parse_args(argv)

--- a/scripts/replay_economy.py
+++ b/scripts/replay_economy.py
@@ -1,0 +1,217 @@
+"""Offline replay + synthetic simulator for the action-economy spike (ADR 0008).
+
+ZERO new LLM compute. Two stages that gate the expensive A/B runs (Codex review):
+
+  Stage 0 (replay): feed an EXISTING run's committed verb trace
+    (data/<run>/episodic.sqlite, produced with the economy OFF) through the
+    EnergyLedger executor offline, to estimate the mechanical contribute-share
+    ceiling and substitution rate the cost numbers would produce — and to
+    expose degenerate equilibria (e.g. ENERGY_MAX too high to bite) BEFORE
+    spending ~6h/run on a live A/B.
+
+  Stage 1 (synthetic): drive the same executor with no-LLM policies
+    (always-contribute, uniform-random, role-biased) to prove the cost numbers
+    mechanically diversify and to read the theoretical entropy ceiling.
+
+Both reuse ``EnergyLedger.resolve_executed_verb`` so the offline estimate
+matches the live lever exactly. The per-tick whole-roster regen is
+approximated as per-actor regen (the trace only records the acting agent),
+so these are estimates, not the live measurement — run
+``spike_workshop_measure.py`` on a real run for the gate read.
+
+Usage:
+    uv run python scripts/replay_economy.py --data data/econ-off-s42
+    uv run python scripts/replay_economy.py --synthetic --ticks 2000 --seed 42
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import sqlite3
+import sys
+from collections import Counter
+from pathlib import Path
+
+from microverse.config import ENERGY_MAX, ENERGY_REGEN_PER_TICK
+from microverse.world.economy import EnergyLedger, build_cost_table
+
+_VERBS = ("speak", "craft", "study", "rest", "travel", "contribute")
+# Default 2-resident roster mirrors run.py's _build_roster.
+_DEFAULT_ROSTER: tuple[tuple[str, str], ...] = (("Aki", "artisan"), ("Cy", "scholar"))
+
+
+def _entropy_norm(counts: Counter, *, k: int = 6) -> float:
+    total = sum(counts.values())
+    if total <= 0 or k <= 1:
+        return 0.0
+    h = -sum((c / total) * math.log2(c / total) for c in counts.values() if c > 0)
+    return h / math.log2(k)
+
+
+def replay_executor(events: list[tuple[str, str, str]], *, ledger: EnergyLedger) -> dict:
+    """Run a chronological ``(actor, role, chosen_verb)`` trace through the
+    executor. Per event: resolve (afford-or-substitute) at the current pool,
+    deduct the executed verb, then regen the actor (per-actor approximation of
+    the live whole-roster per-tick regen). Returns chosen/executed counts and
+    the substitution rate."""
+    chosen: Counter = Counter()
+    executed: Counter = Counter()
+    subs = 0
+    for actor, role, verb in events:
+        ex = ledger.resolve_executed_verb(actor, role, verb)
+        ledger.deduct(actor, role, ex)
+        ledger.regen(actor)
+        chosen[verb] += 1
+        executed[ex] += 1
+        if ex != verb:
+            subs += 1
+    total = sum(executed.values())
+    return {
+        "total": total,
+        "chosen_counts": dict(chosen),
+        "executed_counts": dict(executed),
+        "substitution_rate": round(subs / total, 4) if total else 0.0,
+        "chosen_contribute_share": round(chosen.get("contribute", 0) / total, 4) if total else 0.0,
+        "executed_contribute_share": round(executed.get("contribute", 0) / total, 4)
+        if total
+        else 0.0,
+        "executed_entropy_norm": round(_entropy_norm(executed), 4),
+    }
+
+
+def _trace_from_episodic(path: Path) -> list[tuple[str, str, str]]:
+    """Chronological ``(actor, role, chosen_verb)`` from a committed run. The
+    chosen verb is ``payload.parsed_verb`` when present (an economy-on run),
+    else the executed action (an economy-off run — the model's own choice)."""
+    conn = sqlite3.connect(str(path))
+    try:
+        rows = conn.execute(
+            "SELECT actor, action, payload_json FROM events "
+            "WHERE actor NOT IN ('world','harvester','scene') ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        conn.close()
+    out: list[tuple[str, str, str]] = []
+    for actor, action, payload_json in rows:
+        if action not in _VERBS:
+            continue
+        payload = json.loads(payload_json) if payload_json else {}
+        role = str(payload.get("role", ""))
+        chosen = payload.get("parsed_verb") or action
+        if role and chosen in _VERBS:
+            out.append((actor, role, chosen))
+    return out
+
+
+def synthetic_run(
+    policy: str,
+    *,
+    n_ticks: int,
+    roster: tuple[tuple[str, str], ...],
+    cost_table: dict[str, dict[str, float]],
+    seed: int,
+) -> dict:
+    """Drive the executor with a no-LLM policy to read the mechanical ceiling.
+
+    Policies: ``always-contribute`` (every chosen verb is contribute),
+    ``uniform-random`` (uniform over the six verbs), ``role-biased`` (each role
+    mostly picks its cheapest specialty). Round-robins the roster one action
+    per tick and regenerates the whole roster each tick (matching live)."""
+    rng = random.Random(seed)
+    ledger = EnergyLedger.fresh(
+        [n for n, _ in roster],
+        max_energy=ENERGY_MAX,
+        regen_per_tick=ENERGY_REGEN_PER_TICK,
+        cost_table=cost_table,
+    )
+    productive = [v for v in _VERBS if v != "rest"]
+    chosen: Counter = Counter()
+    executed: Counter = Counter()
+    subs = 0
+    for tick in range(n_ticks):
+        actor, role = roster[tick % len(roster)]
+        if policy == "always-contribute":
+            verb = "contribute"
+        elif policy == "uniform-random":
+            verb = rng.choice(_VERBS)
+        elif policy == "role-biased":
+            specialty = min(
+                (v for v in productive),
+                key=lambda v: cost_table.get(role, {}).get(v, 0.0),
+            )
+            verb = specialty if rng.random() < 0.8 else rng.choice(productive)
+        else:  # pragma: no cover - guarded by argparse choices
+            raise ValueError(f"unknown policy {policy}")
+        ex = ledger.resolve_executed_verb(actor, role, verb)
+        ledger.deduct(actor, role, ex)
+        chosen[verb] += 1
+        executed[ex] += 1
+        if ex != verb:
+            subs += 1
+        for name, _ in roster:
+            ledger.regen(name)
+    total = sum(executed.values())
+    return {
+        "policy": policy,
+        "total": total,
+        "executed_counts": dict(executed),
+        "substitution_rate": round(subs / total, 4) if total else 0.0,
+        "executed_contribute_share": round(executed.get("contribute", 0) / total, 4)
+        if total
+        else 0.0,
+        "executed_entropy_norm": round(_entropy_norm(executed), 4),
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--data", help="Stage 0: data dir with episodic.sqlite to replay")
+    p.add_argument("--synthetic", action="store_true", help="Stage 1: run synthetic policies")
+    p.add_argument("--mode", default="1", help="economy cost-table mode (1/flat)")
+    p.add_argument("--ticks", type=int, default=2000, help="Stage 1 tick budget")
+    p.add_argument("--seed", type=int, default=42, help="Stage 1 RNG seed")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    cost_table = build_cost_table(args.mode)
+    report: dict = {"mode": args.mode, "energy_max": ENERGY_MAX, "regen": ENERGY_REGEN_PER_TICK}
+
+    if args.data:
+        ep = Path(args.data) / "episodic.sqlite"
+        if not ep.exists():
+            print(f"FATAL: {ep} not found", file=sys.stderr)
+            return 2
+        ledger = EnergyLedger.fresh(
+            [n for n, _ in _DEFAULT_ROSTER],
+            max_energy=ENERGY_MAX,
+            regen_per_tick=ENERGY_REGEN_PER_TICK,
+            cost_table=cost_table,
+        )
+        report["stage0_replay"] = replay_executor(_trace_from_episodic(ep), ledger=ledger)
+
+    if args.synthetic:
+        report["stage1_synthetic"] = [
+            synthetic_run(
+                pol,
+                n_ticks=args.ticks,
+                roster=_DEFAULT_ROSTER,
+                cost_table=cost_table,
+                seed=args.seed,
+            )
+            for pol in ("always-contribute", "uniform-random", "role-biased")
+        ]
+
+    if not args.data and not args.synthetic:
+        print("nothing to do: pass --data <dir> and/or --synthetic", file=sys.stderr)
+        return 1
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/spike_workshop_measure.py
+++ b/scripts/spike_workshop_measure.py
@@ -190,6 +190,7 @@ def gate9_verb_diversity(
     chosen_by_agent: dict[str, Counter] = defaultdict(Counter)
     n_total = 0
     n_sub = 0
+    n_econ_sub = 0
     for r in rows:
         executed = r["action"]
         if executed not in verbset:
@@ -204,6 +205,11 @@ def gate9_verb_diversity(
         n_total += 1
         if chosen != executed:
             n_sub += 1
+        # Economy-ONLY substitution flag set by the agent's economy lever,
+        # distinct from the chosen!=executed total which also folds in
+        # diversity / engagement / validator overrides (Codex review).
+        if payload.get("economy_substituted"):
+            n_econ_sub += 1
 
     executed_block = _diversity_block(exec_by_agent)
     chosen_block = _diversity_block(chosen_by_agent)
@@ -222,6 +228,7 @@ def gate9_verb_diversity(
         "executed": executed_block,
         "chosen": chosen_block,
         "substitution_rate": round((n_sub / n_total) if n_total else 0.0, 4),
+        "economy_substitution_rate": round((n_econ_sub / n_total) if n_total else 0.0, 4),
         "chosen_vs_executed_divergence": round(cxe, 4),
         "entropy_norm_floor": entropy_norm_floor,
         "jsd_norm_floor": jsd_norm_floor,

--- a/scripts/spike_workshop_measure.py
+++ b/scripts/spike_workshop_measure.py
@@ -167,7 +167,7 @@ def _diversity_block(by_agent: dict[str, Counter]) -> dict:
 def gate9_verb_diversity(
     ep: sqlite3.Connection,
     *,
-    entropy_norm_floor: float = 0.55,
+    entropy_norm_floor: float = 0.35,
     jsd_norm_floor: float = 0.25,
 ) -> dict:
     """ADR 0008 re-diagnosis metric. Reports society verb entropy and
@@ -178,6 +178,19 @@ def gate9_verb_diversity(
     choose differently under economic pressure, not merely the executor to
     override verbs (high ``substitution_rate`` with a flat chosen stream is a
     forced-by-construction result, not emergent behavior).
+
+    Scope (review): only FREE verb choices count. Scene turns are forced
+    contributes (ADR 0006) and ``parse_action`` fallback RESTs are parse
+    failures, not choices — both are excluded (scene turns from both streams;
+    parse-fallback from the chosen stream) so neither inflates the diversity
+    signal. Scene volume is reported separately as ``scene_excluded``.
+
+    ``entropy_norm_floor`` defaults to 0.35: with the 2-agent roster two perfect
+    specialists over two verbs cap normalized society entropy at
+    ``log2(2)/log2(6) ≈ 0.387`` — the divergence we WANT — so a 0.55 floor would
+    reject the target outcome. JSD (cross-agent divergence) is the primary
+    signal; the entropy floor only certifies the society broke its single-verb
+    monoculture (baseline ≈ 0.2).
     """
     rows = list(
         ep.execute(
@@ -191,25 +204,36 @@ def gate9_verb_diversity(
     n_total = 0
     n_sub = 0
     n_econ_sub = 0
+    n_scene_excluded = 0
     for r in rows:
         executed = r["action"]
         if executed not in verbset:
             continue
         payload = json.loads(r["payload_json"]) if r["payload_json"] else {}
-        chosen = payload.get("parsed_verb") or executed
-        if chosen not in verbset:
-            chosen = executed
+        # Forced scene contributes (ADR 0006) are not free choices: drop them
+        # from BOTH streams so scene volume can't swamp the free-choice signal.
+        if payload.get("scene_id"):
+            n_scene_excluded += 1
+            continue
         actor = r["actor"]
         exec_by_agent[actor][executed] += 1
-        chosen_by_agent[actor][chosen] += 1
         n_total += 1
-        if chosen != executed:
-            n_sub += 1
         # Economy-ONLY substitution flag set by the agent's economy lever,
         # distinct from the chosen!=executed total which also folds in
         # diversity / engagement / validator overrides (Codex review).
         if payload.get("economy_substituted"):
             n_econ_sub += 1
+        # The CHOSEN (free-choice) stream excludes parse-fallback RESTs: a
+        # malformed payload folded to REST is a parse failure, not a verb the
+        # model freely chose, so it must not pollute chosen-verb diversity.
+        if payload.get("parse_fallback"):
+            continue
+        chosen = payload.get("parsed_verb") or executed
+        if chosen not in verbset:
+            chosen = executed
+        chosen_by_agent[actor][chosen] += 1
+        if chosen != executed:
+            n_sub += 1
 
     executed_block = _diversity_block(exec_by_agent)
     chosen_block = _diversity_block(chosen_by_agent)
@@ -230,6 +254,7 @@ def gate9_verb_diversity(
         "substitution_rate": round((n_sub / n_total) if n_total else 0.0, 4),
         "economy_substitution_rate": round((n_econ_sub / n_total) if n_total else 0.0, 4),
         "chosen_vs_executed_divergence": round(cxe, 4),
+        "scene_excluded": n_scene_excluded,
         "entropy_norm_floor": entropy_norm_floor,
         "jsd_norm_floor": jsd_norm_floor,
         "pass_entropy": pass_entropy,

--- a/scripts/spike_workshop_measure.py
+++ b/scripts/spike_workshop_measure.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import sqlite3
 import statistics
@@ -47,6 +48,11 @@ import sys
 from collections import Counter, defaultdict
 from collections.abc import Iterable
 from pathlib import Path
+
+# Six free-choice verbs (ADR 0008 spike measurement). Gate 9 measures the
+# shape of the verb economy; namespaced events (scene.open, weather.*) and
+# the world/harvester/scene pseudo-actors are excluded.
+_VERBS: tuple[str, ...] = ("speak", "craft", "study", "rest", "travel", "contribute")
 
 # Local tokeniser to avoid pulling the package import (script is meant
 # to run standalone against arbitrary data dirs).
@@ -66,6 +72,160 @@ def _ngrams(tokens: Iterable[str], n: int) -> Iterable[tuple[str, ...]]:
     if len(buf) < n:
         return ()
     return (tuple(buf[i : i + n]) for i in range(len(buf) - n + 1))
+
+
+def _shannon_entropy_bits(counts: dict[str, int]) -> float:
+    total = sum(counts.values())
+    if total <= 0:
+        return 0.0
+    h = 0.0
+    for c in counts.values():
+        if c <= 0:
+            continue
+        p = c / total
+        h -= p * math.log2(p)
+    return h
+
+
+def _entropy_norm(counts: dict[str, int], *, k: int) -> float:
+    """Shannon entropy normalized to [0, 1] against ``k`` possible symbols."""
+    if k <= 1:
+        return 0.0
+    return _shannon_entropy_bits(counts) / math.log2(k)
+
+
+def _normalize(counter: Counter, verbs: Iterable[str]) -> dict[str, float]:
+    total = sum(counter.values())
+    if total <= 0:
+        return dict.fromkeys(verbs, 0.0)
+    return {v: counter.get(v, 0) / total for v in verbs}
+
+
+def _kl_bits(p: dict[str, float], q: dict[str, float]) -> float:
+    s = 0.0
+    for key, pk in p.items():
+        if pk <= 0:
+            continue
+        qk = q.get(key, 0.0)
+        if qk <= 0:  # never happens against the JSD mixture (M >= P/2)
+            continue
+        s += pk * math.log2(pk / qk)
+    return s
+
+
+def _jsd_bits(p: dict[str, float], q: dict[str, float]) -> float:
+    """Jensen-Shannon divergence (base 2) between two distributions. For two
+    distributions this lands in [0, 1]: 0 identical, 1 disjoint supports."""
+    keys = set(p) | set(q)
+    m = {k: 0.5 * (p.get(k, 0.0) + q.get(k, 0.0)) for k in keys}
+    return 0.5 * _kl_bits(p, m) + 0.5 * _kl_bits(q, m)
+
+
+def _multi_jsd(dists: list[dict[str, float]]) -> float:
+    """Cross-agent divergence normalized to [0, 1]. Pairwise for the 2-agent
+    roster (the headline case); generalized + normalized by log2(n) otherwise."""
+    n = len(dists)
+    if n < 2:
+        return 0.0
+    if n == 2:
+        return _jsd_bits(dists[0], dists[1])
+    keys = set().union(*(set(d) for d in dists))
+    m = {k: sum(d.get(k, 0.0) for d in dists) / n for k in keys}
+
+    def _entropy(d: dict[str, float]) -> float:
+        return -sum(v * math.log2(v) for v in d.values() if v > 0)
+
+    jsd = _entropy(m) - sum(_entropy(d) for d in dists) / n
+    return jsd / math.log2(n)
+
+
+def _diversity_block(by_agent: dict[str, Counter]) -> dict:
+    society: Counter = Counter()
+    for c in by_agent.values():
+        society.update(c)
+    society_counts = {v: int(n) for v, n in society.items()}
+    agents = sorted(by_agent)
+    dists = [_normalize(by_agent[a], _VERBS) for a in agents]
+    per_agent_top = {
+        a: (round(max(by_agent[a].values()) / sum(by_agent[a].values()), 4)
+            if sum(by_agent[a].values()) else 0.0)
+        for a in agents
+    }
+    return {
+        "society_counts": society_counts,
+        "society_entropy_bits": round(_shannon_entropy_bits(society_counts), 4),
+        "society_entropy_norm": round(_entropy_norm(society_counts, k=len(_VERBS)), 4),
+        "jsd_norm": round(_multi_jsd(dists), 4),
+        "n_agents": len(agents),
+        "per_agent_top_share": per_agent_top,
+    }
+
+
+def gate9_verb_diversity(
+    ep: sqlite3.Connection,
+    *,
+    entropy_norm_floor: float = 0.55,
+    jsd_norm_floor: float = 0.25,
+) -> dict:
+    """ADR 0008 re-diagnosis metric. Reports society verb entropy and
+    cross-agent JSD on BOTH the executed-verb stream and the model's CHOSEN
+    stream (``payload.parsed_verb``, falling back to the executed verb).
+
+    The CHOSEN stream is the headline: a positive read requires the model to
+    choose differently under economic pressure, not merely the executor to
+    override verbs (high ``substitution_rate`` with a flat chosen stream is a
+    forced-by-construction result, not emergent behavior).
+    """
+    rows = list(
+        ep.execute(
+            "SELECT actor, action, payload_json FROM events "
+            "WHERE actor NOT IN ('world','harvester','scene')"
+        )
+    )
+    verbset = set(_VERBS)
+    exec_by_agent: dict[str, Counter] = defaultdict(Counter)
+    chosen_by_agent: dict[str, Counter] = defaultdict(Counter)
+    n_total = 0
+    n_sub = 0
+    for r in rows:
+        executed = r["action"]
+        if executed not in verbset:
+            continue
+        payload = json.loads(r["payload_json"]) if r["payload_json"] else {}
+        chosen = payload.get("parsed_verb") or executed
+        if chosen not in verbset:
+            chosen = executed
+        actor = r["actor"]
+        exec_by_agent[actor][executed] += 1
+        chosen_by_agent[actor][chosen] += 1
+        n_total += 1
+        if chosen != executed:
+            n_sub += 1
+
+    executed_block = _diversity_block(exec_by_agent)
+    chosen_block = _diversity_block(chosen_by_agent)
+
+    exec_soc: Counter = Counter()
+    chosen_soc: Counter = Counter()
+    for c in exec_by_agent.values():
+        exec_soc.update(c)
+    for c in chosen_by_agent.values():
+        chosen_soc.update(c)
+    cxe = _jsd_bits(_normalize(exec_soc, _VERBS), _normalize(chosen_soc, _VERBS))
+
+    pass_entropy = chosen_block["society_entropy_norm"] >= entropy_norm_floor
+    pass_divergence = chosen_block["jsd_norm"] >= jsd_norm_floor
+    return {
+        "executed": executed_block,
+        "chosen": chosen_block,
+        "substitution_rate": round((n_sub / n_total) if n_total else 0.0, 4),
+        "chosen_vs_executed_divergence": round(cxe, 4),
+        "entropy_norm_floor": entropy_norm_floor,
+        "jsd_norm_floor": jsd_norm_floor,
+        "pass_entropy": pass_entropy,
+        "pass_divergence": pass_divergence,
+        "pass": pass_entropy and pass_divergence,
+    }
 
 
 def _open_db(path: Path) -> sqlite3.Connection:
@@ -552,6 +712,7 @@ def main(argv: list[str]) -> int:
     g6 = gate6_acceptance_throughput(manifest, metrics)
     g7 = gate7_capacity_invariant(ep)
     g8 = gate8_scene_semantic_dependence(ep)
+    g9 = gate9_verb_diversity(ep)
 
     total_contributes = summarize_contribute_total(ep)
     g4_pass = (g4["fold_count"] / max(1, total_contributes)) < 0.01
@@ -575,6 +736,7 @@ def main(argv: list[str]) -> int:
         "gate_6_acceptance_throughput": g6,
         "gate_7_capacity_invariant": g7,
         "gate_8_scene_semantic_dependence": g8,
+        "gate_9_verb_diversity": g9,
     }
     print(json.dumps(report, indent=2, sort_keys=True))
     return 0

--- a/scripts/spike_workshop_measure.py
+++ b/scripts/spike_workshop_measure.py
@@ -147,8 +147,11 @@ def _diversity_block(by_agent: dict[str, Counter]) -> dict:
     agents = sorted(by_agent)
     dists = [_normalize(by_agent[a], _VERBS) for a in agents]
     per_agent_top = {
-        a: (round(max(by_agent[a].values()) / sum(by_agent[a].values()), 4)
-            if sum(by_agent[a].values()) else 0.0)
+        a: (
+            round(max(by_agent[a].values()) / sum(by_agent[a].values()), 4)
+            if sum(by_agent[a].values())
+            else 0.0
+        )
         for a in agents
     }
     return {

--- a/src/microverse/agents/artisan.py
+++ b/src/microverse/agents/artisan.py
@@ -167,7 +167,7 @@ class Artisan(Agent):
         contribute)."""
         if self._energy is None:
             return action
-        return apply_economy_lever(
+        out = apply_economy_lever(
             action,
             world,
             ledger=self._energy,
@@ -177,6 +177,10 @@ class Artisan(Agent):
             metrics=self._metrics,
             replacement_thought=_ECONOMY_REPLACEMENT_THOUGHT,
         )
+        # Economy-only substitution signal for Gate 9 (kept separate from the
+        # diversity/engagement overrides that also change the verb).
+        self._verb_trace["economy_substituted"] = out.action != action.action
+        return out
 
     def _maybe_enforce_engagement(self, action: Action, world: WorldContext) -> Action:
         """Layer-G slice 3 (R2.b): if the runtime set ``required_target``

--- a/src/microverse/agents/artisan.py
+++ b/src/microverse/agents/artisan.py
@@ -121,7 +121,13 @@ class Artisan(Agent):
         # before any lever runs, so the run loop can stamp it on the committed
         # payload (Gate 9 chosen-vs-executed). Captured even when economy is
         # off; the run loop only stamps it in substitution-enabled modes.
-        self._verb_trace = {"parsed_verb": action.action.value}
+        # ``parse_fallback`` flags a malformed/meta-leak/short-WIP payload that
+        # parse_action folded to a fallback REST (empty thought) — NOT a free
+        # verb choice, so Gate 9 drops it from the chosen-verb stream (review).
+        self._verb_trace = {
+            "parsed_verb": action.action.value,
+            "parse_fallback": action.action == ActionKind.REST and not action.thought,
+        }
         # F.2 must run BEFORE the rest rate-limiter: empty-craft is an
         # active tick that should reset the rest streak, not pass
         # through it as rest.
@@ -138,10 +144,16 @@ class Artisan(Agent):
         # engagement, so an affordability override cannot defeat the engagement
         # gate (which must win) and so the diversity lever's chosen verb is
         # what gets affordability-checked.
-        action = self._maybe_apply_economy(action, world)
+        economy_out = self._maybe_apply_economy(action, world)
         # Engagement gate runs LAST so it overrides any earlier coercion
         # (e.g. the rest rate-limiter picking a different peer).
-        return self._maybe_enforce_engagement(action, world)
+        final = self._maybe_enforce_engagement(economy_out, world)
+        # If engagement overrode the economy verb afterward, the committed verb
+        # is not the economy's — don't credit Gate 9's economy_substitution_rate
+        # for a substitution that never reached the log (review).
+        if final.action != economy_out.action:
+            self._verb_trace["economy_substituted"] = False
+        return final
 
     def _maybe_diversify(self, action: Action, world: WorldContext) -> Action:
         """Phase D Step 2 — delegate to the shared helper. The lever

--- a/src/microverse/agents/artisan.py
+++ b/src/microverse/agents/artisan.py
@@ -34,10 +34,12 @@ from microverse.agents.base import (
     Agent,
     WorldContext,
     apply_diversity_lever,
+    apply_economy_lever,
     parse_action,
 )
 from microverse.config import (
     ARTISAN_REST_STREAK_LIMIT,
+    DIVERSITY_SUBSTITUTE_PROB,
     LLM_MAX_TOKENS,
     LLM_TIMEOUT_S,
     SAMPLING_CREATIVE,
@@ -66,10 +68,14 @@ _EMPTY_CRAFT_REPLACEMENT_THOUGHT = (
 # disobeyed monologue to seed the next tick.
 _ENGAGEMENT_REPLACEMENT_THOUGHT = "I turn from my work to greet a neighbor."
 # Phase D: substitution probability when the LLM ignores novelty_hint
-# and re-emits the dominant verb. 0.30 ≈ 1-in-3, balanced between
-# "agent has agency" and "lever actually moves the share."
-_DIVERSIFY_PROB = 0.30
+# and re-emits the dominant verb. Promoted to config.DIVERSITY_SUBSTITUTE_PROB
+# (ADR 0008 spike) so the economy A/B can prove flag-off is a true no-op
+# without the diversity lever as a moving confound.
 _DIVERSITY_REPLACEMENT_THOUGHT = "I try something other than my usual rhythm today."
+# ADR 0008 spike: neutral replacement thought when the economy lever
+# substitutes an unaffordable verb. Like the F.2 / engagement thoughts it is
+# external-facing and never mentions energy/scarcity meta.
+_ECONOMY_REPLACEMENT_THOUGHT = "I turn to the work my hands have strength for today."
 
 
 class Artisan(Agent):
@@ -111,6 +117,11 @@ class Artisan(Agent):
             agent=self.name,
             workshop=self._workshop,
         )
+        # ADR 0008 spike telemetry: record the model's rawest verb choice
+        # before any lever runs, so the run loop can stamp it on the committed
+        # payload (Gate 9 chosen-vs-executed). Captured even when economy is
+        # off; the run loop only stamps it in substitution-enabled modes.
+        self._verb_trace = {"parsed_verb": action.action.value}
         # F.2 must run BEFORE the rest rate-limiter: empty-craft is an
         # active tick that should reset the rest streak, not pass
         # through it as rest.
@@ -123,6 +134,11 @@ class Artisan(Agent):
         # vs LLM-chosen verbs. Skips when no hint is active (the
         # run-loop only sets novelty_hint above the dominance threshold).
         action = self._maybe_diversify(action, world)
+        # ADR 0008 spike: economy substitution runs AFTER diversity and BEFORE
+        # engagement, so an affordability override cannot defeat the engagement
+        # gate (which must win) and so the diversity lever's chosen verb is
+        # what gets affordability-checked.
+        action = self._maybe_apply_economy(action, world)
         # Engagement gate runs LAST so it overrides any earlier coercion
         # (e.g. the rest rate-limiter picking a different peer).
         return self._maybe_enforce_engagement(action, world)
@@ -140,7 +156,26 @@ class Artisan(Agent):
             metrics=self._metrics,
             agent_name=self.name,
             replacement_thought=_DIVERSITY_REPLACEMENT_THOUGHT,
-            probability=_DIVERSIFY_PROB,
+            probability=DIVERSITY_SUBSTITUTE_PROB,
+        )
+
+    def _maybe_apply_economy(self, action: Action, world: WorldContext) -> Action:
+        """ADR 0008 spike: hard-substitute an unaffordable verb. No-op when no
+        EnergyLedger is attached (economy off / throttle-only mode / a test
+        that does not attach). See ``base.apply_economy_lever`` for the
+        contract (skips scene turns and fallback-rest; never produces
+        contribute)."""
+        if self._energy is None:
+            return action
+        return apply_economy_lever(
+            action,
+            world,
+            ledger=self._energy,
+            role=self.role,
+            agent_name=self.name,
+            rng=self._rng,
+            metrics=self._metrics,
+            replacement_thought=_ECONOMY_REPLACEMENT_THOUGHT,
         )
 
     def _maybe_enforce_engagement(self, action: Action, world: WorldContext) -> Action:

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -562,8 +562,7 @@ def apply_economy_lever(
         return action
     if ledger.can_afford(agent_name, role, action.action.value):
         return action
-    cheapest = ledger.cheapest_affordable_productive(agent_name, role)
-    target_verb = ActionKind(cheapest) if cheapest is not None else ActionKind.REST
+    target_verb = ActionKind(ledger.resolve_executed_verb(agent_name, role, action.action.value))
     if target_verb == action.action:
         return action
     metrics.bump("economy_verb_substituted", agent=agent_name)

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -445,11 +445,13 @@ class Agent(abc.ABC):
         # is a no-op in think() (flag off, throttle-only mode, or a test that
         # does not attach), so think() reproduces pre-spike behavior exactly.
         self._energy: EnergyLedger | None = None
-        # ADR 0008 spike telemetry: the verb the model chose this tick before
-        # the economy lever ran (the rawest parse result). The run loop reads
-        # this when stamping the committed payload so Gate 9 can compare the
-        # CHOSEN stream against the EXECUTED stream. Empty until think() runs.
-        self._verb_trace: dict[str, str] = {}
+        # ADR 0008 spike telemetry the run loop stamps onto the committed
+        # payload (Gate 9): ``parsed_verb`` (the rawest model choice, before any
+        # lever — the CHOSEN stream) and ``economy_substituted`` (bool: did the
+        # economy lever rewrite the verb — the economy-ONLY substitution signal,
+        # so Gate 9 need not conflate it with diversity/engagement/fold
+        # overrides). Empty until think() runs.
+        self._verb_trace: dict[str, object] = {}
 
     def attach_workshop(self, workshop: WorkshopProjection) -> None:
         """Bind a WorkshopProjection for the v0.3 validator hard-fold."""

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -405,6 +405,14 @@ class WorldContext:
     # on #38 flagged the string-parse round-trip as brittle).
     novelty_dominant_verb: str = ""
     novelty_suggested_verb: str = ""
+    # ADR 0008 spike: one-line scarcity signal, mirroring ``novelty_hint``.
+    # Empty when the action economy is off (so flag-off prompts are
+    # byte-identical) or when reserves are ample. When the agent's energy is
+    # low it names the role's cheap specialty and the verbs that are currently
+    # out of reach, so the model can choose affordably ON ITS OWN — the
+    # perception channel without which the economy could only ever FORCE
+    # diversity at the executor, never move the model's chosen verbs.
+    energy_hint: str = ""
     # v1.1 (ADR 0007 Phase 1, Pillar 1): the agent's persistent
     # self-record — static traits, a derived relationship ledger, and a
     # periodically summarized beliefs line. The EXPLICIT Path-3 carve-out
@@ -432,10 +440,26 @@ class Agent(abc.ABC):
         # can hard-fold contributes targeting a complete WIP. Defaults
         # to None for tests that construct an agent without a workshop.
         self._workshop: WorkshopProjection | None = None
+        # ADR 0008 spike: the run loop attaches a shared EnergyLedger ONLY in
+        # economy modes that include substitution. None => the economy lever
+        # is a no-op in think() (flag off, throttle-only mode, or a test that
+        # does not attach), so think() reproduces pre-spike behavior exactly.
+        self._energy: EnergyLedger | None = None
+        # ADR 0008 spike telemetry: the verb the model chose this tick before
+        # the economy lever ran (the rawest parse result). The run loop reads
+        # this when stamping the committed payload so Gate 9 can compare the
+        # CHOSEN stream against the EXECUTED stream. Empty until think() runs.
+        self._verb_trace: dict[str, str] = {}
 
     def attach_workshop(self, workshop: WorkshopProjection) -> None:
         """Bind a WorkshopProjection for the v0.3 validator hard-fold."""
         self._workshop = workshop
+
+    def attach_energy(self, ledger: EnergyLedger) -> None:
+        """Bind the shared EnergyLedger so ``think()`` applies the economy
+        substitution lever (ADR 0008 spike). Only called by the run loop in
+        substitution-enabled economy modes."""
+        self._energy = ledger
 
     def tempo(self) -> float:
         """Seconds to sleep after this agent's tick. Override per role."""

--- a/src/microverse/agents/base.py
+++ b/src/microverse/agents/base.py
@@ -30,6 +30,7 @@ from microverse.world.workshop import WIPView
 
 if TYPE_CHECKING:
     from microverse.ops.metrics import Metrics
+    from microverse.world.economy import EnergyLedger
     from microverse.world.workshop import WorkshopProjection
 
 
@@ -487,6 +488,61 @@ def apply_diversity_lever(
     if rng.random() >= probability:
         return action
     metrics.bump("diversity_lever_substituted", agent=agent_name)
+    new_target: str | None = None
+    if target_verb == ActionKind.SPEAK and world.peers_today:
+        new_target = rng.choice(world.peers_today)
+    return action.model_copy(
+        update={
+            "thought": replacement_thought,
+            "action": target_verb,
+            "target": new_target,
+            "artifact": None,
+            "contribute_to": None,
+        }
+    )
+
+
+# Action-economy lever (re-diagnosis spike — ADR 0008). Sibling of
+# ``apply_diversity_lever``: a HARD substitution (not a probabilistic nudge)
+# when the LLM picks a verb the agent cannot pay for. The substitution target
+# is the cheapest affordable PRODUCTIVE verb (never ``contribute`` — cannot
+# fabricate a WIP + fragment; ``rest`` only as a last resort so the lever
+# drives specialization rather than collapsing onto rest).
+def apply_economy_lever(
+    action: Action,
+    world: WorldContext,
+    *,
+    ledger: EnergyLedger,
+    role: str,
+    agent_name: str,
+    rng: Any,
+    metrics: Metrics,
+    replacement_thought: str,
+) -> Action:
+    """Substitute an unaffordable verb for an affordable one. Returns the
+    action unchanged when:
+
+    - the call is inside a scene turn (``world.scene_wip_name`` set) — the
+      forced ``contribute`` must survive or ``SceneRunner`` aborts the scene;
+    - the parsed action is a fallback REST (empty thought) — the
+      ``json_fallback_rest`` watchdog signal must propagate;
+    - the chosen verb is already affordable;
+    - or the substitution would be a no-op (already the target verb).
+
+    Bumps ``economy_verb_substituted{agent}`` only when it changes the verb.
+    """
+    if world.scene_wip_name:
+        return action
+    is_fallback_rest = action.action == ActionKind.REST and not action.thought
+    if is_fallback_rest:
+        return action
+    if ledger.can_afford(agent_name, role, action.action.value):
+        return action
+    cheapest = ledger.cheapest_affordable_productive(agent_name, role)
+    target_verb = ActionKind(cheapest) if cheapest is not None else ActionKind.REST
+    if target_verb == action.action:
+        return action
+    metrics.bump("economy_verb_substituted", agent=agent_name)
     new_target: str | None = None
     if target_verb == ActionKind.SPEAK and world.peers_today:
         new_target = rng.choice(world.peers_today)

--- a/src/microverse/agents/scholar.py
+++ b/src/microverse/agents/scholar.py
@@ -88,10 +88,21 @@ class Scholar(Agent):
             workshop=self._workshop,
         )
         # ADR 0008 spike telemetry: rawest verb choice before any lever.
-        self._verb_trace = {"parsed_verb": action.action.value}
+        # ``parse_fallback`` flags a parse_action fallback REST (empty thought)
+        # so Gate 9 can drop it from the chosen-verb stream (review).
+        self._verb_trace = {
+            "parsed_verb": action.action.value,
+            "parse_fallback": action.action == ActionKind.REST and not action.thought,
+        }
         action = self._maybe_diversify(action, world)
-        action = self._maybe_apply_economy(action, world)
-        return self._maybe_enforce_engagement(action, world)
+        economy_out = self._maybe_apply_economy(action, world)
+        final = self._maybe_enforce_engagement(economy_out, world)
+        # If engagement overrode the economy verb afterward, the committed verb
+        # is not the economy's — don't credit Gate 9's economy_substitution_rate
+        # for a substitution that never reached the log (review).
+        if final.action != economy_out.action:
+            self._verb_trace["economy_substituted"] = False
+        return final
 
     def _maybe_diversify(self, action: Action, world: WorldContext) -> Action:
         """Phase D substitution lever — delegate to the shared helper.

--- a/src/microverse/agents/scholar.py
+++ b/src/microverse/agents/scholar.py
@@ -111,7 +111,7 @@ class Scholar(Agent):
         EnergyLedger is attached. See ``base.apply_economy_lever``."""
         if self._energy is None:
             return action
-        return apply_economy_lever(
+        out = apply_economy_lever(
             action,
             world,
             ledger=self._energy,
@@ -121,6 +121,8 @@ class Scholar(Agent):
             metrics=self._metrics,
             replacement_thought=_ECONOMY_REPLACEMENT_THOUGHT,
         )
+        self._verb_trace["economy_substituted"] = out.action != action.action
+        return out
 
     def _maybe_enforce_engagement(self, action: Action, world: WorldContext) -> Action:
         """Shared with Artisan (semantics identical). Coerce a non-

--- a/src/microverse/agents/scholar.py
+++ b/src/microverse/agents/scholar.py
@@ -29,9 +29,15 @@ from microverse.agents.base import (
     Agent,
     WorldContext,
     apply_diversity_lever,
+    apply_economy_lever,
     parse_action,
 )
-from microverse.config import LLM_MAX_TOKENS, LLM_TIMEOUT_S, SAMPLING_FACTUAL
+from microverse.config import (
+    DIVERSITY_SUBSTITUTE_PROB,
+    LLM_MAX_TOKENS,
+    LLM_TIMEOUT_S,
+    SAMPLING_FACTUAL,
+)
 from microverse.llm.ollama_client import chat
 from microverse.ops.metrics import Metrics
 from microverse.prompts import render
@@ -39,9 +45,11 @@ from microverse.prompts import render
 _PERSONA_TEMPLATE = "persona_scholar.j2"
 
 _ENGAGEMENT_REPLACEMENT_THOUGHT = "I set my notes aside to greet a neighbor."
-# Phase D: mirror Artisan's substitution constants for scholar.
-_DIVERSIFY_PROB = 0.30
+# Phase D: mirror Artisan's substitution constants for scholar. The
+# probability is now config.DIVERSITY_SUBSTITUTE_PROB (ADR 0008 spike).
 _DIVERSITY_REPLACEMENT_THOUGHT = "I try a different rhythm today."
+# ADR 0008 spike: neutral replacement thought for economy substitution.
+_ECONOMY_REPLACEMENT_THOUGHT = "I turn to the work I have the focus for today."
 
 
 class Scholar(Agent):
@@ -79,7 +87,10 @@ class Scholar(Agent):
             agent=self.name,
             workshop=self._workshop,
         )
+        # ADR 0008 spike telemetry: rawest verb choice before any lever.
+        self._verb_trace = {"parsed_verb": action.action.value}
         action = self._maybe_diversify(action, world)
+        action = self._maybe_apply_economy(action, world)
         return self._maybe_enforce_engagement(action, world)
 
     def _maybe_diversify(self, action: Action, world: WorldContext) -> Action:
@@ -92,7 +103,23 @@ class Scholar(Agent):
             metrics=self._metrics,
             agent_name=self.name,
             replacement_thought=_DIVERSITY_REPLACEMENT_THOUGHT,
-            probability=_DIVERSIFY_PROB,
+            probability=DIVERSITY_SUBSTITUTE_PROB,
+        )
+
+    def _maybe_apply_economy(self, action: Action, world: WorldContext) -> Action:
+        """ADR 0008 spike: hard-substitute an unaffordable verb. No-op when no
+        EnergyLedger is attached. See ``base.apply_economy_lever``."""
+        if self._energy is None:
+            return action
+        return apply_economy_lever(
+            action,
+            world,
+            ledger=self._energy,
+            role=self.role,
+            agent_name=self.name,
+            rng=self._rng,
+            metrics=self._metrics,
+            replacement_thought=_ECONOMY_REPLACEMENT_THOUGHT,
         )
 
     def _maybe_enforce_engagement(self, action: Action, world: WorldContext) -> Action:

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -6,6 +6,8 @@ caps. Importable from anywhere — keep this module dependency-free.
 
 from __future__ import annotations
 
+import os
+
 # Single-model invariant. Every LLM call goes here. No router, no fallback.
 # v0.3 (ADR 0004 Decision 5): swapped from "gemma4:e4b" (9.6 GB) to
 # "gemma4:26b" (17 GB) — same model family (prompt format, tokenizer,
@@ -209,3 +211,52 @@ SCENE_GATE_P: float = 0.15
 # rotation: turn 2 reads turn 1, turn 3 reads turn 1+2. Raising this
 # back to >= 2 requires growing the default roster first.
 SCENE_MIN_PEERS: int = 1
+
+# ----------------------------------------------------------------------
+# Action-economy spike (re-diagnosis under HALT — ADR 0008).
+#
+# Falsifiable test of ADR 0008's claim that Gate 3 (verb monoculture) is
+# STRUCTURAL and needs an action-economy lever, not identity. A finite
+# per-agent stamina pool + comparative-advantage verb costs make each role
+# cheap at its specialty and dear elsewhere; the scene-initiation gate and a
+# hard-substitution lever are the two mechanisms. Env-driven so all A/B arms
+# run from a single commit (no edit between runs):
+#
+#   "0"        off — constructs no ledger; reproduces current main EXACTLY.
+#   "1"        role-advantage (both mechanisms: scene gate + substitution).
+#   "flat"     role-agnostic control (both mechanisms, no cheap specialty).
+#   "throttle" ablation: scene gate only (no substitution).
+#   "sub"      ablation: substitution only (no scene gate).
+#
+# The "flat" control and the two ablations exist to attribute any diversity
+# gain (Codex review): is it comparative advantage, or merely a uniform
+# contribute throttle, or merely executor override?
+ECONOMY_MODE: str = os.environ.get("MICROVERSE_ECONOMY", "0")
+ECONOMY_ENABLED: bool = ECONOMY_MODE != "0"
+_ECONOMY_SCENE_GATE: bool = ECONOMY_MODE in ("1", "flat", "throttle")
+_ECONOMY_SUBSTITUTE: bool = ECONOMY_MODE in ("1", "flat", "sub")
+
+# Finite stamina pool. Regen sits between the cheap specialty (~6) and the
+# dear contribute (~22) so a role can sustain its specialty indefinitely but
+# must save up across cheaper/idle ticks to afford an off-specialty verb or
+# to re-initiate a scene — the scarcity pressure that should diversify the mix.
+ENERGY_MAX: float = 100.0
+ENERGY_REGEN_PER_TICK: float = 12.0
+
+# Comparative advantage: each role is cheap at exactly one productive verb
+# (its strict specialty) and dear elsewhere. ``rest`` is free for every role
+# (always affordable — the energy analog of the scheduler's
+# ``max(soul_tokens, 1)`` floor, so the system can never deadlock on energy).
+VERB_COST_BY_ROLE: dict[str, dict[str, float]] = {
+    "artisan": {"craft": 6.0, "study": 14.0, "speak": 16.0, "travel": 18.0,
+                "rest": 0.0, "contribute": 22.0},
+    "scholar": {"study": 6.0, "speak": 10.0, "craft": 18.0, "travel": 16.0,
+                "rest": 0.0, "contribute": 14.0},
+    "stranger": {"travel": 6.0, "speak": 10.0, "study": 12.0, "craft": 16.0,
+                 "rest": 0.0, "contribute": 18.0},
+}
+
+# Phase D diversity-lever substitution probability, promoted out of the
+# hardcoded agent constants so the A/B can prove the economy flag-off arm is a
+# true no-op without the diversity lever as a confound.
+DIVERSITY_SUBSTITUTE_PROB: float = 0.30

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -248,12 +248,30 @@ ENERGY_REGEN_PER_TICK: float = 12.0
 # (always affordable — the energy analog of the scheduler's
 # ``max(soul_tokens, 1)`` floor, so the system can never deadlock on energy).
 VERB_COST_BY_ROLE: dict[str, dict[str, float]] = {
-    "artisan": {"craft": 6.0, "study": 14.0, "speak": 16.0, "travel": 18.0,
-                "rest": 0.0, "contribute": 22.0},
-    "scholar": {"study": 6.0, "speak": 10.0, "craft": 18.0, "travel": 16.0,
-                "rest": 0.0, "contribute": 14.0},
-    "stranger": {"travel": 6.0, "speak": 10.0, "study": 12.0, "craft": 16.0,
-                 "rest": 0.0, "contribute": 18.0},
+    "artisan": {
+        "craft": 6.0,
+        "study": 14.0,
+        "speak": 16.0,
+        "travel": 18.0,
+        "rest": 0.0,
+        "contribute": 22.0,
+    },
+    "scholar": {
+        "study": 6.0,
+        "speak": 10.0,
+        "craft": 18.0,
+        "travel": 16.0,
+        "rest": 0.0,
+        "contribute": 14.0,
+    },
+    "stranger": {
+        "travel": 6.0,
+        "speak": 10.0,
+        "study": 12.0,
+        "craft": 16.0,
+        "rest": 0.0,
+        "contribute": 18.0,
+    },
 }
 
 # Phase D diversity-lever substitution probability, promoted out of the

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -231,6 +231,10 @@ SCENE_MIN_PEERS: int = 1
 # The "flat" control and the two ablations exist to attribute any diversity
 # gain (Codex review): is it comparative advantage, or merely a uniform
 # contribute throttle, or merely executor override?
+# The full set of recognized modes. An unrecognized value (e.g. a typo) would
+# otherwise build a ledger with neither gate nor substitution — a silent,
+# unlabeled experiment arm — so run() validates against this set and fails fast.
+VALID_ECONOMY_MODES: frozenset[str] = frozenset({"0", "1", "flat", "throttle", "sub"})
 ECONOMY_MODE: str = os.environ.get("MICROVERSE_ECONOMY", "0")
 ECONOMY_ENABLED: bool = ECONOMY_MODE != "0"
 _ECONOMY_SCENE_GATE: bool = ECONOMY_MODE in ("1", "flat", "throttle")

--- a/src/microverse/memory/episodic.py
+++ b/src/microverse/memory/episodic.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -121,6 +122,27 @@ class EpisodicMemory:
             )
             for r in rows
         ]
+
+    def iter_chronological(self) -> Iterator[Event]:
+        """Yield every event oldest-first, streaming via a cursor.
+
+        Unlike ``last(count())`` + reverse, this never materializes the whole
+        log (plus a reversed copy) in memory — a real cost on multi-week soaks
+        whose event count grows without bound. Used by the energy-ledger restart
+        reconstruction, which replays the full history but needs only one event
+        at a time (review)."""
+        cur = self._conn.execute(
+            "SELECT id, ts, actor, action, target, payload_json FROM events ORDER BY id ASC"
+        )
+        for r in cur:
+            yield Event(
+                id=r[0],
+                ts=r[1],
+                actor=r[2],
+                action=r[3],
+                target=r[4],
+                payload=json.loads(r[5]) if r[5] else {},
+            )
 
     def since(self, ts_floor: float, *, limit: int | None = None) -> list[Event]:
         """Return events with ``ts >= ts_floor`` ordered newest-first.

--- a/src/microverse/prompts/persona_artisan.j2
+++ b/src/microverse/prompts/persona_artisan.j2
@@ -53,9 +53,9 @@ You are opening the scene; write the first fragment.
 {% if world.novelty_hint -%}
 {{ world.novelty_hint }}
 {% endif %}
-{% if world.energy_hint -%}
+{%- if world.energy_hint %}
 {{ world.energy_hint }}
-{% endif %}
+{%- endif %}
 {% if world.engagement_hint -%}
 {{ world.engagement_hint }}
 {% endif %}

--- a/src/microverse/prompts/persona_artisan.j2
+++ b/src/microverse/prompts/persona_artisan.j2
@@ -53,6 +53,9 @@ You are opening the scene; write the first fragment.
 {% if world.novelty_hint -%}
 {{ world.novelty_hint }}
 {% endif %}
+{% if world.energy_hint -%}
+{{ world.energy_hint }}
+{% endif %}
 {% if world.engagement_hint -%}
 {{ world.engagement_hint }}
 {% endif %}

--- a/src/microverse/prompts/persona_scholar.j2
+++ b/src/microverse/prompts/persona_scholar.j2
@@ -53,6 +53,9 @@ You are opening the scene; write the first observation.
 {% if world.novelty_hint -%}
 {{ world.novelty_hint }}
 {% endif %}
+{% if world.energy_hint -%}
+{{ world.energy_hint }}
+{% endif %}
 {% if world.engagement_hint -%}
 {{ world.engagement_hint }}
 {% endif %}

--- a/src/microverse/prompts/persona_scholar.j2
+++ b/src/microverse/prompts/persona_scholar.j2
@@ -53,9 +53,9 @@ You are opening the scene; write the first observation.
 {% if world.novelty_hint -%}
 {{ world.novelty_hint }}
 {% endif %}
-{% if world.energy_hint -%}
+{%- if world.energy_hint %}
 {{ world.energy_hint }}
-{% endif %}
+{%- endif %}
 {% if world.engagement_hint -%}
 {{ world.engagement_hint }}
 {% endif %}

--- a/src/microverse/prompts/persona_stranger.j2
+++ b/src/microverse/prompts/persona_stranger.j2
@@ -51,6 +51,9 @@ You are opening the scene; write the first fragment.
 {% if world.novelty_hint -%}
 {{ world.novelty_hint }}
 {% endif %}
+{% if world.energy_hint -%}
+{{ world.energy_hint }}
+{% endif %}
 
 # Your task this tick
 Decide ONE action. Output STRICT JSON with exactly these keys:

--- a/src/microverse/prompts/persona_stranger.j2
+++ b/src/microverse/prompts/persona_stranger.j2
@@ -51,9 +51,9 @@ You are opening the scene; write the first fragment.
 {% if world.novelty_hint -%}
 {{ world.novelty_hint }}
 {% endif %}
-{% if world.energy_hint -%}
+{%- if world.energy_hint %}
 {{ world.energy_hint }}
-{% endif %}
+{%- endif %}
 
 # Your task this tick
 Decide ONE action. Output STRICT JSON with exactly these keys:

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -38,7 +38,7 @@ import signal
 import sys
 import time
 from collections import Counter
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import ExitStack
 from pathlib import Path
 
@@ -330,23 +330,21 @@ def _lazy_attach_energy(agent: Agent, energy: EnergyLedger | None) -> None:
         agent.attach_energy(energy)
 
 
-def _replay_energy_events(episodic: EpisodicMemory) -> list[tuple[str, str, str]]:
-    """Chronological ``(actor, role, verb)`` for committed agent actions, used
-    to reconstruct the EnergyLedger on restart (ADR 0008 spike). Role is read
-    from each event's payload (written by ``_commit_action``); world/scene/
-    harvester pseudo-actors and namespaced events are skipped. Best-effort and
-    approximate — see ``EnergyLedger.reconstruct_from_events``."""
+def _replay_energy_events(episodic: EpisodicMemory) -> Iterator[tuple[str, str, str]]:
+    """Stream chronological ``(actor, role, verb)`` for committed agent actions,
+    used to reconstruct the EnergyLedger on restart (ADR 0008 spike). Role is
+    read from each event's payload (written by ``_commit_action``); world/scene/
+    harvester pseudo-actors and namespaced events are skipped. A generator over
+    ``iter_chronological`` so a multi-week log is never fully materialized in
+    memory (review). Best-effort and approximate — see
+    ``EnergyLedger.reconstruct_from_events``."""
     verbset = {k.value for k in ActionKind}
-    rows = episodic.last(episodic.count())
-    rows.reverse()  # episodic.last is newest-first; flip to chronological
-    out: list[tuple[str, str, str]] = []
-    for ev in rows:
+    for ev in episodic.iter_chronological():
         if ev.actor in ("world", "scene", "harvester") or ev.action not in verbset:
             continue
         role = str(ev.payload.get("role", ""))
         if role:
-            out.append((ev.actor, role, ev.action))
-    return out
+            yield (ev.actor, role, ev.action)
 
 
 class _RelationshipLedgerCache:

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -38,7 +38,7 @@ import signal
 import sys
 import time
 from collections import Counter
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import ExitStack
 from pathlib import Path
 
@@ -56,6 +56,7 @@ from microverse.memory.semantic import SemanticMemory
 from microverse.ops.metrics import Metrics
 from microverse.ops.watchdog import Watchdog
 from microverse.world.clock import WorldClock
+from microverse.world.economy import EnergyLedger, build_cost_table
 from microverse.world.relationships import derive_relationships
 from microverse.world.scene import SceneRunner
 from microverse.world.scheduler import WeightedScheduler
@@ -286,6 +287,50 @@ def _compute_novelty_hint(episodic: EpisodicMemory, agent: Agent) -> tuple[str, 
     return (hint, top_verb, suggested)
 
 
+def _compute_energy_hint(energy: EnergyLedger | None, agent: Agent) -> str:
+    """ADR 0008 spike: one-line scarcity signal for the persona, mirroring
+    ``novelty_hint``. Empty when the economy is off (so flag-off prompts are
+    byte-identical) or when reserves are ample. When some productive verbs are
+    unaffordable it names the verbs out of reach and the verb that still comes
+    easily (the role's cheap specialty under the role-advantage table; a stable
+    tie under the flat control), so the model can choose affordably on its own
+    — the perception channel that lets the CHOSEN-verb stream actually move.
+    """
+    if energy is None:
+        return ""
+    productive = ["speak", "craft", "study", "travel", "contribute"]
+    unaffordable = [v for v in productive if not energy.can_afford(agent.name, agent.role, v)]
+    if not unaffordable:
+        return ""
+    cheapest = energy.cheapest_affordable_productive(agent.name, agent.role)
+    out_of_reach = ", ".join(unaffordable)
+    if cheapest:
+        return (
+            f"Your reserves are low: {out_of_reach} feel out of reach right now, "
+            f"but {cheapest} still comes easily."
+        )
+    return f"Your reserves are spent; rest before attempting {out_of_reach}."
+
+
+def _replay_energy_events(episodic: EpisodicMemory) -> list[tuple[str, str, str]]:
+    """Chronological ``(actor, role, verb)`` for committed agent actions, used
+    to reconstruct the EnergyLedger on restart (ADR 0008 spike). Role is read
+    from each event's payload (written by ``_commit_action``); world/scene/
+    harvester pseudo-actors and namespaced events are skipped. Best-effort and
+    approximate — see ``EnergyLedger.reconstruct_from_events``."""
+    verbset = {k.value for k in ActionKind}
+    rows = episodic.last(episodic.count())
+    rows.reverse()  # episodic.last is newest-first; flip to chronological
+    out: list[tuple[str, str, str]] = []
+    for ev in rows:
+        if ev.actor in ("world", "scene", "harvester") or ev.action not in verbset:
+            continue
+        role = str(ev.payload.get("role", ""))
+        if role:
+            out.append((ev.actor, role, ev.action))
+    return out
+
+
 class _RelationshipLedgerCache:
     """Throttle full-history relationship derivation.
 
@@ -425,6 +470,7 @@ def _build_per_tick_world_base(
     novelty_hint: str = "",
     novelty_dominant_verb: str = "",
     novelty_suggested_verb: str = "",
+    energy_hint: str = "",
     self_view: SelfView | None = None,
 ) -> WorldContext:
     """Assemble the per-tick ``world_base`` for ``build_context``.
@@ -460,6 +506,7 @@ def _build_per_tick_world_base(
         novelty_hint=novelty_hint,
         novelty_dominant_verb=novelty_dominant_verb,
         novelty_suggested_verb=novelty_suggested_verb,
+        energy_hint=energy_hint,
         self_view=self_view if self_view is not None else SelfView(),
     )
 
@@ -470,6 +517,7 @@ def _commit_action(
     action: Action,
     *,
     workshop: WorkshopProjection | None = None,
+    extra_payload: Mapping[str, object] | None = None,
 ) -> int:
     """Append the action to the episodic log and, when it is a
     workshop ``contribute``, mirror it into the WorkshopProjection.
@@ -478,12 +526,18 @@ def _commit_action(
     projection reads (and that the workshop view renders); the
     episodic event also records ``thought`` and ``artifact`` for
     parity with other actions so the audit trail is identical.
+
+    ``extra_payload`` merges additional keys (ADR 0008 spike telemetry —
+    ``parsed_verb``). The run loop passes it only in substitution-enabled
+    economy modes, so a flag-off run writes a byte-identical payload.
     """
     payload: dict[str, object] = {
         "thought": action.thought,
         "artifact": action.artifact,
         "role": agent.role,
     }
+    if extra_payload:
+        payload.update(extra_payload)
     target: str | None = action.target
     if action.action == ActionKind.CONTRIBUTE:
         # contribute_to is the workshop WIP name; target on episodic
@@ -680,6 +734,27 @@ def run(
         # Trader scheduling is internal — it ranks the buffer at flush time,
         # not as a tick action. We don't register it in the scheduler.
 
+        # ADR 0008 spike: the shared action-economy ledger. Constructed only
+        # when the economy is enabled (mode != "0"); otherwise None, so every
+        # deduct/regen/scene-gate/substitution site below is a no-op and the
+        # run reproduces pre-spike behavior exactly. Reconstructed from the WAL
+        # so a restart approximates an uninterrupted run (energy is never
+        # persisted; the WAL stays the durability boundary). Attached to agents
+        # for the substitution lever only in substitution-enabled modes; the
+        # scene gate uses ``energy`` directly regardless.
+        energy: EnergyLedger | None = None
+        if config.ECONOMY_ENABLED:
+            energy = EnergyLedger.fresh(
+                [a.name for a in sched.agents],
+                max_energy=config.ENERGY_MAX,
+                regen_per_tick=config.ENERGY_REGEN_PER_TICK,
+                cost_table=build_cost_table(config.ECONOMY_MODE),
+            )
+            energy.reconstruct_from_events(_replay_energy_events(episodic))
+            if config._ECONOMY_SUBSTITUTE:
+                for agent in sched.agents:
+                    agent.attach_energy(energy)
+
         # v1.1: throttle-cache for the full-history relationship ledger so
         # it is not recomputed from scratch on every agent on every tick.
         rel_ledger = _RelationshipLedgerCache(episodic, refresh_events=REL_LEDGER_REFRESH_EVENTS)
@@ -825,6 +900,7 @@ def run(
                 novelty_hint=novelty_hint,
                 novelty_dominant_verb=novelty_dominant_verb,
                 novelty_suggested_verb=novelty_suggested_verb,
+                energy_hint=_compute_energy_hint(energy, agent),
                 self_view=_build_self_view(
                     episodic,
                     agent,
@@ -855,10 +931,22 @@ def run(
                 (w for w in workshop.wips() if w.phase != "complete"),
                 None,
             )
+            # ADR 0008 spike: in scene-gate economy modes (1/flat/throttle) an
+            # agent can only OPEN a scene if it can afford a contribute. This
+            # is the only economy interaction with scenes — evaluated BEFORE
+            # any scene.open is emitted, so there are no partial/orphaned
+            # scenes and the ADR 0006 scene contract is untouched. The three
+            # scene contributes are paid at commit, never substituted.
+            scene_energy_ok = (
+                energy is None
+                or not config._ECONOMY_SCENE_GATE
+                or energy.can_afford(agent.name, agent.role, "contribute")
+            )
             scene_eligible = (
                 config.SCENE_GATE_P > 0
                 and open_wip is not None
                 and len(other_peers) >= config.SCENE_MIN_PEERS
+                and scene_energy_ok
                 and rng.random() < config.SCENE_GATE_P
             )
             if scene_eligible and open_wip is not None:
@@ -884,6 +972,7 @@ def run(
                         engagement_hint="",
                         required_target=None,
                         metrics=metrics,
+                        energy_hint=_compute_energy_hint(energy, agent),
                         self_view=_build_self_view(
                             episodic,
                             agent,
@@ -913,6 +1002,11 @@ def run(
 
                 def _scene_commit(a: Agent, act: Action) -> None:
                     _commit_action(episodic, a, act, workshop=workshop)
+                    # ADR 0008 spike: the scene's forced contributes are paid
+                    # here (never substituted). No telemetry stamped: a scene
+                    # turn is a forced contribute, so parsed == executed.
+                    if energy is not None:
+                        energy.deduct(a.name, a.role, act.action.value)
                     if act.action == ActionKind.CONTRIBUTE and act.contribute_to:
                         wip_target_counts[act.contribute_to] += 1
                     _maybe_harvest(harvester, a, act)
@@ -933,6 +1027,11 @@ def run(
                 metrics.reset("consecutive_fail", agent=agent.name)
                 deadlock_breaks_since_success = 0
                 executed += 1
+                # ADR 0008 spike: whole-roster regen once per tick (fair across
+                # the scheduler's weighting; non-acting agents also recover).
+                if energy is not None:
+                    for a in sched.agents:
+                        energy.regen(a.name)
                 # Skip single-tick path for this tick.
                 # World clock + watchdog still run per-tick below via
                 # the shared trailing block.
@@ -1006,7 +1105,19 @@ def run(
                 continue
             metrics.reset("consecutive_fail", agent=agent.name)
             deadlock_breaks_since_success = 0
-            _commit_action(episodic, agent, action, workshop=workshop)
+            # ADR 0008 spike: stamp the model's pre-economy verb so Gate 9 can
+            # compare CHOSEN vs EXECUTED. Stamped ONLY in substitution-enabled
+            # modes, so a flag-off run writes a byte-identical payload.
+            extra_payload = (
+                dict(agent._verb_trace)
+                if (energy is not None and config._ECONOMY_SUBSTITUTE)
+                else None
+            )
+            _commit_action(
+                episodic, agent, action, workshop=workshop, extra_payload=extra_payload
+            )
+            if energy is not None:
+                energy.deduct(agent.name, agent.role, action.action.value)
             if action.action == ActionKind.CONTRIBUTE and action.contribute_to:
                 wip_target_counts[action.contribute_to] += 1
             _maybe_harvest(harvester, agent, action)
@@ -1016,6 +1127,10 @@ def run(
             # ``EpisodicMemory.append`` default-ts contract.
             last_tick_ts[agent.name] = time.time()
             executed += 1
+            # ADR 0008 spike: whole-roster regen once per tick.
+            if energy is not None:
+                for a in sched.agents:
+                    energy.regen(a.name)
 
             # World clock + watchdog: cheap, run every tick / every Nth.
             _safe("WorldClock.advance", lambda: clock.advance(episodic, ticks_elapsed=1))

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -295,8 +295,12 @@ def _compute_energy_hint(energy: EnergyLedger | None, agent: Agent) -> str:
     easily (the role's cheap specialty under the role-advantage table; a stable
     tie under the flat control), so the model can choose affordably on its own
     — the perception channel that lets the CHOSEN-verb stream actually move.
+
+    Gated behind ``_ECONOMY_SUBSTITUTE`` (modes 1/flat/sub) so the prompt-level
+    pressure is paired with the substitution lever: the ``throttle`` ablation
+    stays a CLEAN scene-gate-only arm with no prompt hint (Codex review).
     """
-    if energy is None:
+    if energy is None or not config._ECONOMY_SUBSTITUTE:
         return ""
     productive = ["speak", "craft", "study", "travel", "contribute"]
     unaffordable = [v for v in productive if not energy.can_afford(agent.name, agent.role, v)]
@@ -942,12 +946,18 @@ def run(
                 or not config._ECONOMY_SCENE_GATE
                 or energy.can_afford(agent.name, agent.role, "contribute")
             )
+            # The scene roll is consumed BEFORE the energy precondition so the
+            # seeded rng stream stays identical across economy arms (Codex
+            # review): an OFF run draws exactly when baseline did, and an ON run
+            # draws the same — energy only suppresses the scene, it never skips
+            # the draw. ``scene_energy_ok`` is last so OFF (always True) is
+            # rng-identical to the pre-spike loop.
             scene_eligible = (
                 config.SCENE_GATE_P > 0
                 and open_wip is not None
                 and len(other_peers) >= config.SCENE_MIN_PEERS
-                and scene_energy_ok
                 and rng.random() < config.SCENE_GATE_P
+                and scene_energy_ok
             )
             if scene_eligible and open_wip is not None:
                 # Scene path. Build a SceneRunner with closures over
@@ -1004,7 +1014,11 @@ def run(
                     _commit_action(episodic, a, act, workshop=workshop)
                     # ADR 0008 spike: the scene's forced contributes are paid
                     # here (never substituted). No telemetry stamped: a scene
-                    # turn is a forced contribute, so parsed == executed.
+                    # turn is a forced contribute, so parsed == executed. Only
+                    # the INITIATOR's contribute affordability gates the scene
+                    # (above); turn-2/3 authors are not pre-checked, so their
+                    # deduct may clamp at 0 (a known approximation — the
+                    # initiation throttle is the lever, not per-turn gating).
                     if energy is not None:
                         energy.deduct(a.name, a.role, act.action.value)
                     if act.action == ActionKind.CONTRIBUTE and act.contribute_to:

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -316,6 +316,20 @@ def _compute_energy_hint(energy: EnergyLedger | None, agent: Agent) -> str:
     return f"Your reserves are spent; rest before attempting {out_of_reach}."
 
 
+def _lazy_attach_energy(agent: Agent, energy: EnergyLedger | None) -> None:
+    """Attach the ledger to an agent that lacks one (ADR 0008 spike).
+
+    The startup roster is attached once at construction, but the Watchdog can
+    register a Stranger mid-run (``ops/watchdog.py``) without an EnergyLedger.
+    Such a Stranger would keep ``_energy is None`` and so escape the
+    substitution lever, executing unaffordable verbs while the resident agents
+    are constrained — biasing the A/B and Gate 9 (review). Attaching it here on
+    its first scheduled tick restores parity with the startup roster. No-op when
+    the economy is off, in a non-substitution mode, or already attached."""
+    if energy is not None and config._ECONOMY_SUBSTITUTE and agent._energy is None:
+        agent.attach_energy(energy)
+
+
 def _replay_energy_events(episodic: EpisodicMemory) -> list[tuple[str, str, str]]:
     """Chronological ``(actor, role, verb)`` for committed agent actions, used
     to reconstruct the EnergyLedger on restart (ADR 0008 spike). Role is read
@@ -746,6 +760,14 @@ def run(
         # persisted; the WAL stays the durability boundary). Attached to agents
         # for the substitution lever only in substitution-enabled modes; the
         # scene gate uses ``energy`` directly regardless.
+        if config.ECONOMY_MODE not in config.VALID_ECONOMY_MODES:
+            # Fail fast: an unrecognized MICROVERSE_ECONOMY (e.g. a typo) would
+            # otherwise silently run an unlabeled no-op arm (ECONOMY_ENABLED but
+            # neither gate nor substitution), corrupting the A/B (review).
+            raise ValueError(
+                f"MICROVERSE_ECONOMY={config.ECONOMY_MODE!r} is not a valid economy mode; "
+                f"expected one of {sorted(config.VALID_ECONOMY_MODES)}"
+            )
         energy: EnergyLedger | None = None
         if config.ECONOMY_ENABLED:
             energy = EnergyLedger.fresh(
@@ -864,6 +886,11 @@ def run(
                     consecutive_skips = 0
                 continue
             consecutive_skips = 0
+            # ADR 0008 spike: a Watchdog-spawned Stranger registers mid-run
+            # without an EnergyLedger; attach it here so the lever + hints apply
+            # to it like the startup roster (no-op when economy off / already
+            # attached). Must precede think() / the scene gate this tick.
+            _lazy_attach_energy(agent, energy)
             # Topic depends on agent.role, so derive per-tick: Watchdog
             # may spawn Strangers mid-run and a cached topic from the
             # initial agent would mis-tag their lore retrieval.
@@ -982,7 +1009,12 @@ def run(
                         engagement_hint="",
                         required_target=None,
                         metrics=metrics,
-                        energy_hint=_compute_energy_hint(energy, agent),
+                        # No energy_hint inside a scene (ADR 0006): scene turns
+                        # are forced contributes, and the lever already skips
+                        # them. A scarcity hint could nudge the author off
+                        # contribute and abort the scene, so it must be silent
+                        # here too (review). Scene throttling is initiation-only.
+                        energy_hint="",
                         self_view=_build_self_view(
                             episodic,
                             agent,

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -1113,9 +1113,7 @@ def run(
                 if (energy is not None and config._ECONOMY_SUBSTITUTE)
                 else None
             )
-            _commit_action(
-                episodic, agent, action, workshop=workshop, extra_payload=extra_payload
-            )
+            _commit_action(episodic, agent, action, workshop=workshop, extra_payload=extra_payload)
             if energy is not None:
                 energy.deduct(agent.name, agent.role, action.action.value)
             if action.action == ActionKind.CONTRIBUTE and action.contribute_to:

--- a/src/microverse/world/economy.py
+++ b/src/microverse/world/economy.py
@@ -1,0 +1,146 @@
+"""Action-economy scarcity lever — re-diagnosis spike for the ADR 0008 halt.
+
+ADR 0008 halted identity Phase 1 because neither Gate 1 nor Gate 3 moved,
+and diagnosed Gate 3 (verb monoculture) as *structural*: the scene/workshop
+loop funnels ~95% of actions into ``contribute``, and "no identity layer can
+diversify verbs without changing the action economy itself."
+
+This module is the smallest viable slice of ADR 0007 Pillar 2 (scarcity +
+comparative advantage) used to test that claim falsifiably. Each agent has a
+finite stamina pool that regenerates per tick; each verb has a per-role cost
+so roles are cheap at their specialty and dear elsewhere. When the LLM picks
+a verb the agent cannot afford, the run loop substitutes the cheapest
+affordable productive verb (see :func:`microverse.agents.base.apply_economy_lever`).
+
+Invariants this module preserves:
+  * **In-memory only.** The ledger is NEVER persisted; the WAL stays the
+    durability boundary. A cold start resets every pool to ``max_energy``,
+    identical to process start. Do not persist it — that would make energy a
+    recovery dependency. Restart equivalence is handled by reconstructing the
+    pool from the WAL at startup (see ``run.py``), not by storing it.
+  * **No LLM calls.** The single-model invariant for ``agent.think()`` is
+    untouched; this module never imports the Ollama client.
+
+The whole lever is feature-flagged in ``config`` (``ECONOMY_MODE``): mode
+``"0"`` constructs no ledger and reproduces current ``main`` behavior exactly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+CostTable = Mapping[str, Mapping[str, float]]
+
+# Verbs that are NOT a free choice the lever may substitute toward:
+# ``contribute`` is excluded because the lever cannot fabricate a WIP +
+# fragment. ``rest`` is excluded from the *primary* candidates so the lever
+# drives specialization (toward the role's cheap productive verb) rather than
+# collapsing every constrained tick onto rest; rest is only the last resort.
+_NON_SUBSTITUTABLE = frozenset({"contribute", "rest"})
+
+
+def derive_flat_table(table: CostTable) -> dict[str, dict[str, float]]:
+    """Role-agnostic control variant of ``table`` (Codex confound control).
+
+    Keeps each role's ``contribute`` cost (so the scene-initiation throttle is
+    IDENTICAL to the role-advantage arm) and ``rest`` (free), but flattens the
+    four remaining productive verbs to a single shared per-role cost (their
+    mean). This removes the comparative advantage while holding everything
+    else constant, isolating "specialization diversifies" from "a uniform
+    contribute throttle diversifies".
+    """
+    flat: dict[str, dict[str, float]] = {}
+    for role, costs in table.items():
+        others = [v for v in costs if v not in _NON_SUBSTITUTABLE]
+        shared = sum(costs[v] for v in others) / len(others) if others else 0.0
+        flat[role] = {
+            v: (0.0 if v == "rest" else costs[v] if v == "contribute" else shared) for v in costs
+        }
+    return flat
+
+
+def build_cost_table(mode: str) -> dict[str, dict[str, float]]:
+    """Resolve the per-mode cost table.
+
+    ``"flat"`` returns the role-agnostic control; every other economy mode
+    (``"1"``, ``"sub"``, ``"throttle"``) uses the role-advantage table.
+    """
+    from microverse.config import VERB_COST_BY_ROLE
+
+    if mode == "flat":
+        return derive_flat_table(VERB_COST_BY_ROLE)
+    return {role: dict(costs) for role, costs in VERB_COST_BY_ROLE.items()}
+
+
+class EnergyLedger:
+    """Per-agent finite stamina with per-tick regen. In-memory only.
+
+    ``cost_table`` maps ``role -> {verb: cost}``. An unknown role or verb costs
+    0.0 (no constraint) so a future role without an entry behaves as if the
+    economy is off for it, never crashing the tick loop.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_energy: float,
+        regen_per_tick: float,
+        cost_table: CostTable,
+    ) -> None:
+        self.max_energy = float(max_energy)
+        self.regen_per_tick = float(regen_per_tick)
+        self._cost: CostTable = cost_table
+        self._pool: dict[str, float] = {}
+
+    @classmethod
+    def fresh(
+        cls,
+        names: Iterable[str],
+        *,
+        max_energy: float,
+        regen_per_tick: float,
+        cost_table: CostTable,
+    ) -> EnergyLedger:
+        ledger = cls(max_energy=max_energy, regen_per_tick=regen_per_tick, cost_table=cost_table)
+        for name in names:
+            ledger._pool[name] = ledger.max_energy
+        return ledger
+
+    def current(self, name: str) -> float:
+        """Energy for ``name``; an unseen agent (e.g. a Watchdog-spawned
+        Stranger) starts full."""
+        return self._pool.setdefault(name, self.max_energy)
+
+    def cost(self, role: str, verb: str) -> float:
+        role_costs = self._cost.get(role)
+        if role_costs is None:
+            return 0.0
+        return float(role_costs.get(verb, 0.0))
+
+    def can_afford(self, name: str, role: str, verb: str) -> bool:
+        return self.current(name) >= self.cost(role, verb)
+
+    def deduct(self, name: str, role: str, verb: str) -> None:
+        self._pool[name] = max(0.0, self.current(name) - self.cost(role, verb))
+
+    def regen(self, name: str) -> None:
+        self._pool[name] = min(self.current(name) + self.regen_per_tick, self.max_energy)
+
+    def affordable_verbs(self, name: str, role: str, candidates: Iterable[str]) -> list[str]:
+        return [v for v in candidates if self.can_afford(name, role, v)]
+
+    def cheapest_affordable_productive(self, name: str, role: str) -> str | None:
+        """The cheapest affordable verb that is neither ``contribute`` nor
+        ``rest`` (the substitution target), or ``None`` if the agent can
+        afford no productive verb (then the lever falls back to rest).
+
+        Ties are broken by ``ActionKind`` declaration order for determinism.
+        """
+        from microverse.agents.base import ActionKind
+
+        order = [k.value for k in ActionKind]
+        productive = [v for v in order if v not in _NON_SUBSTITUTABLE]
+        affordable = self.affordable_verbs(name, role, productive)
+        if not affordable:
+            return None
+        return min(affordable, key=lambda v: (self.cost(role, v), order.index(v)))

--- a/src/microverse/world/economy.py
+++ b/src/microverse/world/economy.py
@@ -31,11 +31,28 @@ from collections.abc import Iterable, Mapping
 
 CostTable = Mapping[str, Mapping[str, float]]
 
-# Verbs that are NOT a free choice the lever may substitute toward:
-# ``contribute`` is excluded because the lever cannot fabricate a WIP +
-# fragment. ``rest`` is excluded from the *primary* candidates so the lever
-# drives specialization (toward the role's cheap productive verb) rather than
-# collapsing every constrained tick onto rest; rest is only the last resort.
+# Verbs that require an LLM-authored payload the lever cannot fabricate, so
+# they are NEVER a substitution *target*: ``contribute`` needs a WIP + fragment,
+# and ``craft`` needs an ``artifact``. Substituting toward either would commit a
+# hollow action (``artifact=None``) that bypasses the empty-craft guard, is
+# unharvestable, yet still counts as productive verb diversity in Gate 9 — i.e.
+# the diagnostic could report improvement without any real work (review). A
+# role whose specialty is a payload verb (the Artisan's ``craft``) therefore
+# diversifies through the perception channel (``energy_hint`` lets the model
+# *choose* craft and author the artifact) and rests when truly drained; the
+# hard executor only ever falls back to payload-free verbs or ``rest``.
+_PAYLOAD_VERBS = frozenset({"contribute", "craft"})
+
+# Excluded from the *primary* substitution candidates: the payload verbs (above)
+# plus ``rest``, which is held back as the last resort so the lever drives
+# specialization toward an affordable productive verb rather than collapsing
+# every constrained tick onto rest.
+_SUBSTITUTION_EXCLUDED = _PAYLOAD_VERBS | {"rest"}
+
+# Verbs excluded from the flat-control flattening: ``contribute`` keeps its
+# per-role cost (so the scene-initiation throttle is identical across arms) and
+# ``rest`` stays free. Everything else — including ``craft`` — collapses to the
+# shared per-role cost so the flat arm genuinely removes the specialty.
 _NON_SUBSTITUTABLE = frozenset({"contribute", "rest"})
 
 
@@ -154,16 +171,18 @@ class EnergyLedger:
             self.regen(actor)
 
     def cheapest_affordable_productive(self, name: str, role: str) -> str | None:
-        """The cheapest affordable verb that is neither ``contribute`` nor
-        ``rest`` (the substitution target), or ``None`` if the agent can
-        afford no productive verb (then the lever falls back to rest).
+        """The cheapest affordable substitution target, or ``None`` if the agent
+        can afford none (then the lever falls back to rest).
 
-        Ties are broken by ``ActionKind`` declaration order for determinism.
+        Candidates exclude the payload verbs (``contribute``, ``craft`` — the
+        lever cannot fabricate their payloads) and ``rest`` (the last resort),
+        so the realistic targets are ``speak``/``study``/``travel``. Ties are
+        broken by ``ActionKind`` declaration order for determinism.
         """
         from microverse.agents.base import ActionKind
 
         order = [k.value for k in ActionKind]
-        productive = [v for v in order if v not in _NON_SUBSTITUTABLE]
+        productive = [v for v in order if v not in _SUBSTITUTION_EXCLUDED]
         affordable = self.affordable_verbs(name, role, productive)
         if not affordable:
             return None

--- a/src/microverse/world/economy.py
+++ b/src/microverse/world/economy.py
@@ -129,6 +129,27 @@ class EnergyLedger:
     def affordable_verbs(self, name: str, role: str, candidates: Iterable[str]) -> list[str]:
         return [v for v in candidates if self.can_afford(name, role, v)]
 
+    def reconstruct_from_events(self, events: Iterable[tuple[str, str, str]]) -> None:
+        """Approximate restart reconstruction from the WAL (Codex #5).
+
+        Energy is never persisted, so a naive restart resets every pool to
+        ``max_energy`` and an interrupted economy-on run would diverge from an
+        uninterrupted one. To keep restart behavior WAL-derived and
+        deterministic, replay committed agent actions in chronological order,
+        regen-then-deduct per actor event.
+
+        This is intentionally APPROXIMATE: whole-roster per-tick regen is
+        collapsed to per-own-action regen, so bit-equality across restart is
+        NOT guaranteed (energy is a soft scheduling signal, not a durability
+        boundary — the WAL remains the only durability contract). ADR 0009
+        records that economy-on runs are not bit-identical across restart.
+
+        ``events`` yields ``(actor, role, verb)`` tuples oldest-first.
+        """
+        for actor, role, verb in events:
+            self.regen(actor)
+            self.deduct(actor, role, verb)
+
     def cheapest_affordable_productive(self, name: str, role: str) -> str | None:
         """The cheapest affordable verb that is neither ``contribute`` nor
         ``rest`` (the substitution target), or ``None`` if the agent can

--- a/src/microverse/world/economy.py
+++ b/src/microverse/world/economy.py
@@ -165,3 +165,14 @@ class EnergyLedger:
         if not affordable:
             return None
         return min(affordable, key=lambda v: (self.cost(role, v), order.index(v)))
+
+    def resolve_executed_verb(self, name: str, role: str, chosen_verb: str) -> str:
+        """Verb-level core of the economy lever, shared with the offline
+        replay/simulator (``scripts/replay_economy.py``) so Stage-0/1 estimates
+        match live behavior exactly. Returns ``chosen_verb`` when affordable;
+        otherwise the cheapest affordable productive verb, or ``"rest"`` if
+        even that is out of reach. Never substitutes toward ``contribute``."""
+        if self.can_afford(name, role, chosen_verb):
+            return chosen_verb
+        cheapest = self.cheapest_affordable_productive(name, role)
+        return cheapest if cheapest is not None else "rest"

--- a/src/microverse/world/economy.py
+++ b/src/microverse/world/economy.py
@@ -144,11 +144,14 @@ class EnergyLedger:
         boundary — the WAL remains the only durability contract). ADR 0009
         records that economy-on runs are not bit-identical across restart.
 
-        ``events`` yields ``(actor, role, verb)`` tuples oldest-first.
+        ``events`` yields ``(actor, role, verb)`` tuples oldest-first. Order is
+        deduct-then-regen per event, matching the live single-tick order
+        (deduct on commit, then regen); it still cannot replicate the live
+        whole-roster per-tick regen exactly, hence "approximate".
         """
         for actor, role, verb in events:
-            self.regen(actor)
             self.deduct(actor, role, verb)
+            self.regen(actor)
 
     def cheapest_affordable_productive(self, name: str, role: str) -> str | None:
         """The cheapest affordable verb that is neither ``contribute`` nor

--- a/tests/test_agent_economy_integration.py
+++ b/tests/test_agent_economy_integration.py
@@ -71,7 +71,8 @@ def test_verb_trace_records_parsed_verb(metrics: Metrics):
         return_value=_chat("craft", artifact="a long enough fragment to be a real craft artifact"),
     ):
         a.think(WorldContext())
-    assert a._verb_trace == {"parsed_verb": "craft"}
+    assert a._verb_trace["parsed_verb"] == "craft"
+    assert a._verb_trace["economy_substituted"] is False  # full energy, no substitution
 
 
 def test_engagement_gate_wins_over_economy(metrics: Metrics):

--- a/tests/test_agent_economy_integration.py
+++ b/tests/test_agent_economy_integration.py
@@ -1,0 +1,89 @@
+"""Agent.think() x EnergyLedger wiring (ADR 0008 spike).
+
+Exercises the economy lever inside Artisan/Scholar think() with a mocked
+chat: it substitutes an unaffordable verb, is a no-op when no ledger is
+attached, is skipped during scene turns, records the parsed-verb telemetry,
+and runs AFTER diversity but BEFORE the engagement gate (which must win).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from microverse.agents.artisan import Artisan
+from microverse.agents.base import ActionKind, WorldContext
+from microverse.config import VERB_COST_BY_ROLE
+from microverse.ops.metrics import Metrics
+from microverse.world.economy import EnergyLedger
+
+
+def _chat(action: str, *, thought: str = "x", target=None, artifact=None) -> dict:
+    import json
+
+    payload = {"thought": thought, "action": action, "target": target, "artifact": artifact}
+    return {"content": json.dumps(payload), "thinking": "", "raw": {}}
+
+
+def _drained_ledger(name: str, level: float) -> EnergyLedger:
+    led = EnergyLedger.fresh(
+        [name], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool[name] = level
+    return led
+
+
+def test_think_substitutes_when_energy_low(metrics: Metrics):
+    # At 10 energy an Artisan affords craft(6) but not study(14).
+    led = _drained_ledger("Aki", 10.0)
+    a = Artisan(name="Aki", metrics=metrics)
+    a.attach_energy(led)
+    with patch("microverse.agents.artisan.chat", return_value=_chat("study")):
+        out = a.think(WorldContext())
+    assert out.action == ActionKind.CRAFT  # cheapest affordable productive verb
+    assert metrics.get("economy_verb_substituted", agent="Aki") == 1
+
+
+def test_no_economy_when_ledger_unattached(metrics: Metrics):
+    a = Artisan(name="Aki", metrics=metrics)  # no attach_energy
+    with patch("microverse.agents.artisan.chat", return_value=_chat("study")):
+        out = a.think(WorldContext())
+    assert out.action == ActionKind.STUDY  # unchanged: economy is a no-op
+    assert metrics.get("economy_verb_substituted", agent="Aki") == 0
+
+
+def test_economy_skipped_during_scene_turn(metrics: Metrics):
+    led = _drained_ledger("Aki", 0.0)  # affords nothing but rest
+    a = Artisan(name="Aki", metrics=metrics)
+    a.attach_energy(led)
+    world = WorldContext(scene_wip_name="village_scroll")
+    with patch("microverse.agents.artisan.chat", return_value=_chat("study")):
+        out = a.think(world)
+    assert out.action == ActionKind.STUDY  # scene turns are never substituted
+    assert metrics.get("economy_verb_substituted", agent="Aki") == 0
+
+
+def test_verb_trace_records_parsed_verb(metrics: Metrics):
+    led = _drained_ledger("Aki", 100.0)  # full: no substitution
+    a = Artisan(name="Aki", metrics=metrics)
+    a.attach_energy(led)
+    with patch(
+        "microverse.agents.artisan.chat",
+        return_value=_chat("craft", artifact="a long enough fragment to be a real craft artifact"),
+    ):
+        a.think(WorldContext())
+    assert a._verb_trace == {"parsed_verb": "craft"}
+
+
+def test_engagement_gate_wins_over_economy(metrics: Metrics):
+    # Drained energy would substitute study->craft, but the engagement gate
+    # runs LAST and must coerce a speak to the required target regardless.
+    led = _drained_ledger("Aki", 10.0)
+    a = Artisan(name="Aki", metrics=metrics)
+    a.attach_energy(led)
+    world = WorldContext(required_target="Bo", peers_today=("Bo",))
+    with patch("microverse.agents.artisan.chat", return_value=_chat("study")):
+        out = a.think(world)
+    assert out.action == ActionKind.SPEAK
+    assert out.target == "Bo"
+    # Economy still ran first (substituted study->craft) before engagement won.
+    assert metrics.get("economy_verb_substituted", agent="Aki") == 1

--- a/tests/test_agent_economy_integration.py
+++ b/tests/test_agent_economy_integration.py
@@ -33,13 +33,15 @@ def _drained_ledger(name: str, level: float) -> EnergyLedger:
 
 
 def test_think_substitutes_when_energy_low(metrics: Metrics):
-    # At 10 energy an Artisan affords craft(6) but not study(14).
-    led = _drained_ledger("Aki", 10.0)
+    # At 15 energy an Artisan affords study(14) but not travel(18). craft is a
+    # payload verb the lever cannot fabricate, so the target is study, not a
+    # hollow craft (review).
+    led = _drained_ledger("Aki", 15.0)
     a = Artisan(name="Aki", metrics=metrics)
     a.attach_energy(led)
-    with patch("microverse.agents.artisan.chat", return_value=_chat("study")):
+    with patch("microverse.agents.artisan.chat", return_value=_chat("travel")):
         out = a.think(WorldContext())
-    assert out.action == ActionKind.CRAFT  # cheapest affordable productive verb
+    assert out.action == ActionKind.STUDY  # cheapest affordable payload-free verb
     assert metrics.get("economy_verb_substituted", agent="Aki") == 1
 
 
@@ -76,8 +78,9 @@ def test_verb_trace_records_parsed_verb(metrics: Metrics):
 
 
 def test_engagement_gate_wins_over_economy(metrics: Metrics):
-    # Drained energy would substitute study->craft, but the engagement gate
-    # runs LAST and must coerce a speak to the required target regardless.
+    # Drained energy would substitute study->rest (craft excluded, nothing
+    # payload-free affordable at 10), but the engagement gate runs LAST and
+    # must coerce a speak to the required target regardless.
     led = _drained_ledger("Aki", 10.0)
     a = Artisan(name="Aki", metrics=metrics)
     a.attach_energy(led)
@@ -86,5 +89,8 @@ def test_engagement_gate_wins_over_economy(metrics: Metrics):
         out = a.think(world)
     assert out.action == ActionKind.SPEAK
     assert out.target == "Bo"
-    # Economy still ran first (substituted study->craft) before engagement won.
+    # The economy lever still FIRED first (metric bumped)...
     assert metrics.get("economy_verb_substituted", agent="Aki") == 1
+    # ...but engagement overrode its verb, so Gate 9 must NOT count it as a
+    # committed economy substitution (review): the trace flag is cleared.
+    assert a._verb_trace["economy_substituted"] is False

--- a/tests/test_economy_ledger.py
+++ b/tests/test_economy_ledger.py
@@ -73,15 +73,13 @@ def test_affordable_verbs_filters_by_pool(ledger: EnergyLedger):
 
 
 def test_can_afford_boundary_is_inclusive(ledger: EnergyLedger):
-    # Exactly enough energy for craft (6) must count as affordable.
-    while ledger.current("Aki") > 6.0:
-        ledger.deduct("Aki", "artisan", "craft")
-    # Now drive to exactly 6 if not already.
-    cur = ledger.current("Aki")
-    if cur > 6.0:
-        # one more craft would overshoot; instead assert >= semantics at cur
-        pass
-    assert ledger.can_afford("Aki", "artisan", "craft") == (ledger.current("Aki") >= 6.0)
+    # Exactly enough energy for craft (6) counts as affordable; a hair under
+    # does not. Pin against concrete values, not the implementation's own
+    # comparison expression.
+    ledger._pool["Aki"] = 6.0
+    assert ledger.can_afford("Aki", "artisan", "craft") is True
+    ledger._pool["Aki"] = 5.999
+    assert ledger.can_afford("Aki", "artisan", "craft") is False
 
 
 def test_comparative_advantage_table_shape():
@@ -156,5 +154,23 @@ def test_resolve_executed_verb_passes_affordable_and_substitutes_drained():
         ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
     )
     assert led.resolve_executed_verb("Aki", "artisan", "study") == "study"  # affordable
-    led._pool["Aki"] = 8.0  # affords craft(6) but not study(14)
-    assert led.resolve_executed_verb("Aki", "artisan", "study") == "craft"
+    # At 15 the artisan cannot afford travel(18) but can afford study(14): the
+    # lever substitutes toward the cheapest affordable PAYLOAD-FREE verb.
+    led._pool["Aki"] = 15.0
+    assert led.resolve_executed_verb("Aki", "artisan", "travel") == "study"
+
+
+def test_resolve_executed_verb_never_substitutes_toward_craft():
+    """Regression (review): craft requires an artifact the lever cannot
+    fabricate, so it is never a substitution target — even when affordable.
+    A drained artisan that can pay for craft(6) but whose chosen verb is
+    unaffordable must fall back to rest, NOT a hollow craft."""
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool["Aki"] = 7.0  # affords craft(6) but nothing payload-free (>=14)
+    assert led.cheapest_affordable_productive("Aki", "artisan") is None
+    assert led.resolve_executed_verb("Aki", "artisan", "study") == "rest"
+    # A model that CHOOSES craft and can afford it still crafts (craft is only
+    # excluded as a substitution TARGET, never as an affordable pass-through).
+    assert led.resolve_executed_verb("Aki", "artisan", "craft") == "craft"

--- a/tests/test_economy_ledger.py
+++ b/tests/test_economy_ledger.py
@@ -1,0 +1,121 @@
+"""EnergyLedger + comparative-advantage cost table (ADR 0008 re-diagnosis spike).
+
+Pure-unit tests: no run loop, no Ollama. The ledger is an in-memory
+finite-stamina pool with per-role verb costs. ``rest`` always costs 0 so
+the system can never deadlock on energy (the energy analog of the
+scheduler's ``max(soul_tokens, 1)`` floor).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from microverse.config import ENERGY_MAX, ENERGY_REGEN_PER_TICK, VERB_COST_BY_ROLE
+from microverse.world.economy import EnergyLedger, build_cost_table, derive_flat_table
+
+
+@pytest.fixture
+def ledger() -> EnergyLedger:
+    return EnergyLedger.fresh(
+        ["Aki", "Cy"],
+        max_energy=100.0,
+        regen_per_tick=12.0,
+        cost_table=VERB_COST_BY_ROLE,
+    )
+
+
+def test_deduct_reduces_pool_by_role_cost(ledger: EnergyLedger):
+    ledger.deduct("Aki", "artisan", "craft")  # cost 6
+    assert ledger.current("Aki") == pytest.approx(94.0)
+    ledger.deduct("Aki", "artisan", "contribute")  # cost 22
+    assert ledger.current("Aki") == pytest.approx(72.0)
+
+
+def test_deduct_clamps_at_zero(ledger: EnergyLedger):
+    for _ in range(10):
+        ledger.deduct("Cy", "scholar", "contribute")  # 14 each, 140 > 100
+    assert ledger.current("Cy") == 0.0
+
+
+def test_regen_caps_at_max(ledger: EnergyLedger):
+    ledger.deduct("Aki", "artisan", "contribute")  # -> 78
+    ledger.regen("Aki")  # +12 -> 90
+    assert ledger.current("Aki") == pytest.approx(90.0)
+    for _ in range(10):
+        ledger.regen("Aki")
+    assert ledger.current("Aki") == 100.0  # never exceeds max
+
+
+def test_rest_always_affordable_even_at_zero(ledger: EnergyLedger):
+    for _ in range(20):
+        ledger.deduct("Aki", "artisan", "contribute")
+    assert ledger.current("Aki") == 0.0
+    assert ledger.cost("artisan", "rest") == 0.0
+    assert ledger.can_afford("Aki", "artisan", "rest") is True
+
+
+def test_unseen_agent_starts_full(ledger: EnergyLedger):
+    # A Watchdog-spawned Stranger was never in the fresh roster.
+    assert ledger.current("Ztoo") == pytest.approx(100.0)
+    assert ledger.can_afford("Ztoo", "stranger", "contribute") is True
+
+
+def test_affordable_verbs_filters_by_pool(ledger: EnergyLedger):
+    # Drain Aki to ~5 energy: only rest (0) and nothing else affordable.
+    while ledger.current("Aki") > 5.0:
+        ledger.deduct("Aki", "artisan", "craft")  # 6 each
+    affordable = ledger.affordable_verbs(
+        "Aki", "artisan", ["speak", "craft", "study", "rest", "travel", "contribute"]
+    )
+    assert "rest" in affordable
+    assert "contribute" not in affordable
+    assert "craft" not in affordable  # 6 > remaining
+
+
+def test_can_afford_boundary_is_inclusive(ledger: EnergyLedger):
+    # Exactly enough energy for craft (6) must count as affordable.
+    while ledger.current("Aki") > 6.0:
+        ledger.deduct("Aki", "artisan", "craft")
+    # Now drive to exactly 6 if not already.
+    cur = ledger.current("Aki")
+    if cur > 6.0:
+        # one more craft would overshoot; instead assert >= semantics at cur
+        pass
+    assert ledger.can_afford("Aki", "artisan", "craft") == (ledger.current("Aki") >= 6.0)
+
+
+def test_comparative_advantage_table_shape():
+    verbs = {"speak", "craft", "study", "rest", "travel", "contribute"}
+    for role, costs in VERB_COST_BY_ROLE.items():
+        assert set(costs) == verbs, f"{role} must price all six verbs"
+        assert costs["rest"] == 0.0, f"{role} rest must be free"
+        # Specialty = strict cheapest non-rest verb (the comparative advantage).
+        non_rest = {v: c for v, c in costs.items() if v != "rest"}
+        cheapest = min(non_rest.values())
+        winners = [v for v, c in non_rest.items() if c == cheapest]
+        assert len(winners) == 1, f"{role} must have a single strict specialty, got {winners}"
+
+
+def test_config_defaults_are_sane():
+    assert ENERGY_MAX > 0
+    # Regen must sit between the cheap specialty and the dear contribute so a
+    # specialty is sustainable but off-specialty verbs require saving up.
+    assert 0 < ENERGY_REGEN_PER_TICK < ENERGY_MAX
+
+
+def test_derive_flat_table_keeps_contribute_and_rest():
+    flat = derive_flat_table(VERB_COST_BY_ROLE)
+    for role, costs in VERB_COST_BY_ROLE.items():
+        assert flat[role]["contribute"] == costs["contribute"], "throttle must match the 1 arm"
+        assert flat[role]["rest"] == 0.0
+        # The other four verbs collapse to one shared cost (no specialty).
+        others = {v for v in costs if v not in ("contribute", "rest")}
+        shared = {flat[role][v] for v in others}
+        assert len(shared) == 1, f"{role} flat arm must remove the specialty"
+
+
+def test_build_cost_table_selects_by_mode():
+    assert build_cost_table("1") == VERB_COST_BY_ROLE
+    assert build_cost_table("sub") == VERB_COST_BY_ROLE
+    assert build_cost_table("throttle") == VERB_COST_BY_ROLE
+    assert build_cost_table("flat") == derive_flat_table(VERB_COST_BY_ROLE)

--- a/tests/test_economy_ledger.py
+++ b/tests/test_economy_ledger.py
@@ -119,3 +119,42 @@ def test_build_cost_table_selects_by_mode():
     assert build_cost_table("sub") == VERB_COST_BY_ROLE
     assert build_cost_table("throttle") == VERB_COST_BY_ROLE
     assert build_cost_table("flat") == derive_flat_table(VERB_COST_BY_ROLE)
+
+
+def _events(n: int) -> list[tuple[str, str, str]]:
+    seq = [
+        ("Aki", "artisan", "contribute"),
+        ("Cy", "scholar", "study"),
+        ("Aki", "artisan", "craft"),
+    ]
+    return seq * n
+
+
+def test_reconstruct_from_events_is_deterministic():
+    a = EnergyLedger.fresh(
+        ["Aki", "Cy"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    b = EnergyLedger.fresh(
+        ["Aki", "Cy"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    a.reconstruct_from_events(_events(5))
+    b.reconstruct_from_events(_events(5))
+    assert a.current("Aki") == b.current("Aki")
+    assert a.current("Cy") == b.current("Cy")
+
+
+def test_reconstruct_reflects_costly_activity():
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led.reconstruct_from_events([("Aki", "artisan", "contribute")] * 20)  # 22 > 12 regen
+    assert led.current("Aki") < 100.0  # restart is WAL-derived, not reset-to-full
+
+
+def test_resolve_executed_verb_passes_affordable_and_substitutes_drained():
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    assert led.resolve_executed_verb("Aki", "artisan", "study") == "study"  # affordable
+    led._pool["Aki"] = 8.0  # affords craft(6) but not study(14)
+    assert led.resolve_executed_verb("Aki", "artisan", "study") == "craft"

--- a/tests/test_economy_lever.py
+++ b/tests/test_economy_lever.py
@@ -1,0 +1,131 @@
+"""apply_economy_lever: hard-substitute an unaffordable verb (ADR 0008 spike).
+
+When the LLM picks a verb the agent cannot pay for, the lever substitutes
+the cheapest affordable *productive* verb (rest only as a last resort, so
+the lever drives specialization rather than collapsing onto rest). It must
+never produce ``contribute`` (cannot fabricate a WIP + fragment), must
+leave a parse-fallback rest untouched, and must NOT fire during a scene
+turn (that would abort the scene).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from microverse.agents.base import Action, ActionKind, WorldContext, apply_economy_lever
+from microverse.ops.metrics import Metrics
+from microverse.world.economy import EnergyLedger
+
+_THOUGHT = "I turn to what I can sustain today."
+
+
+class _FixedRng:
+    """Deterministic stand-in for random.Random used by the lever."""
+
+    def choice(self, seq: Any) -> Any:
+        return seq[0]
+
+
+def _ledger(cost_table: dict[str, dict[str, float]], *, names=("Aki",)) -> EnergyLedger:
+    return EnergyLedger.fresh(
+        list(names), max_energy=100.0, regen_per_tick=12.0, cost_table=cost_table
+    )
+
+
+_ARTISAN = {"craft": 6.0, "study": 14.0, "speak": 16.0, "travel": 18.0, "rest": 0.0, "contribute": 22.0}
+
+
+def _lever(action, world, ledger, metrics, role="artisan", name="Aki"):
+    return apply_economy_lever(
+        action,
+        world,
+        ledger=ledger,
+        role=role,
+        agent_name=name,
+        rng=_FixedRng(),
+        metrics=metrics,
+        replacement_thought=_THOUGHT,
+    )
+
+
+def test_affordable_verb_passes_through(metrics: Metrics):
+    ledger = _ledger({"artisan": _ARTISAN})  # full energy
+    action = Action(thought="make a bowl", action=ActionKind.CRAFT, artifact="a bowl")
+    out = _lever(action, WorldContext(), ledger, metrics)
+    assert out is action or out.action == ActionKind.CRAFT
+    assert metrics.get("economy_verb_substituted", agent="Aki") == 0
+
+
+def test_unaffordable_verb_substituted_to_cheapest_productive(metrics: Metrics):
+    ledger = _ledger({"artisan": _ARTISAN})
+    # Drain Aki below contribute(22) but above craft(6).
+    while ledger.current("Aki") > 10.0:
+        ledger.deduct("Aki", "artisan", "craft")
+    action = Action(thought="add to the scroll", action=ActionKind.CONTRIBUTE,
+                    contribute_to="village_scroll", artifact="x" * 200)
+    out = _lever(action, WorldContext(), ledger, metrics)
+    assert out.action == ActionKind.CRAFT  # cheapest affordable productive verb
+    assert out.contribute_to is None
+    assert out.artifact is None
+    assert metrics.get("economy_verb_substituted", agent="Aki") == 1
+
+
+def test_substitution_never_contribute(metrics: Metrics):
+    # Even if contribute were notionally "cheapest", it is excluded.
+    cheap_contribute = {**_ARTISAN, "contribute": 0.0, "craft": 50.0, "study": 50.0,
+                        "speak": 50.0, "travel": 50.0}
+    ledger = _ledger({"artisan": cheap_contribute})
+    while ledger.current("Aki") > 5.0:
+        ledger.deduct("Aki", "artisan", "rest")  # 0 cost; loop guard below
+        break
+    # Force low energy directly.
+    ledger._pool["Aki"] = 5.0  # noqa: SLF001 - test reaches into the pool deliberately
+    action = Action(thought="x", action=ActionKind.TRAVEL)
+    out = _lever(action, WorldContext(), ledger, metrics)
+    assert out.action != ActionKind.CONTRIBUTE
+
+
+def test_fallback_rest_untouched(metrics: Metrics):
+    ledger = _ledger({"artisan": _ARTISAN})
+    ledger._pool["Aki"] = 0.0  # noqa: SLF001
+    fallback = Action(thought="", action=ActionKind.REST)  # parse-fallback shape
+    out = _lever(fallback, WorldContext(), ledger, metrics)
+    assert out.action == ActionKind.REST
+    assert out.thought == ""
+    assert metrics.get("economy_verb_substituted", agent="Aki") == 0
+
+
+def test_intentional_rest_passes_through(metrics: Metrics):
+    ledger = _ledger({"artisan": _ARTISAN})
+    ledger._pool["Aki"] = 0.0  # noqa: SLF001
+    rest = Action(thought="I pause to gather myself.", action=ActionKind.REST)
+    out = _lever(rest, WorldContext(), ledger, metrics)
+    assert out.action == ActionKind.REST  # rest is always affordable
+    assert metrics.get("economy_verb_substituted", agent="Aki") == 0
+
+
+def test_no_substitution_during_scene_turn(metrics: Metrics):
+    ledger = _ledger({"artisan": _ARTISAN})
+    ledger._pool["Aki"] = 0.0  # noqa: SLF001 - cannot afford contribute
+    world = WorldContext(scene_wip_name="village_scroll")
+    action = Action(thought="add a line", action=ActionKind.CONTRIBUTE,
+                    contribute_to="village_scroll", artifact="x" * 200)
+    out = _lever(action, world, ledger, metrics)
+    assert out.action == ActionKind.CONTRIBUTE  # scene turn never substituted
+    assert metrics.get("economy_verb_substituted", agent="Aki") == 0
+
+
+def test_speak_substitution_sets_target_when_peers(metrics: Metrics):
+    # Cost table where speak is the cheapest affordable productive verb.
+    speak_cheap = {"speak": 4.0, "craft": 40.0, "study": 40.0, "travel": 40.0,
+                   "rest": 0.0, "contribute": 40.0}
+    ledger = _ledger({"scholar": speak_cheap}, names=("Cy",))
+    ledger._pool["Cy"] = 5.0  # noqa: SLF001 - affords only speak(4) + rest(0)
+    world = WorldContext(peers_today=("Aki",))
+    action = Action(thought="study the soil", action=ActionKind.STUDY)
+    out = apply_economy_lever(
+        action, world, ledger=ledger, role="scholar", agent_name="Cy",
+        rng=_FixedRng(), metrics=metrics, replacement_thought=_THOUGHT,
+    )
+    assert out.action == ActionKind.SPEAK
+    assert out.target == "Aki"

--- a/tests/test_economy_lever.py
+++ b/tests/test_economy_lever.py
@@ -65,9 +65,11 @@ def test_affordable_verb_passes_through(metrics: Metrics):
 
 def test_unaffordable_verb_substituted_to_cheapest_productive(metrics: Metrics):
     ledger = _ledger({"artisan": _ARTISAN})
-    # Drain Aki below contribute(22) but above craft(6).
-    while ledger.current("Aki") > 10.0:
-        ledger.deduct("Aki", "artisan", "craft")
+    # At 15 the artisan affords craft(6) and study(14) but not speak(16) /
+    # travel(18) / contribute(22). craft is a payload verb the lever cannot
+    # fabricate, so the substitution target is the cheapest PAYLOAD-FREE verb:
+    # study. (A hollow craft here would bypass the empty-craft guard — review.)
+    ledger._pool["Aki"] = 15.0
     action = Action(
         thought="add to the scroll",
         action=ActionKind.CONTRIBUTE,
@@ -75,7 +77,7 @@ def test_unaffordable_verb_substituted_to_cheapest_productive(metrics: Metrics):
         artifact="x" * 200,
     )
     out = _lever(action, WorldContext(), ledger, metrics)
-    assert out.action == ActionKind.CRAFT  # cheapest affordable productive verb
+    assert out.action == ActionKind.STUDY  # cheapest affordable payload-free verb
     assert out.contribute_to is None
     assert out.artifact is None
     assert metrics.get("economy_verb_substituted", agent="Aki") == 1

--- a/tests/test_economy_lever.py
+++ b/tests/test_economy_lever.py
@@ -32,7 +32,14 @@ def _ledger(cost_table: dict[str, dict[str, float]], *, names=("Aki",)) -> Energ
     )
 
 
-_ARTISAN = {"craft": 6.0, "study": 14.0, "speak": 16.0, "travel": 18.0, "rest": 0.0, "contribute": 22.0}
+_ARTISAN = {
+    "craft": 6.0,
+    "study": 14.0,
+    "speak": 16.0,
+    "travel": 18.0,
+    "rest": 0.0,
+    "contribute": 22.0,
+}
 
 
 def _lever(action, world, ledger, metrics, role="artisan", name="Aki"):
@@ -61,8 +68,12 @@ def test_unaffordable_verb_substituted_to_cheapest_productive(metrics: Metrics):
     # Drain Aki below contribute(22) but above craft(6).
     while ledger.current("Aki") > 10.0:
         ledger.deduct("Aki", "artisan", "craft")
-    action = Action(thought="add to the scroll", action=ActionKind.CONTRIBUTE,
-                    contribute_to="village_scroll", artifact="x" * 200)
+    action = Action(
+        thought="add to the scroll",
+        action=ActionKind.CONTRIBUTE,
+        contribute_to="village_scroll",
+        artifact="x" * 200,
+    )
     out = _lever(action, WorldContext(), ledger, metrics)
     assert out.action == ActionKind.CRAFT  # cheapest affordable productive verb
     assert out.contribute_to is None
@@ -72,14 +83,20 @@ def test_unaffordable_verb_substituted_to_cheapest_productive(metrics: Metrics):
 
 def test_substitution_never_contribute(metrics: Metrics):
     # Even if contribute were notionally "cheapest", it is excluded.
-    cheap_contribute = {**_ARTISAN, "contribute": 0.0, "craft": 50.0, "study": 50.0,
-                        "speak": 50.0, "travel": 50.0}
+    cheap_contribute = {
+        **_ARTISAN,
+        "contribute": 0.0,
+        "craft": 50.0,
+        "study": 50.0,
+        "speak": 50.0,
+        "travel": 50.0,
+    }
     ledger = _ledger({"artisan": cheap_contribute})
     while ledger.current("Aki") > 5.0:
         ledger.deduct("Aki", "artisan", "rest")  # 0 cost; loop guard below
         break
     # Force low energy directly.
-    ledger._pool["Aki"] = 5.0  # noqa: SLF001 - test reaches into the pool deliberately
+    ledger._pool["Aki"] = 5.0
     action = Action(thought="x", action=ActionKind.TRAVEL)
     out = _lever(action, WorldContext(), ledger, metrics)
     assert out.action != ActionKind.CONTRIBUTE
@@ -87,7 +104,7 @@ def test_substitution_never_contribute(metrics: Metrics):
 
 def test_fallback_rest_untouched(metrics: Metrics):
     ledger = _ledger({"artisan": _ARTISAN})
-    ledger._pool["Aki"] = 0.0  # noqa: SLF001
+    ledger._pool["Aki"] = 0.0
     fallback = Action(thought="", action=ActionKind.REST)  # parse-fallback shape
     out = _lever(fallback, WorldContext(), ledger, metrics)
     assert out.action == ActionKind.REST
@@ -97,7 +114,7 @@ def test_fallback_rest_untouched(metrics: Metrics):
 
 def test_intentional_rest_passes_through(metrics: Metrics):
     ledger = _ledger({"artisan": _ARTISAN})
-    ledger._pool["Aki"] = 0.0  # noqa: SLF001
+    ledger._pool["Aki"] = 0.0
     rest = Action(thought="I pause to gather myself.", action=ActionKind.REST)
     out = _lever(rest, WorldContext(), ledger, metrics)
     assert out.action == ActionKind.REST  # rest is always affordable
@@ -106,10 +123,14 @@ def test_intentional_rest_passes_through(metrics: Metrics):
 
 def test_no_substitution_during_scene_turn(metrics: Metrics):
     ledger = _ledger({"artisan": _ARTISAN})
-    ledger._pool["Aki"] = 0.0  # noqa: SLF001 - cannot afford contribute
+    ledger._pool["Aki"] = 0.0
     world = WorldContext(scene_wip_name="village_scroll")
-    action = Action(thought="add a line", action=ActionKind.CONTRIBUTE,
-                    contribute_to="village_scroll", artifact="x" * 200)
+    action = Action(
+        thought="add a line",
+        action=ActionKind.CONTRIBUTE,
+        contribute_to="village_scroll",
+        artifact="x" * 200,
+    )
     out = _lever(action, world, ledger, metrics)
     assert out.action == ActionKind.CONTRIBUTE  # scene turn never substituted
     assert metrics.get("economy_verb_substituted", agent="Aki") == 0
@@ -117,15 +138,27 @@ def test_no_substitution_during_scene_turn(metrics: Metrics):
 
 def test_speak_substitution_sets_target_when_peers(metrics: Metrics):
     # Cost table where speak is the cheapest affordable productive verb.
-    speak_cheap = {"speak": 4.0, "craft": 40.0, "study": 40.0, "travel": 40.0,
-                   "rest": 0.0, "contribute": 40.0}
+    speak_cheap = {
+        "speak": 4.0,
+        "craft": 40.0,
+        "study": 40.0,
+        "travel": 40.0,
+        "rest": 0.0,
+        "contribute": 40.0,
+    }
     ledger = _ledger({"scholar": speak_cheap}, names=("Cy",))
-    ledger._pool["Cy"] = 5.0  # noqa: SLF001 - affords only speak(4) + rest(0)
+    ledger._pool["Cy"] = 5.0
     world = WorldContext(peers_today=("Aki",))
     action = Action(thought="study the soil", action=ActionKind.STUDY)
     out = apply_economy_lever(
-        action, world, ledger=ledger, role="scholar", agent_name="Cy",
-        rng=_FixedRng(), metrics=metrics, replacement_thought=_THOUGHT,
+        action,
+        world,
+        ledger=ledger,
+        role="scholar",
+        agent_name="Cy",
+        rng=_FixedRng(),
+        metrics=metrics,
+        replacement_thought=_THOUGHT,
     )
     assert out.action == ActionKind.SPEAK
     assert out.target == "Aki"

--- a/tests/test_gate9_verb_diversity.py
+++ b/tests/test_gate9_verb_diversity.py
@@ -19,7 +19,8 @@ import pytest
 
 _MEASURE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "spike_workshop_measure.py"
 _spec = importlib.util.spec_from_file_location("spike_workshop_measure", _MEASURE_PATH)
-assert _spec is not None and _spec.loader is not None
+assert _spec is not None
+assert _spec.loader is not None
 swm = importlib.util.module_from_spec(_spec)
 sys.modules["spike_workshop_measure"] = swm
 _spec.loader.exec_module(swm)
@@ -54,7 +55,7 @@ def test_entropy_monoculture_is_zero():
 
 
 def test_entropy_uniform_six_verbs_norm_is_one():
-    counts = {v: 10 for v in ("speak", "craft", "study", "rest", "travel", "contribute")}
+    counts = dict.fromkeys(("speak", "craft", "study", "rest", "travel", "contribute"), 10)
     assert swm._entropy_norm(counts, k=6) == pytest.approx(1.0)
     # raw bits = log2(6)
     assert swm._shannon_entropy_bits(counts) == pytest.approx(math.log2(6))

--- a/tests/test_gate9_verb_diversity.py
+++ b/tests/test_gate9_verb_diversity.py
@@ -1,0 +1,127 @@
+"""gate9_verb_diversity: society verb entropy + cross-agent JSD (ADR 0008 spike).
+
+Old Gate 3 penalizes any single agent concentrating on one verb. But the
+re-diagnosis target (ADR 0007 measurement #1) is the inverse: agents should
+concentrate on *different* verbs (divergence), and the society as a whole
+should stop being a contribute-monoculture (rising entropy). Gate 9 measures
+both, on the executed-verb stream and the model's chosen (parsed) stream.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_MEASURE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "spike_workshop_measure.py"
+_spec = importlib.util.spec_from_file_location("spike_workshop_measure", _MEASURE_PATH)
+assert _spec is not None and _spec.loader is not None
+swm = importlib.util.module_from_spec(_spec)
+sys.modules["spike_workshop_measure"] = swm
+_spec.loader.exec_module(swm)
+
+
+def _events_db(rows: list[tuple[str, str, dict]]) -> sqlite3.Connection:
+    """In-memory events table. rows = (actor, action, payload)."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, ts REAL, "
+        "actor TEXT, action TEXT, target TEXT, payload_json TEXT)"
+    )
+    import json
+
+    ts = 1000.0
+    for actor, action, payload in rows:
+        conn.execute(
+            "INSERT INTO events (ts, actor, action, target, payload_json) VALUES (?,?,?,?,?)",
+            (ts, actor, action, None, json.dumps(payload)),
+        )
+        ts += 1.0
+    conn.commit()
+    return conn
+
+
+# --- pure-math helpers ------------------------------------------------------
+
+
+def test_entropy_monoculture_is_zero():
+    assert swm._shannon_entropy_bits({"craft": 100}) == pytest.approx(0.0)
+
+
+def test_entropy_uniform_six_verbs_norm_is_one():
+    counts = {v: 10 for v in ("speak", "craft", "study", "rest", "travel", "contribute")}
+    assert swm._entropy_norm(counts, k=6) == pytest.approx(1.0)
+    # raw bits = log2(6)
+    assert swm._shannon_entropy_bits(counts) == pytest.approx(math.log2(6))
+
+
+def test_jsd_identical_distributions_zero():
+    p = {"craft": 1.0}
+    assert swm._jsd_bits(p, dict(p)) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_jsd_disjoint_specialists_is_one():
+    aki = {"craft": 1.0}
+    cy = {"study": 1.0}
+    assert swm._jsd_bits(aki, cy) == pytest.approx(1.0, abs=1e-9)
+
+
+# --- gate9 over an events DB ------------------------------------------------
+
+
+def test_gate9_monoculture_fails():
+    rows = [("Aki", "contribute", {}) for _ in range(50)]
+    rows += [("Cy", "contribute", {}) for _ in range(50)]
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    assert g["executed"]["society_entropy_norm"] == pytest.approx(0.0)
+    assert g["executed"]["jsd_norm"] == pytest.approx(0.0)
+    assert g["pass"] is False
+
+
+def test_gate9_disjoint_specialists_pass():
+    rows = [("Aki", "craft", {}) for _ in range(50)]
+    rows += [("Cy", "study", {}) for _ in range(50)]
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    # Society uses two verbs equally => entropy_norm = log2(2)/log2(6).
+    assert g["executed"]["society_entropy_norm"] > 0.0
+    # Disjoint specialists => maximal divergence.
+    assert g["executed"]["jsd_norm"] == pytest.approx(1.0, abs=1e-9)
+
+
+def test_gate9_excludes_world_and_namespaced_events():
+    rows = [
+        ("world", "weather.storm", {}),
+        ("scene", "scene.open", {}),
+        ("harvester", "harvest.write", {}),
+        ("Aki", "craft", {}),
+        ("Cy", "study", {}),
+    ]
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    assert set(g["executed"]["society_counts"]) == {"craft", "study"}
+
+
+def test_gate9_chosen_stream_uses_parsed_verb_payload():
+    # Executed is all-craft (forced by the economy lever), but the model
+    # actually CHOSE contribute every time -> chosen stream stays monocultural.
+    rows = [("Aki", "craft", {"parsed_verb": "contribute"}) for _ in range(40)]
+    rows += [("Cy", "study", {"parsed_verb": "contribute"}) for _ in range(40)]
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    assert g["chosen"]["society_counts"] == {"contribute": 80}
+    assert g["chosen"]["society_entropy_norm"] == pytest.approx(0.0)
+    # substitution_rate: every row had chosen != executed.
+    assert g["substitution_rate"] == pytest.approx(1.0)
+    # The headline pass reads the CHOSEN stream, so forced-by-construction fails.
+    assert g["pass"] is False
+
+
+def test_gate9_chosen_falls_back_to_action_when_no_payload():
+    rows = [("Aki", "craft", {}) for _ in range(20)]
+    rows += [("Cy", "study", {}) for _ in range(20)]
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    assert g["substitution_rate"] == pytest.approx(0.0)
+    assert g["chosen"]["society_counts"] == {"craft": 20, "study": 20}

--- a/tests/test_gate9_verb_diversity.py
+++ b/tests/test_gate9_verb_diversity.py
@@ -126,3 +126,15 @@ def test_gate9_chosen_falls_back_to_action_when_no_payload():
     g = swm.gate9_verb_diversity(_events_db(rows))
     assert g["substitution_rate"] == pytest.approx(0.0)
     assert g["chosen"]["society_counts"] == {"craft": 20, "study": 20}
+
+
+def test_gate9_economy_substitution_rate_is_economy_only():
+    # 10 economy substitutions, 10 NON-economy overrides (e.g. diversity), 10 clean.
+    rows = [("Aki", "craft", {"parsed_verb": "contribute", "economy_substituted": True})] * 10
+    rows += [("Aki", "craft", {"parsed_verb": "speak"})] * 10  # parsed!=exec, not economy
+    rows += [("Aki", "craft", {"parsed_verb": "craft"})] * 10
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    # Total override counts both the economy subs and the diversity-style ones.
+    assert g["substitution_rate"] == pytest.approx(20 / 30, abs=1e-4)
+    # Economy-only rate counts just the flagged ones.
+    assert g["economy_substitution_rate"] == pytest.approx(10 / 30, abs=1e-4)

--- a/tests/test_gate9_verb_diversity.py
+++ b/tests/test_gate9_verb_diversity.py
@@ -88,10 +88,39 @@ def test_gate9_disjoint_specialists_pass():
     rows = [("Aki", "craft", {}) for _ in range(50)]
     rows += [("Cy", "study", {}) for _ in range(50)]
     g = swm.gate9_verb_diversity(_events_db(rows))
-    # Society uses two verbs equally => entropy_norm = log2(2)/log2(6).
-    assert g["executed"]["society_entropy_norm"] > 0.0
+    # Society uses two verbs equally => entropy_norm = log2(2)/log2(6) ≈ 0.387.
+    expected_norm = math.log2(2) / math.log2(6)
+    assert g["executed"]["society_entropy_norm"] == pytest.approx(expected_norm, abs=1e-4)
     # Disjoint specialists => maximal divergence.
     assert g["executed"]["jsd_norm"] == pytest.approx(1.0, abs=1e-9)
+    # This is the TARGET outcome (comparative-advantage specialization), so the
+    # gate must PASS it: the 0.35 entropy floor sits just under the 2-agent
+    # two-verb ceiling and JSD is well over its floor.
+    assert g["pass"] is True
+
+
+def test_gate9_excludes_scene_forced_contributes():
+    # Free choices: Aki craft, Cy study. The 40 forced scene contributes
+    # (tagged with scene_id) must NOT enter either diversity stream, else scene
+    # volume would swamp the signal back toward a contribute-monoculture.
+    rows = [("Aki", "craft", {}) for _ in range(20)]
+    rows += [("Cy", "study", {}) for _ in range(20)]
+    rows += [("Aki", "contribute", {"scene_id": "s1", "turn_index": 0}) for _ in range(40)]
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    assert g["scene_excluded"] == 40
+    assert set(g["executed"]["society_counts"]) == {"craft", "study"}
+    assert "contribute" not in g["chosen"]["society_counts"]
+
+
+def test_gate9_parse_fallback_excluded_from_chosen_only():
+    # 20 real studies + 10 parse-fallback RESTs. The fallbacks are realized
+    # (executed=rest) but not free choices, so they count in the executed
+    # stream yet are dropped from the chosen stream.
+    rows = [("Aki", "study", {"parsed_verb": "study"}) for _ in range(20)]
+    rows += [("Aki", "rest", {"parsed_verb": "rest", "parse_fallback": True}) for _ in range(10)]
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    assert g["executed"]["society_counts"] == {"study": 20, "rest": 10}
+    assert g["chosen"]["society_counts"] == {"study": 20}
 
 
 def test_gate9_excludes_world_and_namespaced_events():

--- a/tests/test_replay_economy.py
+++ b/tests/test_replay_economy.py
@@ -1,0 +1,83 @@
+"""Offline replay + synthetic simulator (scripts/replay_economy.py, ADR 0008).
+
+Stage 0/1 estimators must be deterministic and must reuse the live executor
+(``EnergyLedger.resolve_executed_verb``) so a draining policy is genuinely
+throttled. Zero LLM compute.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from microverse.config import VERB_COST_BY_ROLE
+from microverse.world.economy import EnergyLedger
+
+_PATH = Path(__file__).resolve().parents[1] / "scripts" / "replay_economy.py"
+_spec = importlib.util.spec_from_file_location("replay_economy", _PATH)
+assert _spec is not None
+assert _spec.loader is not None
+replay_economy = importlib.util.module_from_spec(_spec)
+sys.modules["replay_economy"] = replay_economy
+_spec.loader.exec_module(replay_economy)
+
+
+def _ledger(level: float | None = None) -> EnergyLedger:
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    if level is not None:
+        led._pool["Aki"] = level
+    return led
+
+
+def test_replay_executor_deterministic():
+    trace = [("Aki", "artisan", "study")] * 30
+    r1 = replay_economy.replay_executor(trace, ledger=_ledger())
+    r2 = replay_economy.replay_executor(trace, ledger=_ledger())
+    assert r1 == r2  # pure function of (trace, fresh ledger)
+
+
+def test_replay_keeps_affordable_specialty():
+    # Artisan crafting (cost 6 < regen 12): always affordable, never substituted.
+    trace = [("Aki", "artisan", "craft")] * 50
+    r = replay_economy.replay_executor(trace, ledger=_ledger())
+    assert r["substitution_rate"] == 0.0
+    assert r["executed_counts"] == {"craft": 50}
+
+
+def test_replay_throttles_unaffordable_drain():
+    # Artisan contributing every tick (cost 22 > regen 12) drains and the
+    # executor substitutes toward the cheap specialty once it cannot pay.
+    trace = [("Aki", "artisan", "contribute")] * 60
+    r = replay_economy.replay_executor(trace, ledger=_ledger())
+    assert r["chosen_contribute_share"] == 1.0
+    assert r["executed_contribute_share"] < 1.0  # throttled
+    assert r["substitution_rate"] > 0.0
+    assert "craft" in r["executed_counts"]  # substituted toward the specialty
+
+
+def test_synthetic_always_contribute_single_agent_throttled():
+    # One agent, contribute >> regen: a pure-contribute policy must be throttled.
+    out = replay_economy.synthetic_run(
+        "always-contribute",
+        n_ticks=80,
+        roster=(("Aki", "artisan"),),
+        cost_table=VERB_COST_BY_ROLE,
+        seed=1,
+    )
+    assert out["executed_contribute_share"] < 1.0
+    assert out["substitution_rate"] > 0.0
+
+
+def test_synthetic_role_biased_diversifies():
+    out = replay_economy.synthetic_run(
+        "role-biased",
+        n_ticks=200,
+        roster=(("Aki", "artisan"), ("Cy", "scholar")),
+        cost_table=VERB_COST_BY_ROLE,
+        seed=7,
+    )
+    # Two specialists pulling toward different cheap verbs => non-trivial entropy.
+    assert out["executed_entropy_norm"] > 0.0

--- a/tests/test_replay_economy.py
+++ b/tests/test_replay_economy.py
@@ -49,13 +49,27 @@ def test_replay_keeps_affordable_specialty():
 
 def test_replay_throttles_unaffordable_drain():
     # Artisan contributing every tick (cost 22 > regen 12) drains and the
-    # executor substitutes toward the cheap specialty once it cannot pay.
+    # executor substitutes once it cannot pay. craft is a payload verb the lever
+    # cannot fabricate, so the target is a payload-free verb (study), never a
+    # hollow craft (review).
     trace = [("Aki", "artisan", "contribute")] * 60
     r = replay_economy.replay_executor(trace, ledger=_ledger())
     assert r["chosen_contribute_share"] == 1.0
     assert r["executed_contribute_share"] < 1.0  # throttled
     assert r["substitution_rate"] > 0.0
-    assert "craft" in r["executed_counts"]  # substituted toward the specialty
+    assert "craft" not in r["executed_counts"]  # never fabricated by substitution
+    assert "study" in r["executed_counts"]  # cheapest affordable payload-free verb
+
+
+def test_replay_forced_scene_contributes_not_substituted():
+    # Scene turns (forced=True) are deducted but NEVER substituted — matching
+    # live, where the lever skips scene turns — even when the pool cannot afford
+    # them (deduct clamps at 0). Without this the offline estimate would predict
+    # substitutions that cannot happen live and inflate the rate (review).
+    trace = [("Aki", "artisan", "contribute", True)] * 60
+    r = replay_economy.replay_executor(trace, ledger=_ledger())
+    assert r["substitution_rate"] == 0.0
+    assert r["executed_counts"] == {"contribute": 60}
 
 
 def test_synthetic_always_contribute_single_agent_throttled():

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -108,6 +108,24 @@ def test_scene_gate_blocked_when_initiator_cannot_afford_contribute(tmp_path: Pa
     assert "scene.open" not in actions
 
 
+def test_flag_off_run_is_deterministic(tmp_path: Path):
+    """Two economy-off runs with the same seed + mocked chat commit an
+    identical event stream, confirming the flag-off path adds no rng
+    perturbation. The diversity lever is disabled because it draws from an
+    unseeded per-agent rng (pre-existing, unrelated to the economy) which would
+    otherwise make any two runs differ."""
+
+    def _run_once(d: Path) -> list[tuple[str, str]]:
+        with (
+            patch("microverse.agents.artisan.DIVERSITY_SUBSTITUTE_PROB", 0.0),
+            patch("microverse.agents.artisan.chat", return_value=_study_only()),
+        ):
+            run(ticks=10, seed=5, tempo=0, data_dir=d, harvest_dir=d / "h", solo=True)
+        return _events(d)
+
+    assert _run_once(tmp_path / "a") == _run_once(tmp_path / "b")
+
+
 def test_scene_fires_when_affordable(tmp_path: Path):
     """Same forced scene roll, but ample energy: scenes DO open (scene.open
     present), confirming the gate only blocks on the energy precondition."""

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -1,0 +1,130 @@
+"""Run-loop wiring for the action-economy spike (ADR 0008).
+
+End-to-end with mocked Ollama. Asserts: the economy is a clean no-op when
+off, substitution fires during a real run once an agent drains, and the
+scene-initiation gate blocks scenes when the initiator cannot afford a
+contribute (preserving the ADR 0006 scene contract by never opening one).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+from microverse import config
+from microverse.run import run
+
+
+@contextmanager
+def _economy(mode: str, *, energy_max: float = 100.0):
+    """Patch the import-time economy flags so run() sees the chosen mode."""
+    with (
+        patch.object(config, "ECONOMY_MODE", mode),
+        patch.object(config, "ECONOMY_ENABLED", mode != "0"),
+        patch.object(config, "_ECONOMY_SCENE_GATE", mode in ("1", "flat", "throttle")),
+        patch.object(config, "_ECONOMY_SUBSTITUTE", mode in ("1", "flat", "sub")),
+        patch.object(config, "ENERGY_MAX", energy_max),
+    ):
+        yield
+
+
+def _events(data_dir: Path) -> list[tuple[str, str]]:
+    with sqlite3.connect(str(data_dir / "episodic.sqlite")) as conn:
+        return list(conn.execute("SELECT actor, action FROM events ORDER BY id"))
+
+
+def _payloads(data_dir: Path) -> list[dict]:
+    with sqlite3.connect(str(data_dir / "episodic.sqlite")) as conn:
+        rows = conn.execute("SELECT payload_json FROM events WHERE actor NOT IN ('world')")
+        return [json.loads(r[0]) for r in rows if r[0]]
+
+
+def _study_only() -> dict:
+    return {
+        "content": '{"thought": "I study the soil.", "action": "study", '
+        '"target": null, "artifact": null}',
+        "thinking": "",
+        "raw": {},
+    }
+
+
+def test_economy_off_is_default_noop(tmp_path: Path):
+    """With the economy off (default), no parsed_verb telemetry is written
+    and the substitution metric never appears: pre-spike behavior."""
+    data_dir = tmp_path / "data"
+    with patch("microverse.agents.artisan.chat", return_value=_study_only()):
+        run(ticks=8, seed=1, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h", solo=True)
+    assert all("parsed_verb" not in p for p in _payloads(data_dir))
+    with sqlite3.connect(str(data_dir / "metrics.sqlite")) as conn:
+        row = conn.execute(
+            "SELECT MAX(value) FROM metrics WHERE name='economy_verb_substituted'"
+        ).fetchone()
+    assert row[0] is None  # metric never bumped
+
+
+def test_economy_on_substitutes_when_drained(tmp_path: Path):
+    """A solo Artisan that always wants study (cost 14 > regen 12) drains
+    below the study cost and the lever substitutes to craft. parsed_verb
+    telemetry is stamped so Gate 9 can read the chosen stream."""
+    data_dir = tmp_path / "data"
+    # Small pool so study (cost 14 > regen 12) drives the pool under the study
+    # cost within a few ticks; diversity lever disabled so the drain is clean.
+    with (
+        _economy("1", energy_max=30.0),
+        patch("microverse.agents.artisan.DIVERSITY_SUBSTITUTE_PROB", 0.0),
+        patch("microverse.agents.artisan.chat", return_value=_study_only()),
+    ):
+        run(ticks=40, seed=1, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h", solo=True)
+    with sqlite3.connect(str(data_dir / "metrics.sqlite")) as conn:
+        subs = conn.execute(
+            "SELECT MAX(value) FROM metrics WHERE name='economy_verb_substituted'"
+        ).fetchone()[0]
+    assert subs is not None, "economy_verb_substituted metric never recorded"
+    assert subs >= 1, "lever should fire once energy drains"
+    # The executed stream now contains craft (substituted) even though the
+    # model only ever chose study; parsed_verb records the model's choice.
+    actions = {a for _, a in _events(data_dir)}
+    assert "craft" in actions
+    payloads = _payloads(data_dir)
+    assert any(p.get("parsed_verb") == "study" for p in payloads)
+
+
+def test_scene_gate_blocked_when_initiator_cannot_afford_contribute(tmp_path: Path):
+    """With a tiny energy pool the initiator cannot afford a contribute, so
+    no scene is opened (no scene.open event) even at SCENE_GATE_P=1. The
+    scene contract is preserved by never opening a partial scene."""
+    data_dir = tmp_path / "data"
+    with (
+        _economy("throttle", energy_max=5.0),  # < every role's contribute cost
+        patch.object(config, "SCENE_GATE_P", 1.0),
+        patch("microverse.agents.artisan.chat", return_value=_study_only()),
+        patch("microverse.agents.scholar.chat", return_value=_study_only()),
+    ):
+        run(ticks=12, seed=3, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h")
+    actions = [a for _, a in _events(data_dir)]
+    assert "scene.open" not in actions
+
+
+def test_scene_fires_when_affordable(tmp_path: Path):
+    """Same forced scene roll, but ample energy: scenes DO open (scene.open
+    present), confirming the gate only blocks on the energy precondition."""
+    data_dir = tmp_path / "data"
+    contribute = {
+        "content": '{"thought": "I add a line to the scroll.", "action": "contribute", '
+        '"contribute_to": "village_scroll", '
+        '"artifact": "' + ("a steady line of careful work " * 6).strip() + '"}',
+        "thinking": "",
+        "raw": {},
+    }
+    with (
+        _economy("throttle", energy_max=100.0),
+        patch.object(config, "SCENE_GATE_P", 1.0),
+        patch("microverse.agents.artisan.chat", return_value=contribute),
+        patch("microverse.agents.scholar.chat", return_value=contribute),
+    ):
+        run(ticks=12, seed=3, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h")
+    actions = [a for _, a in _events(data_dir)]
+    assert "scene.open" in actions

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -14,10 +14,12 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from microverse import config
 from microverse.agents.artisan import Artisan
 from microverse.config import VERB_COST_BY_ROLE
-from microverse.run import _compute_energy_hint, run
+from microverse.run import _compute_energy_hint, _lazy_attach_energy, run
 from microverse.world.economy import EnergyLedger
 
 
@@ -87,10 +89,11 @@ def test_economy_on_substitutes_when_drained(tmp_path: Path):
         ).fetchone()[0]
     assert subs is not None, "economy_verb_substituted metric never recorded"
     assert subs >= 1, "lever should fire once energy drains"
-    # The executed stream now contains craft (substituted) even though the
-    # model only ever chose study; parsed_verb records the model's choice.
+    # The model only ever chose study, but once drained the lever substitutes
+    # toward a payload-free verb (rest at this small pool). It must NEVER
+    # fabricate a hollow craft (review); parsed_verb records the model's choice.
     actions = {a for _, a in _events(data_dir)}
-    assert "craft" in actions
+    assert "craft" not in actions
     payloads = _payloads(data_dir)
     assert any(p.get("parsed_verb") == "study" for p in payloads)
 
@@ -164,3 +167,55 @@ def test_scene_fires_when_affordable(tmp_path: Path):
         run(ticks=12, seed=3, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h")
     actions = [a for _, a in _events(data_dir)]
     assert "scene.open" in actions
+
+
+def _fresh_ledger() -> EnergyLedger:
+    return EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+
+
+def test_lazy_attach_energy_attaches_unattached_agent():
+    """A Watchdog-spawned Stranger registers mid-run without an EnergyLedger;
+    the run loop must attach it so the lever applies to it like the startup
+    roster (otherwise it would execute unaffordable verbs, biasing the A/B)."""
+    led = _fresh_ledger()
+    spawned = Artisan(name="Zix")  # never in the fresh roster, no energy attached
+    assert spawned._energy is None
+    with _economy("sub"):
+        _lazy_attach_energy(spawned, led)
+    assert spawned._energy is led
+
+
+def test_lazy_attach_energy_noop_in_scene_gate_only_mode():
+    """``throttle`` is scene-gate-only: no substitution, so no agent gets the
+    ledger attached — the spawned Stranger stays consistent with the roster."""
+    led = _fresh_ledger()
+    spawned = Artisan(name="Zix")
+    with _economy("throttle"):
+        _lazy_attach_energy(spawned, led)
+    assert spawned._energy is None
+
+
+def test_lazy_attach_energy_noop_when_economy_off():
+    spawned = Artisan(name="Zix")
+    _lazy_attach_energy(spawned, None)  # economy off: no ledger to attach
+    assert spawned._energy is None
+
+
+def test_invalid_economy_mode_fails_fast(tmp_path: Path):
+    """A typo'd MICROVERSE_ECONOMY must raise, not silently run an unlabeled
+    no-op arm (ECONOMY_ENABLED but neither gate nor substitution)."""
+    with (
+        patch.object(config, "ECONOMY_MODE", "bogus"),
+        patch.object(config, "ECONOMY_ENABLED", True),
+        pytest.raises(ValueError, match="not a valid economy mode"),
+    ):
+        run(
+            ticks=1,
+            seed=1,
+            tempo=0,
+            data_dir=tmp_path / "data",
+            harvest_dir=tmp_path / "h",
+            solo=True,
+        )

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -15,7 +15,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 from microverse import config
-from microverse.run import run
+from microverse.agents.artisan import Artisan
+from microverse.config import VERB_COST_BY_ROLE
+from microverse.run import _compute_energy_hint, run
+from microverse.world.economy import EnergyLedger
 
 
 @contextmanager
@@ -106,6 +109,21 @@ def test_scene_gate_blocked_when_initiator_cannot_afford_contribute(tmp_path: Pa
         run(ticks=12, seed=3, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h")
     actions = [a for _, a in _events(data_dir)]
     assert "scene.open" not in actions
+
+
+def test_energy_hint_only_in_substitution_modes():
+    """The energy_hint (prompt-level scarcity signal) is paired with the
+    substitution lever, so the scene-gate-only ``throttle`` ablation stays
+    clean: no prompt pressure, only the gate."""
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool["Aki"] = 0.0  # drained -> hint would fire if the mode allows it
+    agent = Artisan(name="Aki")
+    with _economy("throttle"):
+        assert _compute_energy_hint(led, agent) == ""  # scene-gate-only: no hint
+    with _economy("sub"):
+        assert _compute_energy_hint(led, agent) != ""  # substitution arm: hint on
 
 
 def test_flag_off_run_is_deterministic(tmp_path: Path):


### PR DESCRIPTION
## Summary

A feature-flagged **action-economy spike** to falsifiably re-diagnose the ADR 0008 halt. ADR 0008 halted identity Phase 1 because neither Gate 1 nor Gate 3 moved, and diagnosed Gate 3 (verb monoculture) as *structural*: the scene/workshop loop funnels ~95% of actions into `contribute`, and "no identity layer can diversify verbs without changing the action economy itself." This PR adds the smallest viable slice of ADR 0007 Pillar 2 (scarcity + comparative advantage) plus the measurement to test that claim. Mode `0` (default) reproduces current `main` exactly; the spike is entirely opt-in via `MICROVERSE_ECONOMY`.

No live runs are included — this is the instrumented mechanism + offline tooling. The live A/B and ADR 0009 write-up are operator-driven (see Post-Merge).

## Background / Motivation

Recent merges left the project halted: identity Phase 1 (#43) shipped and was read as HALTED (#44 / ADR 0008). The halt's re-diagnosis directions split the two failing gates by root cause — Gate 1 is a wrong proxy (already superseded by Gate 8), Gate 3 is structural and needs an action-economy lever. This spike tests the structural claim. A second finding shaped the design: **old Gate 3 is itself mis-framed** — it penalizes any single agent concentrating on one verb, but ADR 0007's actual target is "agents concentrate on *different* things" (divergence). So the spike adds a correctly-framed metric (Gate 9), not just a re-read of Gate 3.

Design was reviewed by Codex twice (pre-implementation and pre-PR); the second pass caught four A/B-validity issues that are fixed here (see Design Notes).

## Breaking Changes

- [ ] No breaking changes. Default behavior (`MICROVERSE_ECONOMY` unset → `"0"`) is byte-identical to pre-spike `main` (verified: persona render-equality when the economy is off; the seeded rng stream is unchanged in the OFF arm).

## Changes Made

- **`world/economy.py` (new):** `EnergyLedger` — in-memory per-agent stamina + per-tick regen; `VERB_COST_BY_ROLE` comparative-advantage costs; `derive_flat_table`/`build_cost_table` (role-agnostic control); `resolve_executed_verb` (shared verb-level core); `reconstruct_from_events` (WAL-derived restart approximation; never persisted).
- **`agents/base.py`:** `apply_economy_lever` — hard-substitute an unaffordable verb to the cheapest affordable productive verb (never `contribute`; skips scene turns and fallback-rest); `Agent.attach_energy` + `_verb_trace` telemetry; `WorldContext.energy_hint`.
- **`agents/artisan.py` + `scholar.py`:** call the lever after diversity, before engagement (engagement still wins); record the economy-only substitution flag; diversity prob promoted to `config.DIVERSITY_SUBSTITUTE_PROB`.
- **Personas (3):** conditional `energy_hint` block (whitespace-neutral when empty) so the model perceives scarcity and its *chosen* verbs can adapt.
- **`run.py`:** construct the ledger flag-gated; reconstruct from WAL on startup; attach to agents in substitution modes; scene-initiation energy precondition (preserves ADR 0006); deduct on single-tick + scene commit; whole-roster regen per tick; stamp `parsed_verb`/`economy_substituted` telemetry.
- **`config.py`:** env-driven `ECONOMY_MODE` (`0`/`1`/`flat`/`throttle`/`sub`) + `_ECONOMY_SCENE_GATE`/`_ECONOMY_SUBSTITUTE` decomposition; energy/cost knobs.
- **`scripts/spike_workshop_measure.py`:** `gate9_verb_diversity` — society verb entropy + cross-agent JSD on chosen vs executed streams; `substitution_rate` (total override) and `economy_substitution_rate` (economy-only). Gate 3 left untouched.
- **`scripts/replay_economy.py` (new):** zero-LLM Stage 0 (replay a committed trace) + Stage 1 (synthetic policies) to find the mechanical ceiling and degenerate equilibria before any live run.

## Dependencies

None. No new packages; pure-Python (no numpy) for the metric math.

## Test Methodologies and Results

Full local gate, all green:
```
uv run ruff check && uv run ruff format --check && uv run mypy src/microverse \
  && uv run pip-audit && uv run pytest -q -m 'not integration' && uv build
# => 582 passed, 3 deselected; build OK; no known vulnerabilities
```
69 new tests across ledger, lever, agent integration, run-loop wiring, gate9 math, reconstruction, replay/simulator, and flag-off determinism.

Offline Stage-1 smoke already surfaces a real finding (the point of the cheap stage):
```
uv run python scripts/replay_economy.py --synthetic --ticks 2000 --seed 42
# always-contribute @ 2-agent roster: sub_rate=0.0 (NOT throttled — single
# contributes regen faster than they cost; only scene bursts drain). Tune
# regen / rely on the scene gate before spending live compute.
```

## Design & Reasoning Notes

- **Feature-flag strategy:** one env var, evaluated at import; mode `0` constructs no ledger and every economy site is a no-op. All A/B arms run from a single commit.
- **Five modes for attribution (Codex):** `1` (both mechanisms), `flat` (role-agnostic control — isolates comparative advantage from a uniform throttle), `throttle` (scene-gate-only ablation), `sub` (substitution-only ablation).
- **Chosen-vs-executed telemetry:** hard substitution alone would *force* diversity; the headline is the model's *chosen* (parsed) verb stream, and an `energy_hint` gives the model the perception channel so its choices can genuinely adapt. `economy_substitution_rate` isolates the economy effect from diversity/engagement overrides.
- **Pre-PR Codex fixes:** (1) scene roll consumed before the energy gate so the rng stream stays aligned across arms; (2) `energy_hint` gated to substitution modes so `throttle` is a clean ablation; (3) persona block whitespace-neutral when empty (flag-off byte-identical); (4) economy-only substitution metric.

## Impact / Risk Assessment

- **Affected:** only runs with `MICROVERSE_ECONOMY` set to a non-`0` value. Production/CI default is unaffected.
- **Invariants preserved:** single-model `think()` (no new LLM calls); WAL durability (energy in-memory, never persisted); ADR 0006 scene contract (additive initiation precondition only, before `scene.open`); Watchdog as sole scheduler authority; Path-3 redaction.
- **Known approximations (documented):** restart energy reconstruction is best-effort (not bit-exact; runs are uninterrupted); scene turn-2/3 affordability isn't individually gated (initiation throttle is the lever).
- **Rollback:** unset `MICROVERSE_ECONOMY` (default off); no code change needed.

## Documentation

Inline module/function docstrings document the mechanism, invariants, and approximations. No README/AGENTS change needed (operator workflow is the existing run + `spike_workshop_measure.py` recipe, extended by `replay_economy.py`). ADR 0009 (the read + decision) is written *after* the live A/B, per the plan.

## Review Focus

- [CRITICAL] Flag-off no-op: scene-gate rng ordering (`run.py` scene_eligible) and persona whitespace — confirm OFF stays identical to baseline.
- [IMPORTANT] Deduct/regen wiring across the single-tick vs scene paths (`run.py`) — consistency, no double-count/double-regen.
- [IMPORTANT] `gate9_verb_diversity` (`spike_workshop_measure.py`) — chosen vs executed streams; entropy/JSD math.
- [MINOR] Cost-table numbers and `energy_hint` wording (tunable in Stage 0/1).

## Post-Merge Recommendations

1. **Stage 0/1 (free):** run `replay_economy.py` over an existing economy-OFF run + the synthetic policies; tune `ENERGY_MAX`/`ENERGY_REGEN_PER_TICK`/`VERB_COST_BY_ROLE` until the cost numbers actually throttle (Stage-1 already shows the default 2-agent single-contribute case is not throttled).
2. **Stage 2 (cheap):** ~300-event runs across the five modes; escalate only if the *chosen* (parsed) verbs shift away from contribute.
3. **Stage 3 (live A/B):** 3000-tick runs, seeds {42,38,7}, modes {`0`,`1`,`flat`}; read Gate 9; write **ADR 0009** with the decision. The HALT stays in force until a PASS read.