### PR TITLE
docs(adr): action-economy Stage 3 read — ADR 0009 (HALT stays)

### DIFF
--- a/docs/adr/0009-action-economy-stage3-read.md
+++ b/docs/adr/0009-action-economy-stage3-read.md
@@ -32,10 +32,10 @@ The headline read is `jsd_norm`.
 
 ## Method
 
-- Runner: `MICROVERSE_ECONOMY={mode} python -m microverse.run --ticks 3000 --tempo 0
+- Runner: `MICROVERSE_ECONOMY={mode} uv run python -m microverse.run --ticks 3000 --tempo 0
   --seed {seed}` into isolated `MICROVERSE_DATA`/`MICROVERSE_HARVEST` dirs. Model `gemma4:26b`
   (the configured `agent.think()` model). 3000 ticks so the run spans ~5–6 h / ~3500–3800 agent
-  events — large enough that the early-sample noise flagged in the Stage 2 note washes out.
+  events.
 - Knobs: Stage 0/1 tune `ENERGY_REGEN_PER_TICK = 8`, all else default. `ENERGY_MAX = 100`,
   `VERB_COST_BY_ROLE` unchanged (preserves cross-mode cost parity + the strict-specialty
   invariant).
@@ -43,6 +43,11 @@ The headline read is `jsd_norm`.
   scene-initiation gate inert, so it is dropped), `flat` (role-agnostic substitution control).
 - Measurement: `scripts/spike_workshop_measure.py` `gate9_verb_diversity` on the **chosen**
   stream; scene-forced contributes (ADR 0006) and parse-fallback rests excluded as non-choices.
+  `parsed_verb` is stamped only in substitution-enabled modes (`run.py:1155-1160`), so for the
+  `0` arm the reader falls back to the *executed* verb (`measure:231`). That is exact, not an
+  approximation: with the economy off there is no substitution, so chosen ≡ executed for the
+  baseline; for `sub`/`flat` the chosen stream is the model's pick **before** the executor may
+  rewrite it.
 - **Planned seeds `{42, 38, 7}`; the sweep was stopped after seed 42** (operator decision —
   see Limitations).
 
@@ -54,24 +59,32 @@ The headline read is `jsd_norm`.
 | `sub`  | 77.3% (1975/2555)       | 0.409               | 0.109           | 0.204         | 0.078 | FAIL   |
 | `flat` | 66.9% (1826/2730)       | 0.574               | **0.185**       | 0.157         | 0.030 | FAIL   |
 
-`cxe` = `chosen_vs_executed_divergence` (≈0 → the executor is not forcing the shift; the agent
-chooses it through the `energy_hint` perception channel).
+`econ_sub_rate` = `economy_substitution_rate`, the **per-event** executor-override rate. `cxe` =
+`chosen_vs_executed_divergence`, the JSD between the **society-aggregated** chosen and executed
+distributions (`measure:248`) — a society-level summary, not a per-event rewrite count.
 
-### Scale comparison vs Stage 2 (200 ticks, same seed)
+### Scale comparison vs Stage 2 (200 ticks, same seed) — two independent runs
 
-| mode   | entropy 200t → 3000t | jsd 200t → 3000t | contribute 200t → 3000t |
+The 200-tick and 3000-tick numbers come from **separate live runs**, not two sample lengths of
+one trajectory. `--seed` seeds only the Python RNGs (scheduler/weather/clock, `run.py:695,786`);
+the `gemma4:26b` sampling is unseeded, so the runs diverge from tick 1. Read the pair as two
+independent draws at different horizons.
+
+| mode   | entropy 200t / 3000t | jsd 200t / 3000t | contribute 200t / 3000t |
 |--------|:--------------------:|:----------------:|:-----------------------:|
-| `0`    | 0.258 → 0.274        | 0.031 → 0.017    | 88.7% → 88.1%           |
-| `sub`  | 0.534 → 0.409        | 0.222 → 0.109    | 66.7% → 77.3%           |
-| `flat` | 0.642 → 0.574        | 0.168 → 0.185    | 60.7% → 66.9%           |
+| `0`    | 0.258 / 0.274        | 0.031 / 0.017    | 88.7% / 88.1%           |
+| `sub`  | 0.534 / 0.409        | 0.222 / 0.109    | 66.7% / 77.3%           |
+| `flat` | 0.642 / 0.574        | 0.168 / 0.185    | 60.7% / 66.9%           |
 
 ## Findings
 
 1. **The lever moves verb diversity — ADR 0008's re-diagnosis is half right.** Both lever modes
-   clear the entropy floor and cut the chosen contribute share from 88% to 67–77%, and the shift
-   is genuine model choice (`cxe ≤ 0.078`, `econ_sub` below the total chosen shift), not executor
-   forcing. So the monoculture is *not* immovable: an identity-independent change to the action
-   economy does diversify chosen verbs.
+   clear the entropy floor and cut the chosen contribute share from 88% to 67–77%. The chosen
+   stream is `parsed_verb`, the model's pick **before** the executor may rewrite it, so the
+   entropy/JSD numbers are model choice by construction; the per-event override rate (`econ_sub`
+   0.157–0.204) is real but below the total chosen shift, and `cxe` (0.03–0.08) shows the override
+   barely moves the society-level mix. The monoculture is *not* immovable: an
+   identity-independent change to the action economy does diversify chosen verbs.
 
 2. **But it does not unlock cross-agent specialization — Gate 9 FAILS in every mode.** `jsd_norm`
    tops out at 0.185 (`flat`), 26% under the 0.25 floor. Agents reduce the monoculture by
@@ -79,15 +92,15 @@ chooses it through the `energy_hint` perception channel).
    rather than splitting into distinct profiles. Cross-agent divergence — the actual ADR 0007
    target — does not emerge.
 
-3. **At scale the divergence decays.** Stage 2's near-floor `sub` read (jsd 0.222) was
-   small-sample optimism: over 3000 ticks `sub` regresses (jsd → 0.109, contribute → 77.3%). More
-   events make the gap worse, not better — evidence the co-drift is the equilibrium, not a
-   transient.
+3. **The longer run does not move toward the floor.** The independent 3000-tick `sub` run lands
+   at jsd 0.109 / contribute 77.3% vs the 200-tick run's 0.222 / 66.7%. Two draws is too few to
+   assert a trend, but the larger-sample run is no closer to passing, so the near-floor Stage 2
+   `sub` read does not survive as evidence that more events produce specialization.
 
 4. **Comparative advantage is not the driver.** `flat` (role-agnostic) matches or beats `sub`
-   (role-specific costs) on both entropy and JSD and is more stable over the long run. The agents
-   are not exploiting cost structure to differentiate; raw substitution pressure, not comparative
-   advantage, is what little movement there is.
+   (role-specific costs) on both entropy and JSD. The agents are not exploiting cost structure to
+   differentiate; raw substitution pressure, not comparative advantage, is what little movement
+   there is.
 
 ## Decision
 
@@ -96,19 +109,23 @@ chooses it through the `energy_hint` perception channel).
 ADR 0008 framed verb monoculture as the structural blocker and the action economy as the
 unlock. Stage 3 shows the action economy unlocks *diversity* (society entropy) but **not
 specialization** (cross-agent JSD), and specialization is what "from workshop to civilization"
-actually requires. Tuning the economy harder is unlikely to close a 0.185 → 0.25 gap that
-*widens* with scale; the missing ingredient is a force that makes agents differentiate from each
-other, not merely vary their own output. That is a deeper design question than the spike was
-built to answer, and it stays open. Do not start Phase 2 on the strength of the economy lever.
+actually requires. The JSD shortfall is wide (0.185 vs 0.25) and does not close in the longer
+run; the missing ingredient is a force that makes agents differentiate from each other, not
+merely vary their own output. That is a deeper design question than the spike was built to
+answer, and it stays open. Do not start Phase 2 on the strength of the economy lever.
 
 ## Limitations
 
 - **Single seed at scale.** Seeds 38 and 7 were planned but not run; the sweep was stopped after
   seed 42 once the within-seed signal was unambiguous and consistent with Stage 2. The numeric
-  JSD/entropy values are therefore one-seed point estimates without a cross-seed variance band.
-  The *qualitative* verdict (entropy floor cleared, JSD floor missed by a wide and scale-widening
-  margin) is robust to plausible seed variance; a specific mode's borderline pass on a lucky seed
-  would not constitute a robust Gate 9 PASS.
+  JSD/entropy values are therefore one-seed point estimates with no cross-seed variance band. The
+  *qualitative* verdict (entropy floor cleared, JSD floor missed by a wide margin that does not
+  close in the longer run) is robust to plausible seed variance; a specific mode's borderline pass
+  on a lucky seed would not constitute a robust Gate 9 PASS.
+- **`cxe` is a society-level summary.** A low `chosen_vs_executed_divergence` means the
+  *aggregate* chosen and executed verb mixes are close; it does not bound the per-event rewrite
+  count (that is `economy_substitution_rate`, 0.16–0.20 here). The "model choice, not executor
+  forcing" claim rests on the chosen stream being pre-substitution `parsed_verb`, not on `cxe`.
 - Two-resident roster (Aki/artisan, Cy/scholar). JSD across two agents is a coarse divergence
   estimate; a larger roster could change the specialization dynamics and is untested here.
 - The spike deliberately did not tune prompts to manufacture movement (ADR 0008 constraint

--- a/docs/adr/0009-action-economy-stage3-read.md
+++ b/docs/adr/0009-action-economy-stage3-read.md
@@ -1,0 +1,131 @@
+# ADR 0009: Action-economy Stage 3 — verb-diversity A/B read (Gate 9)
+
+**Status:** Accepted (measurement record) — records the falsifiable Stage 3 read that
+re-tests the ADR 0008 "verb monoculture is structural" re-diagnosis.
+**Halt decision: HALT stays.** The action economy moves verb *diversity* but not cross-agent
+*specialization*; the ADR 0007 substrate thesis remains unproven.
+
+**Date:** 2026-06-02
+
+## Context
+
+ADR 0008 halted ADR 0007 Phase 1 (durable identity moved neither Gate 1 nor Gate 3) and offered
+a re-diagnosis: **Gate 3 (verb monoculture) is structural** — "the scene/workshop loop funnels
+~95% of actions into `contribute`; no identity layer can diversify verbs without changing the
+action economy itself" (ADR 0008, re-diagnosis #2). PR #45 built a feature-flagged
+**action-economy spike** (finite per-agent stamina `EnergyLedger` + comparative-advantage verb
+costs `VERB_COST_BY_ROLE`, gated by `MICROVERSE_ECONOMY`) to test that claim *falsifiably*. Its
+operator runbook ran in three stages:
+
+- **Stage 0/1** (offline, #46): tune the cost numbers until the lever actually throttles
+  (`ENERGY_REGEN_PER_TICK 12 → 8`); confirm a draining policy is substituted while a sustainable
+  specialty is not.
+- **Stage 2** (cheap live, 200 ticks × 5 modes): the chosen (`parsed_verb`) stream genuinely
+  shifts away from `contribute` under the substitution lever — escalate.
+- **Stage 3** (this ADR): long live A/B for the real target, **Gate 9 cross-agent verb
+  divergence**.
+
+Gate 9 is the operational form of ADR 0007's "civilization" thesis: agents should not merely emit
+varied verbs (society entropy) but settle into **distinct** verb profiles (cross-agent
+Jensen-Shannon divergence). **PASS = chosen `entropy_norm ≥ 0.35` AND chosen `jsd_norm ≥ 0.25`.**
+The headline read is `jsd_norm`.
+
+## Method
+
+- Runner: `MICROVERSE_ECONOMY={mode} python -m microverse.run --ticks 3000 --tempo 0
+  --seed {seed}` into isolated `MICROVERSE_DATA`/`MICROVERSE_HARVEST` dirs. Model `gemma4:26b`
+  (the configured `agent.think()` model). 3000 ticks so the run spans ~5–6 h / ~3500–3800 agent
+  events — large enough that the early-sample noise flagged in the Stage 2 note washes out.
+- Knobs: Stage 0/1 tune `ENERGY_REGEN_PER_TICK = 8`, all else default. `ENERGY_MAX = 100`,
+  `VERB_COST_BY_ROLE` unchanged (preserves cross-mode cost parity + the strict-specialty
+  invariant).
+- Modes: `0` (economy off, baseline), `sub` (substitution lever only — Stage 2 showed the
+  scene-initiation gate inert, so it is dropped), `flat` (role-agnostic substitution control).
+- Measurement: `scripts/spike_workshop_measure.py` `gate9_verb_diversity` on the **chosen**
+  stream; scene-forced contributes (ADR 0006) and parse-fallback rests excluded as non-choices.
+- **Planned seeds `{42, 38, 7}`; the sweep was stopped after seed 42** (operator decision —
+  see Limitations).
+
+## Results (seed 42, 3000 ticks)
+
+| mode   | chosen contribute share | chosen entropy_norm | chosen jsd_norm | econ_sub_rate | cxe   | Gate 9 |
+|--------|------------------------:|--------------------:|----------------:|--------------:|------:|:------:|
+| `0`    | 88.1% (2229/2531)       | 0.274               | 0.017           | 0.000         | 0.000 | FAIL   |
+| `sub`  | 77.3% (1975/2555)       | 0.409               | 0.109           | 0.204         | 0.078 | FAIL   |
+| `flat` | 66.9% (1826/2730)       | 0.574               | **0.185**       | 0.157         | 0.030 | FAIL   |
+
+`cxe` = `chosen_vs_executed_divergence` (≈0 → the executor is not forcing the shift; the agent
+chooses it through the `energy_hint` perception channel).
+
+### Scale comparison vs Stage 2 (200 ticks, same seed)
+
+| mode   | entropy 200t → 3000t | jsd 200t → 3000t | contribute 200t → 3000t |
+|--------|:--------------------:|:----------------:|:-----------------------:|
+| `0`    | 0.258 → 0.274        | 0.031 → 0.017    | 88.7% → 88.1%           |
+| `sub`  | 0.534 → 0.409        | 0.222 → 0.109    | 66.7% → 77.3%           |
+| `flat` | 0.642 → 0.574        | 0.168 → 0.185    | 60.7% → 66.9%           |
+
+## Findings
+
+1. **The lever moves verb diversity — ADR 0008's re-diagnosis is half right.** Both lever modes
+   clear the entropy floor and cut the chosen contribute share from 88% to 67–77%, and the shift
+   is genuine model choice (`cxe ≤ 0.078`, `econ_sub` below the total chosen shift), not executor
+   forcing. So the monoculture is *not* immovable: an identity-independent change to the action
+   economy does diversify chosen verbs.
+
+2. **But it does not unlock cross-agent specialization — Gate 9 FAILS in every mode.** `jsd_norm`
+   tops out at 0.185 (`flat`), 26% under the 0.25 floor. Agents reduce the monoculture by
+   co-drifting toward the *same* alternatives (`sub` → study/rest; `flat` → speak/rest/study)
+   rather than splitting into distinct profiles. Cross-agent divergence — the actual ADR 0007
+   target — does not emerge.
+
+3. **At scale the divergence decays.** Stage 2's near-floor `sub` read (jsd 0.222) was
+   small-sample optimism: over 3000 ticks `sub` regresses (jsd → 0.109, contribute → 77.3%). More
+   events make the gap worse, not better — evidence the co-drift is the equilibrium, not a
+   transient.
+
+4. **Comparative advantage is not the driver.** `flat` (role-agnostic) matches or beats `sub`
+   (role-specific costs) on both entropy and JSD and is more stable over the long run. The agents
+   are not exploiting cost structure to differentiate; raw substitution pressure, not comparative
+   advantage, is what little movement there is.
+
+## Decision
+
+**The action economy is necessary-ish but not sufficient for the ADR 0007 thesis. HALT stays.**
+
+ADR 0008 framed verb monoculture as the structural blocker and the action economy as the
+unlock. Stage 3 shows the action economy unlocks *diversity* (society entropy) but **not
+specialization** (cross-agent JSD), and specialization is what "from workshop to civilization"
+actually requires. Tuning the economy harder is unlikely to close a 0.185 → 0.25 gap that
+*widens* with scale; the missing ingredient is a force that makes agents differentiate from each
+other, not merely vary their own output. That is a deeper design question than the spike was
+built to answer, and it stays open. Do not start Phase 2 on the strength of the economy lever.
+
+## Limitations
+
+- **Single seed at scale.** Seeds 38 and 7 were planned but not run; the sweep was stopped after
+  seed 42 once the within-seed signal was unambiguous and consistent with Stage 2. The numeric
+  JSD/entropy values are therefore one-seed point estimates without a cross-seed variance band.
+  The *qualitative* verdict (entropy floor cleared, JSD floor missed by a wide and scale-widening
+  margin) is robust to plausible seed variance; a specific mode's borderline pass on a lucky seed
+  would not constitute a robust Gate 9 PASS.
+- Two-resident roster (Aki/artisan, Cy/scholar). JSD across two agents is a coarse divergence
+  estimate; a larger roster could change the specialization dynamics and is untested here.
+- The spike deliberately did not tune prompts to manufacture movement (ADR 0008 constraint
+  carried forward).
+
+## Reproduction
+
+```bash
+# per mode in {0, sub, flat}, seed in {42, 38, 7}:
+MICROVERSE_ECONOMY=$MODE \
+MICROVERSE_DATA=data/econ-stage3-$MODE-s$SEED \
+MICROVERSE_HARVEST=harvest/econ-stage3-$MODE-s$SEED \
+  uv run python -m microverse.run --ticks 3000 --tempo 0 --seed $SEED
+uv run python scripts/spike_workshop_measure.py \
+  --data data/econ-stage3-$MODE-s$SEED --harvest harvest/econ-stage3-$MODE-s$SEED
+# read .gate_9_verb_diversity.chosen.{society_entropy_norm,jsd_norm} and .pass
+```
+
+Offline knob sweep (zero LLM compute): `scripts/replay_economy.py --synthetic --regen 8`.
+Stage 2 read: `docs/economy-stage2-findings.md`. Stage 3 read: `docs/economy-stage3-findings.md`.

--- a/docs/economy-stage3-findings.md
+++ b/docs/economy-stage3-findings.md
@@ -6,9 +6,9 @@ ADR 0008 HALT stays in force; this records the read that informs it.
 ## Setup
 
 - Knobs: `ENERGY_REGEN_PER_TICK = 8` (Stage 0/1 tune, #46), everything else default.
-- Runner: `MICROVERSE_ECONOMY={mode} python -m microverse.run --ticks 3000 --tempo 0
-  --seed {seed}`, model `gemma4:26b`, isolated `MICROVERSE_DATA`/`MICROVERSE_HARVEST`
-  per run. Each run ~5.3–6.2 h / ~3500–3800 agent events.
+- Runner: `MICROVERSE_ECONOMY={mode} uv run python -m microverse.run --ticks 3000
+  --tempo 0 --seed {seed}`, model `gemma4:26b`, isolated `MICROVERSE_DATA`/
+  `MICROVERSE_HARVEST` per run. Each run ~5.3–6.2 h / ~3500–3800 agent events.
 - Modes: `0` (economy off / baseline), `sub` (substitution lever only, no scene gate —
   Stage 2 showed the scene gate inert, so it is dropped here), `flat` (role-agnostic
   substitution control: substitution pressure without comparative advantage).
@@ -19,59 +19,77 @@ ADR 0008 HALT stays in force; this records the read that informs it.
   chosen `jsd_norm ≥ 0.25`.** Primary read is `jsd_norm` (cross-agent divergence —
   ADR 0007's real target).
 
+> **Chosen stream, by mode.** `parsed_verb` is stamped only in substitution-enabled
+> modes (`run.py:1155-1160`, gated on `_ECONOMY_SUBSTITUTE`). For mode `0` the gate9
+> reader (`measure:231`) falls back to the *executed* verb, so the `0` arm's "chosen"
+> stream is its executed stream. That is exact for the baseline, not an approximation:
+> with the economy off there is no substitution (`econ_sub = 0`), so chosen ≡ executed by
+> construction. For `sub`/`flat` the chosen stream is the model's pick **before** the
+> executor may rewrite it.
+
 ## Results (seed 42, 3000 ticks)
 
 | mode   | chosen contribute share | chosen entropy_norm | chosen jsd_norm | econ_sub_rate | cxe   | Gate 9 PASS |
 |--------|------------------------:|--------------------:|----------------:|--------------:|------:|:-----------:|
-| `0`    | 88.1% (2229/2531)       | 0.2741              | 0.017           | 0.000         | 0.000 | no          |
-| `sub`  | 77.3% (1975/2555)       | 0.4090              | 0.1088          | 0.2041        | 0.078 | no          |
-| `flat` | 66.9% (1826/2730)       | 0.5738              | **0.1846**      | 0.1573        | 0.030 | no          |
+| `0`    | 88.1% (2229/2531)       | 0.274               | 0.017           | 0.000         | 0.000 | no          |
+| `sub`  | 77.3% (1975/2555)       | 0.409               | 0.109           | 0.204         | 0.078 | no          |
+| `flat` | 66.9% (1826/2730)       | 0.574               | **0.185**       | 0.157         | 0.030 | no          |
 
-`econ_sub_rate` = `economy_substitution_rate`; `cxe` = `chosen_vs_executed_divergence`
-(small in every mode → the executor is not forcing the shift). Per-run elapsed: `0` 6.22 h,
-`sub` 5.92 h, `flat` 5.27 h.
+`econ_sub_rate` = `economy_substitution_rate`, the **per-event** rate at which the executor
+overrode the model's pick (`measure:222-224`). `cxe` = `chosen_vs_executed_divergence`, the
+JSD between the **society-aggregated** chosen and executed verb distributions (`measure:248`) —
+a society-level summary, not a per-event rewrite count. Per-run elapsed: `0` 6.22 h, `sub`
+5.92 h, `flat` 5.27 h.
 
-### Stage 2 (200 ticks) vs Stage 3 (3000 ticks), seed 42
+### Stage 2 (200 ticks) vs Stage 3 (3000 ticks), seed 42 — two independent runs
 
-| mode   | entropy 200t → 3000t | jsd 200t → 3000t | contribute 200t → 3000t |
+These are **separate live runs** at the same config and `--seed`, not two sample lengths of
+one trajectory: `--seed` seeds only the Python RNGs (scheduler/weather/clock); the `gemma4:26b`
+sampling is unseeded, so the runs diverge from tick 1. Read the pair as two independent draws at
+different horizons, not a within-run time series.
+
+| mode   | entropy 200t / 3000t | jsd 200t / 3000t | contribute 200t / 3000t |
 |--------|:--------------------:|:----------------:|:-----------------------:|
-| `0`    | 0.258 → 0.274        | 0.031 → 0.017    | 88.7% → 88.1%           |
-| `sub`  | 0.534 → 0.409        | 0.222 → **0.109**| 66.7% → 77.3%           |
-| `flat` | 0.642 → 0.574        | 0.168 → 0.185    | 60.7% → 66.9%           |
+| `0`    | 0.258 / 0.274        | 0.031 / 0.017    | 88.7% / 88.1%           |
+| `sub`  | 0.534 / 0.409        | 0.222 / 0.109    | 66.7% / 77.3%           |
+| `flat` | 0.642 / 0.574        | 0.168 / 0.185    | 60.7% / 66.9%           |
 
 ## Read
 
 1. **The lever breaks the monoculture but never reaches the divergence floor.** Both lever
    modes clear the entropy floor (`sub` 0.409, `flat` 0.574 ≥ 0.35) and drop the chosen
-   contribute share from 88% toward 67–77%. The shift is genuine model choice via the
-   `energy_hint` channel, not executor forcing (`cxe` ≤ 0.078, `econ_sub` 0.16–0.20 below the
-   total chosen shift). **But `jsd_norm` tops out at 0.185 (`flat`), a 26% shortfall on the
-   0.25 floor.** No mode passes Gate 9.
+   contribute share from 88% toward 67–77%. This is a shift in *chosen* verbs: the chosen stream
+   is `parsed_verb`, the model's pick **before** the executor may rewrite it, so the entropy/JSD
+   numbers reflect model choice by construction, not executor output. The per-event override rate
+   (`econ_sub` 0.157–0.204) is real but well below the total chosen shift, and `cxe` (0.03–0.08)
+   shows the override barely moves the society-level verb mix. **But `jsd_norm` tops out at 0.185
+   (`flat`), a 26% shortfall on the 0.25 floor.** No mode passes Gate 9.
 
-2. **At scale the early divergence decays — agents co-drift, they do not specialize.** The
-   Stage 2 200-tick `sub` read (jsd 0.222, near the floor) was small-sample optimism: at
-   3000 ticks `sub` regresses (jsd 0.222 → 0.109, contribute 66.7% → 77.3%). The
-   non-contribute mass piles onto the *same* alternatives for both agents (`sub` → study 412
-   / rest 103; `flat` → speak 434 / rest 247 / study 170), which lifts society entropy while
-   leaving cross-agent JSD low. More events make the divergence gap look *worse*, not better.
+2. **The longer run does not converge to specialization; if anything divergence is lower.** The
+   independent 3000-tick `sub` run lands at jsd 0.109 / contribute 77.3% vs the 200-tick run's
+   0.222 / 66.7%. Two draws is far too few to call a trend, but the larger-sample run does not
+   move *toward* the floor, and the non-contribute mass piles onto the *same* alternatives for
+   both agents (`sub` → study 412 / rest 103; `flat` → speak 434 / rest 247 / study 170) — society
+   entropy rises while cross-agent JSD stays low. The co-drift, not specialization, is what the
+   extra events buy.
 
-3. **`flat` ≥ `sub` on both axes at scale.** Comparative advantage (role-specific costs) is
-   not the driver; flat substitution pressure diversifies at least as well and is more stable
-   over the longer run. This is the opposite of what a "specialize into your cheap verb" story
-   predicts, and is itself evidence that the agents are not using cost structure to differentiate.
+3. **`flat` ≥ `sub` on both axes.** Comparative advantage (role-specific costs) is not the
+   driver; flat substitution pressure diversifies at least as well. This is the opposite of what a
+   "specialize into your cheap verb" story predicts, and is itself evidence the agents are not
+   using cost structure to differentiate.
 
 ## Decision: stop, HALT stays
 
 **Stopped after seed 42** (3 of 9 runs). Rationale: the within-seed pattern is monotone and
-internally consistent (entropy climbs, JSD plateaus far under floor), the mechanism dominates
-RNG, and it corroborates the Stage 2 direction at scale. A second/third seed would refine the
-variance estimate but is very unlikely to flip a 0.185 → 0.25 JSD verdict. Compute (~36 h for
-the remaining 6 runs) was judged not worth that marginal rigor.
+internally consistent (entropy climbs, JSD plateaus far under floor), and it matches the Stage 2
+direction. A second/third seed would add a cross-seed variance band but is very unlikely to flip
+a 0.185 → 0.25 JSD verdict. Compute (~36 h for the remaining 6 runs) was judged not worth that
+marginal rigor.
 
 **Caveat:** this is a single seed at scale. ADR 0009 records the verdict with that explicit
-limitation; seeds 38/7 were not run.
+limitation; seeds 38/7 were not run, so no cross-seed variance band exists.
 
 The action-economy lever is **necessary-ish but not sufficient**: it moves verb *diversity*
-(refuting "only identity-independent structure, nothing the agent chooses, can move Gate 3")
-but does not unlock cross-agent *specialization* (Gate 9 JSD — ADR 0007's actual target). The
-ADR 0008 HALT stays in force. See `docs/adr/0009-action-economy-stage3-read.md`.
+(refuting "nothing the agent chooses can move Gate 3") but does not unlock cross-agent
+*specialization* (Gate 9 JSD — ADR 0007's actual target). The ADR 0008 HALT stays in force. See
+`docs/adr/0009-action-economy-stage3-read.md`.

--- a/docs/economy-stage3-findings.md
+++ b/docs/economy-stage3-findings.md
@@ -1,0 +1,77 @@
+# Action-economy Stage 3 findings (post-#45, ADR 0008 re-diagnosis)
+
+Operator note recording the Stage 3 live A/B that feeds **ADR 0009**. The
+ADR 0008 HALT stays in force; this records the read that informs it.
+
+## Setup
+
+- Knobs: `ENERGY_REGEN_PER_TICK = 8` (Stage 0/1 tune, #46), everything else default.
+- Runner: `MICROVERSE_ECONOMY={mode} python -m microverse.run --ticks 3000 --tempo 0
+  --seed {seed}`, model `gemma4:26b`, isolated `MICROVERSE_DATA`/`MICROVERSE_HARVEST`
+  per run. Each run ~5.3–6.2 h / ~3500–3800 agent events.
+- Modes: `0` (economy off / baseline), `sub` (substitution lever only, no scene gate —
+  Stage 2 showed the scene gate inert, so it is dropped here), `flat` (role-agnostic
+  substitution control: substitution pressure without comparative advantage).
+- Planned seeds `{42, 38, 7}`; **stopped after seed 42** by operator decision (below).
+- Metric: `gate9_verb_diversity` (`scripts/spike_workshop_measure.py`), **chosen**
+  (`parsed_verb`) stream. Scene-forced contributes (ADR 0006) and parse-fallback rests are
+  excluded as non-choices. **Gate 9 PASS = chosen `entropy_norm ≥ 0.35` AND
+  chosen `jsd_norm ≥ 0.25`.** Primary read is `jsd_norm` (cross-agent divergence —
+  ADR 0007's real target).
+
+## Results (seed 42, 3000 ticks)
+
+| mode   | chosen contribute share | chosen entropy_norm | chosen jsd_norm | econ_sub_rate | cxe   | Gate 9 PASS |
+|--------|------------------------:|--------------------:|----------------:|--------------:|------:|:-----------:|
+| `0`    | 88.1% (2229/2531)       | 0.2741              | 0.017           | 0.000         | 0.000 | no          |
+| `sub`  | 77.3% (1975/2555)       | 0.4090              | 0.1088          | 0.2041        | 0.078 | no          |
+| `flat` | 66.9% (1826/2730)       | 0.5738              | **0.1846**      | 0.1573        | 0.030 | no          |
+
+`econ_sub_rate` = `economy_substitution_rate`; `cxe` = `chosen_vs_executed_divergence`
+(small in every mode → the executor is not forcing the shift). Per-run elapsed: `0` 6.22 h,
+`sub` 5.92 h, `flat` 5.27 h.
+
+### Stage 2 (200 ticks) vs Stage 3 (3000 ticks), seed 42
+
+| mode   | entropy 200t → 3000t | jsd 200t → 3000t | contribute 200t → 3000t |
+|--------|:--------------------:|:----------------:|:-----------------------:|
+| `0`    | 0.258 → 0.274        | 0.031 → 0.017    | 88.7% → 88.1%           |
+| `sub`  | 0.534 → 0.409        | 0.222 → **0.109**| 66.7% → 77.3%           |
+| `flat` | 0.642 → 0.574        | 0.168 → 0.185    | 60.7% → 66.9%           |
+
+## Read
+
+1. **The lever breaks the monoculture but never reaches the divergence floor.** Both lever
+   modes clear the entropy floor (`sub` 0.409, `flat` 0.574 ≥ 0.35) and drop the chosen
+   contribute share from 88% toward 67–77%. The shift is genuine model choice via the
+   `energy_hint` channel, not executor forcing (`cxe` ≤ 0.078, `econ_sub` 0.16–0.20 below the
+   total chosen shift). **But `jsd_norm` tops out at 0.185 (`flat`), a 26% shortfall on the
+   0.25 floor.** No mode passes Gate 9.
+
+2. **At scale the early divergence decays — agents co-drift, they do not specialize.** The
+   Stage 2 200-tick `sub` read (jsd 0.222, near the floor) was small-sample optimism: at
+   3000 ticks `sub` regresses (jsd 0.222 → 0.109, contribute 66.7% → 77.3%). The
+   non-contribute mass piles onto the *same* alternatives for both agents (`sub` → study 412
+   / rest 103; `flat` → speak 434 / rest 247 / study 170), which lifts society entropy while
+   leaving cross-agent JSD low. More events make the divergence gap look *worse*, not better.
+
+3. **`flat` ≥ `sub` on both axes at scale.** Comparative advantage (role-specific costs) is
+   not the driver; flat substitution pressure diversifies at least as well and is more stable
+   over the longer run. This is the opposite of what a "specialize into your cheap verb" story
+   predicts, and is itself evidence that the agents are not using cost structure to differentiate.
+
+## Decision: stop, HALT stays
+
+**Stopped after seed 42** (3 of 9 runs). Rationale: the within-seed pattern is monotone and
+internally consistent (entropy climbs, JSD plateaus far under floor), the mechanism dominates
+RNG, and it corroborates the Stage 2 direction at scale. A second/third seed would refine the
+variance estimate but is very unlikely to flip a 0.185 → 0.25 JSD verdict. Compute (~36 h for
+the remaining 6 runs) was judged not worth that marginal rigor.
+
+**Caveat:** this is a single seed at scale. ADR 0009 records the verdict with that explicit
+limitation; seeds 38/7 were not run.
+
+The action-economy lever is **necessary-ish but not sufficient**: it moves verb *diversity*
+(refuting "only identity-independent structure, nothing the agent chooses, can move Gate 3")
+but does not unlock cross-agent *specialization* (Gate 9 JSD — ADR 0007's actual target). The
+ADR 0008 HALT stays in force. See `docs/adr/0009-action-economy-stage3-read.md`.


### PR DESCRIPTION
## Summary

Records the **Stage 3** live A/B from the PR #45 action-economy runbook and writes **ADR 0009**. Stage 3 tests the ADR 0008 re-diagnosis ("verb monoculture is structural; only an action-economy change can move it") against its real target: **Gate 9 cross-agent verb divergence**.

- `docs/adr/0009-action-economy-stage3-read.md` — the measurement-record ADR + HALT decision.
- `docs/economy-stage3-findings.md` — operator findings note (tables, scale comparison, read).

No code changes.

## Background / Motivation

ADR 0008 halted ADR 0007 Phase 1 and re-diagnosed the Gate-3 verb monoculture as *structural* — unmovable by identity, only by the action economy. PR #45 built the feature-flagged economy spike to test that falsifiably; #46 tuned the knobs (Stage 0/1). Stage 2 (200t) showed the chosen verb stream does shift off `contribute`. Stage 3 asks the question that actually matters for "workshop → civilization": does changing the economy make agents **specialize into distinct verb profiles** (Gate 9 JSD ≥ 0.25), or do they just co-drift?

## What was run

`MICROVERSE_ECONOMY={0,sub,flat} python -m microverse.run --ticks 3000 --tempo 0 --seed 42`, model `gemma4:26b`, measured with `spike_workshop_measure.py` Gate 9 on the **chosen** (`parsed_verb`) stream. ~5–6 h/run.

| mode | chosen contribute | entropy_norm | jsd_norm | econ_sub | cxe | Gate 9 |
|---|---:|---:|---:|---:|---:|:--:|
| `0` | 88.1% | 0.274 | 0.017 | 0.000 | 0.000 | FAIL |
| `sub` | 77.3% | 0.409 | 0.109 | 0.204 | 0.078 | FAIL |
| `flat` | 66.9% | 0.574 | **0.185** | 0.157 | 0.030 | FAIL |

PASS = chosen `entropy_norm ≥ 0.35` AND `jsd_norm ≥ 0.25`.

## Design & Reasoning Notes

- **The lever works on diversity, fails on specialization.** Both lever modes clear the entropy floor and cut the contribute share, via genuine model choice (`cxe ≤ 0.078`, not executor forcing) — so the monoculture is *not* immovable. But `jsd_norm` tops out at 0.185 (26% under floor); agents co-drift to the *same* alternatives rather than splitting.
- **Divergence decays with scale.** Stage 2's near-floor `sub` jsd (0.222@200t) was small-sample optimism → 0.109@3000t. The gap widens with more events.
- **Comparative advantage is not the driver:** `flat` (role-agnostic) ≥ `sub` on both axes and is more stable.
- **Verdict:** the action economy is necessary-ish but **not sufficient** for the ADR 0007 thesis. **ADR 0008 HALT stays.**

## Decision & Reasoning: stopping after seed 42

Planned seeds were {42, 38, 7}. Sweep **stopped after seed 42** by operator decision: the within-seed pattern is monotone and internally consistent, the mechanism dominates RNG, and it corroborates Stage 2 at scale, so two more seeds (~36 h) would refine the variance band but not flip a 0.185 → 0.25 verdict that *widens* with scale. ADR 0009 carries the explicit **single-seed-at-scale caveat**; seeds 38/7 deferred.

## Documentation

ADR 0009 + Stage 3 findings note added; both cross-link Stage 2 findings and the reproduction commands. No README/CLAUDE.md changes needed (the spike's flags/tooling were already documented in #45/#46).

## Testing

Docs-only. Full local gate green: `ruff check`, `ruff format --check`, `mypy src/microverse`, `pytest -q -m 'not integration'` (596 passed). `pip-audit`/`uv build` unaffected (no dependency or package changes) and run in CI.

## Post-Merge Recommendations

- **HALT remains in force.** Do not start ADR 0007 Phase 2 on the strength of the economy lever.
- The open question is now **specialization, not diversity**: what force makes agents differentiate *from each other* (vs co-drift). That is a deeper design question than this spike covered — candidate directions: larger roster (JSD across 2 agents is coarse), per-agent differentiated incentives/affordances, or revisiting whether Gate 9 JSD on a 2-resident world is the right civilization proxy.
- If seed-variance rigor is later wanted, the runbook (`docs/economy-stage3-findings.md`) reproduces seeds 38/7 unchanged.