### PR TITLE
tune(economy): Stage 0/1 — make the cost numbers throttle (post-#45)

### DIFF
--- a/docs/economy-stage2-findings.md
+++ b/docs/economy-stage2-findings.md
@@ -1,0 +1,70 @@
+# Action-economy Stage 2 findings (post-#45, re-diagnosis of the ADR 0008 halt)
+
+Short operator note (not an ADR). Records the Stage 2 read that gates Stage 3.
+ADR 0009 is still written *after* Stage 3, per the #45 plan. The ADR 0008 HALT
+stays in force.
+
+## Setup
+
+- Knobs: `ENERGY_REGEN_PER_TICK = 8` (Stage 0/1 tune, this PR), everything else default.
+- Runs: `--ticks 200 --tempo 0 --seed 42`, model `gemma4:26b`, one run per mode.
+- Five modes: `0` (economy off / baseline), `1` (scene-gate + comparative-advantage
+  substitution), `flat` (role-agnostic control — substitution without comparative
+  advantage), `throttle` (scene-gate only, no substitution), `sub` (substitution only,
+  no scene gate).
+- Metric: `gate9_verb_diversity` (`scripts/spike_workshop_measure.py`). The **chosen**
+  (`parsed_verb`) stream is the headline; scene-forced contributes (ADR 0006) and
+  parse-fallback rests are excluded as non-choices. Single seed, ~165–182 free-choice
+  events/mode — directional, not definitive.
+
+## Results
+
+| mode     | chosen contribute share | chosen entropy_norm | chosen JSD_norm | econ_sub_rate | Gate 9 PASS |
+|----------|------------------------:|--------------------:|----------------:|--------------:|:-----------:|
+| 0        | 88.7% (149/168)         | 0.258               | 0.031           | 0.000         | no          |
+| 1        | 78.4% (138/176)         | 0.405               | 0.074           | 0.210         | no          |
+| flat     | 60.7% (108/178)         | 0.642               | 0.168           | 0.124         | no          |
+| throttle | 89.6% (163/182)         | 0.250               | 0.013           | 0.000         | no          |
+| sub      | 66.7% (110/165)         | 0.534               | 0.222           | 0.133         | no          |
+
+Gate 9 PASS = chosen `entropy_norm ≥ 0.35` **AND** chosen `jsd_norm ≥ 0.25`.
+`chosen_vs_executed_divergence` stayed small (0.03–0.07) in every mode.
+
+## Read
+
+1. **Chosen verbs do shift away from `contribute`** under every substitution-bearing
+   mode (`1`, `flat`, `sub`): the free-choice contribute share drops from 88.7% (baseline)
+   to 60.7–78.4%, and chosen entropy roughly doubles. Because
+   `chosen_vs_executed_divergence` is tiny and `economy_substitution_rate` (0.12–0.21) is
+   *below* the total chosen shift, this is the model genuinely **choosing** other verbs via
+   the `energy_hint` perception channel — not the executor forcing them. This directly
+   contradicts the ADR 0008 framing that "no identity layer can diversify verbs without
+   changing the action economy" only insofar as it shows the action-economy lever *can*
+   move chosen verbs.
+2. **The scene-gate alone does nothing.** `throttle` (89.6%, entropy 0.250) is
+   indistinguishable from baseline. The substitution lever + `energy_hint`, not the
+   scene-initiation throttle, is what moves choices.
+3. **Divergence is the remaining gap.** No mode clears Gate 9: modes `1`/`flat`/`sub` pass
+   the entropy floor but **fail the chosen JSD floor** (max 0.222, mode `sub`). Agents
+   reduce the monoculture but drift toward the *same* alternatives (study/rest) rather than
+   specializing into *distinct* verbs — and cross-agent divergence is exactly ADR 0007's
+   real target.
+4. **`flat` ≈ `1` on the contribute axis** (and beats it on chosen entropy), while `sub`
+   leads on divergence. Comparative advantage is not the driver here; the substitution
+   pressure + perception is.
+
+## Decision
+
+**Escalate to Stage 3.** The Stage 2 criterion ("escalate only if the chosen verbs shift
+away from contribute") is met. Recommended adjustments for the Stage 3 design:
+
+- Modes `{0, sub, flat}` (swap `1` → `sub`: `sub` led divergence and isolates the lever
+  from the scene gate, which Stage 2 showed inert). Keep `flat` as the comparative-advantage
+  control.
+- Seeds `{42, 38, 7}`, 3000 ticks, per the #45 plan — needed because the single-seed
+  ~170-event reads here are noisy and the JSD signal is small.
+- Primary read: **chosen JSD_norm** (divergence), not just contribute share. The open
+  question Stage 3 must answer is whether more events let agents settle into *distinct*
+  specialties (JSD ≥ 0.25), or whether they keep co-drifting (the lever lowers monoculture
+  but does not produce ADR 0007 divergence).
+- Write **ADR 0009** from the Stage 3 read. HALT remains until a PASS.

--- a/scripts/replay_economy.py
+++ b/scripts/replay_economy.py
@@ -22,6 +22,8 @@ so these are estimates, not the live measurement — run
 Usage:
     uv run python scripts/replay_economy.py --data data/econ-off-s42
     uv run python scripts/replay_economy.py --synthetic --ticks 2000 --seed 42
+    # tuning sweep: override the knobs without editing config
+    uv run python scripts/replay_economy.py --synthetic --regen 8 --energy-max 100
 """
 
 from __future__ import annotations
@@ -128,18 +130,25 @@ def synthetic_run(
     roster: tuple[tuple[str, str], ...],
     cost_table: dict[str, dict[str, float]],
     seed: int,
+    max_energy: float = ENERGY_MAX,
+    regen_per_tick: float = ENERGY_REGEN_PER_TICK,
 ) -> dict:
     """Drive the executor with a no-LLM policy to read the mechanical ceiling.
 
     Policies: ``always-contribute`` (every chosen verb is contribute),
     ``uniform-random`` (uniform over the six verbs), ``role-biased`` (each role
     mostly picks its cheapest specialty). Round-robins the roster one action
-    per tick and regenerates the whole roster each tick (matching live)."""
+    per tick and regenerates the whole roster each tick (matching live).
+
+    ``max_energy``/``regen_per_tick`` default to the config constants but can be
+    overridden so the Stage-1 sweep can search for throttling numbers without
+    editing ``config`` (the cost table being unthrottled at the default knobs is
+    the whole point of the stage)."""
     rng = random.Random(seed)
     ledger = EnergyLedger.fresh(
         [n for n, _ in roster],
-        max_energy=ENERGY_MAX,
-        regen_per_tick=ENERGY_REGEN_PER_TICK,
+        max_energy=max_energy,
+        regen_per_tick=regen_per_tick,
         cost_table=cost_table,
     )
     productive = [v for v in _VERBS if v != "rest"]
@@ -193,13 +202,25 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     p.add_argument("--ticks", type=int, default=2000, help="Stage 1 tick budget")
     p.add_argument("--seed", type=int, default=42, help="Stage 1 RNG seed")
+    p.add_argument(
+        "--energy-max",
+        type=float,
+        default=ENERGY_MAX,
+        help="override ENERGY_MAX (tuning sweep; defaults to config)",
+    )
+    p.add_argument(
+        "--regen",
+        type=float,
+        default=ENERGY_REGEN_PER_TICK,
+        help="override ENERGY_REGEN_PER_TICK (tuning sweep; defaults to config)",
+    )
     return p.parse_args(argv)
 
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     cost_table = build_cost_table(args.mode)
-    report: dict = {"mode": args.mode, "energy_max": ENERGY_MAX, "regen": ENERGY_REGEN_PER_TICK}
+    report: dict = {"mode": args.mode, "energy_max": args.energy_max, "regen": args.regen}
 
     if args.data:
         ep = Path(args.data) / "episodic.sqlite"
@@ -208,8 +229,8 @@ def main(argv: list[str]) -> int:
             return 2
         ledger = EnergyLedger.fresh(
             [n for n, _ in _DEFAULT_ROSTER],
-            max_energy=ENERGY_MAX,
-            regen_per_tick=ENERGY_REGEN_PER_TICK,
+            max_energy=args.energy_max,
+            regen_per_tick=args.regen,
             cost_table=cost_table,
         )
         report["stage0_replay"] = replay_executor(_trace_from_episodic(ep), ledger=ledger)
@@ -222,6 +243,8 @@ def main(argv: list[str]) -> int:
                 roster=_DEFAULT_ROSTER,
                 cost_table=cost_table,
                 seed=args.seed,
+                max_energy=args.energy_max,
+                regen_per_tick=args.regen,
             )
             for pol in ("always-contribute", "uniform-random", "role-biased")
         ]

--- a/scripts/replay_economy.py
+++ b/scripts/replay_economy.py
@@ -214,7 +214,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=ENERGY_REGEN_PER_TICK,
         help="override ENERGY_REGEN_PER_TICK (tuning sweep; defaults to config)",
     )
-    return p.parse_args(argv)
+    args = p.parse_args(argv)
+    # Fail fast on meaningless knobs: a non-positive pool or negative regen is
+    # never a valid economy and would silently yield a degenerate all-rest sweep.
+    if args.energy_max <= 0:
+        p.error("--energy-max must be > 0")
+    if args.regen < 0:
+        p.error("--regen must be >= 0")
+    return args
 
 
 def main(argv: list[str]) -> int:

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -244,8 +244,18 @@ _ECONOMY_SUBSTITUTE: bool = ECONOMY_MODE in ("1", "flat", "sub")
 # dear contribute (~22) so a role can sustain its specialty indefinitely but
 # must save up across cheaper/idle ticks to afford an off-specialty verb or
 # to re-initiate a scene — the scarcity pressure that should diversify the mix.
+#
+# Stage 0/1 tune (post-#45): regen 12 → 8. At 12 a pure-contribute policy was
+# NOT throttled — in the 2-agent roster the whole-roster per-tick regen returns
+# 2*12=24 between an agent's own actions, exceeding even the artisan's
+# contribute cost (22), so the pool never drains and the cost numbers never
+# bit. 8 makes contribute drain (offline replay: always-contribute sub_rate
+# 0.0 → 0.37, contribute share 1.0 → 0.63) while the role specialty (cost 6)
+# stays fully sustainable (sub_rate 0.0). ENERGY_MAX is not the lever — the
+# steady state oscillates near the regen/cost balance, not near max. Verify
+# with: uv run python scripts/replay_economy.py --synthetic --regen 8.
 ENERGY_MAX: float = 100.0
-ENERGY_REGEN_PER_TICK: float = 12.0
+ENERGY_REGEN_PER_TICK: float = 8.0
 
 # Comparative advantage: each role is cheap at exactly one productive verb
 # (its strict specialty) and dear elsewhere. ``rest`` is free for every role

--- a/tests/test_replay_economy.py
+++ b/tests/test_replay_economy.py
@@ -85,6 +85,34 @@ def test_synthetic_always_contribute_single_agent_throttled():
     assert out["substitution_rate"] > 0.0
 
 
+def test_synthetic_respects_energy_overrides():
+    # The override knobs must thread through to the ledger so the Stage-1 sweep
+    # can find throttling numbers without editing config. Same 2-agent
+    # always-contribute policy + seed: a generous regen sustains it (not
+    # throttled), a tight regen drains it (throttled).
+    roster = (("Aki", "artisan"), ("Cy", "scholar"))
+    generous = replay_economy.synthetic_run(
+        "always-contribute",
+        n_ticks=400,
+        roster=roster,
+        cost_table=VERB_COST_BY_ROLE,
+        seed=42,
+        max_energy=100.0,
+        regen_per_tick=12.0,
+    )
+    tight = replay_economy.synthetic_run(
+        "always-contribute",
+        n_ticks=400,
+        roster=roster,
+        cost_table=VERB_COST_BY_ROLE,
+        seed=42,
+        max_energy=100.0,
+        regen_per_tick=8.0,
+    )
+    assert generous["substitution_rate"] == 0.0
+    assert tight["substitution_rate"] > 0.0
+
+
 def test_synthetic_role_biased_diversifies():
     out = replay_economy.synthetic_run(
         "role-biased",

--- a/tests/test_replay_economy.py
+++ b/tests/test_replay_economy.py
@@ -8,8 +8,11 @@ throttled. Zero LLM compute.
 from __future__ import annotations
 
 import importlib.util
+import sqlite3
 import sys
 from pathlib import Path
+
+import pytest
 
 from microverse.config import VERB_COST_BY_ROLE
 from microverse.world.economy import EnergyLedger
@@ -111,6 +114,66 @@ def test_synthetic_respects_energy_overrides():
     )
     assert generous["substitution_rate"] == 0.0
     assert tight["substitution_rate"] > 0.0
+
+
+def test_main_threads_overrides_into_synthetic(monkeypatch):
+    # The --synthetic CLI path must hand the parsed knobs to synthetic_run, not
+    # the bare config constants (otherwise the sweep silently ignores --regen).
+    captured: dict[str, float] = {}
+
+    def _spy(policy: str, **kwargs: object) -> dict:
+        captured["max_energy"] = kwargs["max_energy"]  # type: ignore[assignment]
+        captured["regen_per_tick"] = kwargs["regen_per_tick"]  # type: ignore[assignment]
+        return {
+            "policy": policy,
+            "total": 0,
+            "executed_counts": {},
+            "substitution_rate": 0.0,
+            "executed_contribute_share": 0.0,
+            "executed_entropy_norm": 0.0,
+        }
+
+    monkeypatch.setattr(replay_economy, "synthetic_run", _spy)
+    rc = replay_economy.main(["--synthetic", "--ticks", "5", "--energy-max", "55", "--regen", "7"])
+    assert rc == 0
+    assert captured == {"max_energy": 55.0, "regen_per_tick": 7.0}
+
+
+def test_main_threads_overrides_into_stage0(monkeypatch, tmp_path):
+    # The --data (Stage 0) path must construct the ledger with the parsed knobs.
+    run = tmp_path / "run"
+    run.mkdir()
+    conn = sqlite3.connect(run / "episodic.sqlite")
+    conn.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY, actor TEXT, action TEXT, payload_json TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+    captured: dict[str, float] = {}
+    real_fresh = replay_economy.EnergyLedger.fresh
+
+    def _spy_fresh(names: object, **kwargs: object) -> EnergyLedger:
+        captured["max_energy"] = kwargs["max_energy"]  # type: ignore[assignment]
+        captured["regen_per_tick"] = kwargs["regen_per_tick"]  # type: ignore[assignment]
+        return real_fresh(names, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(replay_economy.EnergyLedger, "fresh", staticmethod(_spy_fresh))
+    rc = replay_economy.main(["--data", str(run), "--energy-max", "55", "--regen", "7"])
+    assert rc == 0
+    assert captured == {"max_energy": 55.0, "regen_per_tick": 7.0}
+
+
+@pytest.mark.parametrize(
+    ("flag", "value"),
+    [("--energy-max", "0"), ("--energy-max", "-5"), ("--regen", "-1")],
+)
+def test_cli_rejects_nonsensical_knobs(flag: str, value: str):
+    # Fail fast on meaningless tuning input rather than silently producing a
+    # degenerate all-rest sweep (a non-positive pool / negative regen is never a
+    # valid economy). argparse error() exits with code 2.
+    with pytest.raises(SystemExit):
+        replay_economy.parse_args(["--synthetic", flag, value])
 
 
 def test_synthetic_role_biased_diversifies():


### PR DESCRIPTION
## Summary

Executes the **Stage 0/1** post-merge recommendation from #45: tune the action-economy
knobs until the cost numbers actually throttle, verified offline with zero LLM compute.
The fix is a one-line default change (`ENERGY_REGEN_PER_TICK 12 → 8`) plus a small
reproducibility enhancement to the replay sweep tool. Stage 2 (live 5-mode runs) is in
flight and will land as a follow-up commit on this PR (see Post-Merge).

## Background / Motivation

#45 shipped the action-economy spike (re-diagnosis of the ADR 0008 Gate-3 halt) but
explicitly documented that **the default knobs do not throttle**: a pure-contribute policy
on the 2-agent roster is never constrained. Recommendation 1 was to tune
`ENERGY_MAX`/`ENERGY_REGEN_PER_TICK`/`VERB_COST_BY_ROLE` until the cost numbers bite,
otherwise the live A/B (Stage 3) measures a lever that does nothing.

Root cause (found via an offline sweep): with whole-roster per-tick regen, the 2-agent
roster returns `2 × regen = 24` energy between an agent's own actions — more than even the
artisan's `contribute` cost (22) — so the pool never drains. `ENERGY_MAX` is **not** the
lever (the steady state oscillates near the regen/cost balance, not near max; 100 vs 60
were identical in the sweep). `regen` is.

## Breaking Changes

- [ ] None. `MICROVERSE_ECONOMY` defaults to `0` (economy off) and is byte-identical to
  pre-spike `main`; the regen value is only read when the economy is on. No config-format,
  API, or schema change.

## Changes Made

- **`src/microverse/config.py`:** `ENERGY_REGEN_PER_TICK 12.0 → 8.0`; expanded the comment
  to record why (with the offline numbers and the verify command). `ENERGY_MAX` and
  `VERB_COST_BY_ROLE` unchanged (preserves cross-mode cost parity and the strict-specialty
  invariant).
- **`scripts/replay_economy.py`:** `--energy-max` / `--regen` CLI flags (default to the
  config constants) threaded through `synthetic_run` and the Stage-0 ledger, so the tuning
  sweep can search numbers without editing config. Report now echoes the effective knobs.
- **`tests/test_replay_economy.py`:** new test asserting the override knobs thread through
  (generous regen sustains always-contribute; tight regen throttles it).

## Dependencies

None. Pure-Python, no new packages.

## Test Methodologies and Results

Full local gate, all green:
```
uv run ruff check && uv run ruff format --check && uv run mypy src/microverse \
  && uv run pip-audit && uv run pytest -q -m 'not integration' && uv build
# => 591 passed, 3 deselected; mypy clean; no known vulnerabilities; build OK
```

Stage 0/1 offline verification (zero LLM compute) at the new default:
```
uv run python scripts/replay_economy.py --synthetic --ticks 2000 --seed 42
#   always-contribute: sub_rate 0.37, contribute share 0.63  (was 0.0 / 1.0 — now throttled)
#   role-biased:       sub_rate 0.00                          (specialty still sustainable)
uv run python scripts/replay_economy.py --data data/soak-v1-2   # real economy-OFF trace
#   sub_rate 0.60, executed contribute 0.61 → 0.36, rest 0.21  (diversifies, not rest-collapse)
```

## Design & Reasoning Notes

- **Why regen, not ENERGY_MAX or the cost table:** the sweep showed `ENERGY_MAX` does not
  move the steady state; lowering `regen` is the minimal lever that makes `contribute` drain
  while leaving each role's cheap specialty (cost 6) fully affordable, so comparative
  advantage — the thing the spike is testing — is preserved.
- **Why 8 (not 6 or 10):** 10 barely bites (always-contribute sub only 0.12); 6 over-collapses
  the real trace toward rest (27%). 8 throttles the degenerate case (sub 0.37) and keeps the
  real-trace rest share reasonable (21%). The role specialty stays at sub 0.0 at all three.
- **Cost table untouched** so modes `1`/`flat`/`throttle`/`sub` keep identical `contribute`
  costs (the `flat` control and the strict-specialty test both depend on this).
- **CLI overrides** keep the tune reproducible and let future re-tunes sweep without touching
  source.

## Impact / Risk Assessment

- **Affected:** only runs with `MICROVERSE_ECONOMY` set non-`0`. Production/CI default
  (economy off) is unaffected — the regen value is never read.
- **Invariants preserved:** single-model `think()`; WAL durability (energy stays in-memory);
  flag-off byte-identical baseline.
- **Rollback:** revert the one-line default (or unset `MICROVERSE_ECONOMY`); no migration.

## Documentation

Inline config comment now documents the tune rationale + verify command. No README/AGENTS
change needed (the operator recipe is the existing `replay_economy.py` / `run.py` flow).
ADR 0009 is written after the live A/B (Stage 3), per the #45 plan.

## Review Focus

- [IMPORTANT] `config.py` — the regen rationale and that `ENERGY_MAX`/`VERB_COST_BY_ROLE`
  are deliberately unchanged.
- [MINOR] `replay_economy.py` override threading (`synthetic_run` kwargs + Stage-0 ledger).

## Post-Merge Recommendations

The next blocking action is reading whether the tuned lever moves *chosen* verbs live:

1. **Stage 2 (in flight on this PR):** ~300-event runs across the five modes
   (`{0,1,flat,throttle,sub}`, seed 42) at the new regen, measured with
   `spike_workshop_measure.py` (`gate9_verb_diversity`, chosen-vs-executed streams). Results
   land as a follow-up commit here. **Escalate to Stage 3 only if the chosen (parsed) verbs
   shift away from `contribute`** vs the mode-`0` baseline.
2. **Stage 3 (deferred — days of compute):** 3000-tick runs × seeds `{42,38,7}` × modes
   `{0,1,flat}`; read Gate 9; write **ADR 0009** with the decision. The ADR 0008 HALT stays
   in force until a PASS read.