### PR TITLE
test(gate9): validate the divergence metric — halt is real, not a measurement floor

### DIFF
--- a/docs/economy-stage3-findings.md
+++ b/docs/economy-stage3-findings.md
@@ -105,7 +105,8 @@ through the production `gate9` reader (`_diversity_block`) gives a clean respons
 |---|---:|:--:|
 | disjoint specialists (craft \| study) | 1.000 | PASS |
 | distinct specialties, 40% shared `contribute` each | 0.600 | PASS |
-| one agent's **modal** verb relocated off `contribute` | 0.335 | PASS |
+| both keep `contribute` as mode, but disjoint *secondary* mass | 0.400 | PASS |
+| one agent's modal verb relocated off `contribute` | 0.335 | PASS |
 | both keep `contribute` as mode, one grows a long diverse tail | 0.212 | fail |
 | **real `flat-s42` (co-drift)** | 0.185 | fail |
 | identical agents | 0.000 | fail (correct) |
@@ -116,12 +117,14 @@ calibration is on the same code path as the gate. Two takeaways:
 1. **The ruler is sound.** Gate 9 is comfortably satisfiable on two agents (jsd up to 1.0) and
    correctly scores identical agents at 0. The halt is a behavioral finding, not a measurement
    artifact.
-2. **Sharper diagnosis than "co-drift."** The binding constraint is *shared mass on the dominant
-   verb*. The real `flat-s42` agents are not symmetric: Cy stays ~93% `contribute` while Aki
-   diversified to ~51% `contribute` + a large speak/rest/study tail. Aki moved a lot — but its
-   **plurality is still `contribute`**, so the two agents overlap there and JSD caps at 0.185.
-   The synthetic contrast is decisive: growing a tail while the mode stays `contribute` fails
-   (0.212), but relocating a single agent's **modal** verb off `contribute` passes (0.335).
-   **Gate 9 demands modal-verb relocation; the Stage 3 lever only thinned the tail.** That is the
-   concrete, falsifiable target for any next intervention: move an agent's *primary* verb off the
-   shared attractor, not merely spread its tail.
+2. **Sharper diagnosis than "co-drift."** Gate 9 compares the agents' *full* verb distributions;
+   it passes when they put **different mass on different verbs** and fails when they cluster near
+   the same corner. The real `flat-s42` agents are not symmetric — Cy stays ~93% `contribute`
+   while Aki diversified to ~51% `contribute` + a large speak/rest/study tail — but both keep
+   their plurality on `contribute` *and* their tails overlap, so JSD caps at 0.185. The synthetic
+   contrast isolates the lever's gap: growing a tail while staying clustered near `contribute`
+   fails (0.212), whereas divergence passes via either route — relocating an agent's modal verb
+   off `contribute` (0.335) **or** keeping `contribute` modal for both but concentrating disjoint
+   *secondary* mass (0.400). The Stage 3 lever did neither; it only thinned one agent's tail.
+   The concrete, falsifiable target for any next intervention: make the two agents' distributions
+   *diverge* (different verbs carrying their mass), not merely spread a shared one.

--- a/docs/economy-stage3-findings.md
+++ b/docs/economy-stage3-findings.md
@@ -125,6 +125,7 @@ calibration is on the same code path as the gate. Two takeaways:
    contrast isolates the lever's gap: growing a tail while staying clustered near `contribute`
    fails (0.212), whereas divergence passes via either route — relocating an agent's modal verb
    off `contribute` (0.335) **or** keeping `contribute` modal for both but concentrating disjoint
-   *secondary* mass (0.400). The Stage 3 lever did neither; it only thinned one agent's tail.
+   *secondary* mass (0.400). The Stage 3 lever did neither; it only grew an overlapping tail
+   for one agent.
    The concrete, falsifiable target for any next intervention: make the two agents' distributions
    *diverge* (different verbs carrying their mass), not merely spread a shared one.

--- a/docs/economy-stage3-findings.md
+++ b/docs/economy-stage3-findings.md
@@ -93,3 +93,35 @@ The action-economy lever is **necessary-ish but not sufficient**: it moves verb 
 (refuting "nothing the agent chooses can move Gate 3") but does not unlock cross-agent
 *specialization* (Gate 9 JSD — ADR 0007's actual target). The ADR 0008 HALT stays in force. See
 `docs/adr/0009-action-economy-stage3-read.md`.
+
+## Metric validation (ADR 0009 follow-up)
+
+Before spending more compute, we checked whether the Stage 3 failure is real or just a metric
+that a 2-resident world cannot satisfy. It is real. Feeding synthetic per-agent distributions
+through the production `gate9` reader (`_diversity_block`) gives a clean response curve
+(`tests/test_gate9_verb_diversity.py`):
+
+| 2-agent scenario | chosen jsd_norm | Gate 9 |
+|---|---:|:--:|
+| disjoint specialists (craft \| study) | 1.000 | PASS |
+| distinct specialties, 40% shared `contribute` each | 0.600 | PASS |
+| one agent's **modal** verb relocated off `contribute` | 0.335 | PASS |
+| both keep `contribute` as mode, one grows a long diverse tail | 0.212 | fail |
+| **real `flat-s42` (co-drift)** | 0.185 | fail |
+| identical agents | 0.000 | fail (correct) |
+
+The harness reproduces the live `flat-s42` read (entropy 0.574 / jsd 0.185) exactly, so the
+calibration is on the same code path as the gate. Two takeaways:
+
+1. **The ruler is sound.** Gate 9 is comfortably satisfiable on two agents (jsd up to 1.0) and
+   correctly scores identical agents at 0. The halt is a behavioral finding, not a measurement
+   artifact.
+2. **Sharper diagnosis than "co-drift."** The binding constraint is *shared mass on the dominant
+   verb*. The real `flat-s42` agents are not symmetric: Cy stays ~93% `contribute` while Aki
+   diversified to ~51% `contribute` + a large speak/rest/study tail. Aki moved a lot — but its
+   **plurality is still `contribute`**, so the two agents overlap there and JSD caps at 0.185.
+   The synthetic contrast is decisive: growing a tail while the mode stays `contribute` fails
+   (0.212), but relocating a single agent's **modal** verb off `contribute` passes (0.335).
+   **Gate 9 demands modal-verb relocation; the Stage 3 lever only thinned the tail.** That is the
+   concrete, falsifiable target for any next intervention: move an agent's *primary* verb off the
+   shared attractor, not merely spread its tail.

--- a/tests/test_gate9_verb_diversity.py
+++ b/tests/test_gate9_verb_diversity.py
@@ -192,8 +192,10 @@ def _dist_rows(by_agent: dict[str, dict[str, int]]) -> list[tuple[str, str, dict
 def test_gate9_real_stage3_codrift_flat_s42_fails():
     # The actual seed-42 `flat` chosen distribution (docs/economy-stage3-findings.md).
     # Cy is ~93% contribute; Aki diversified to ~51% contribute + a speak/rest/study
-    # tail. Society entropy clears its floor, but because BOTH agents keep contribute
-    # as their plurality the cross-agent JSD is capped well under 0.25 -> Gate 9 fails.
+    # tail. Society entropy clears its floor, but because both agents keep contribute
+    # as their plurality AND their tails overlap (not disjoint — cf. the
+    # disjoint-secondary test below, which PASSES on a shared plurality) the
+    # cross-agent JSD is capped well under 0.25 -> Gate 9 fails.
     # This is the metric reproducing the live read, not a synthetic toy.
     rows = _dist_rows(
         {

--- a/tests/test_gate9_verb_diversity.py
+++ b/tests/test_gate9_verb_diversity.py
@@ -181,11 +181,12 @@ def test_gate9_economy_substitution_rate_is_economy_only():
 def _dist_rows(by_agent: dict[str, dict[str, int]]) -> list[tuple[str, str, dict]]:
     """Expand {agent: {verb: count}} into free-choice rows (empty payload =>
     chosen stream == executed stream, which is what `pass` reads)."""
-    rows: list[tuple[str, str, dict]] = []
-    for agent, dist in by_agent.items():
-        for verb, count in dist.items():
-            rows += [(agent, verb, {}) for _ in range(count)]
-    return rows
+    return [
+        (agent, verb, {})
+        for agent, dist in by_agent.items()
+        for verb, count in dist.items()
+        for _ in range(count)
+    ]
 
 
 def test_gate9_real_stage3_codrift_flat_s42_fails():
@@ -220,7 +221,7 @@ def test_gate9_shared_modal_verb_caps_divergence_even_with_a_long_tail():
     )
     g = swm.gate9_verb_diversity(_events_db(rows))
     ch = g["chosen"]
-    assert ch["society_entropy_norm"] >= 0.35  # entropy floor is cleared...
+    assert ch["society_entropy_norm"] == pytest.approx(0.4633, abs=1e-3)  # clears 0.35...
     assert ch["jsd_norm"] == pytest.approx(0.2122, abs=1e-3)  # ...but JSD is not
     assert g["pass"] is False
 
@@ -229,9 +230,9 @@ def test_gate9_relocating_one_agents_modal_verb_passes():
     # Diagnostic half 2: identical heavy `contribute` overlap, but now Aki's MODE
     # is `craft` (it still contributes, just not as its plurality) while Cy stays
     # contribute-dominant. Moving a single agent's modal verb off the shared
-    # attractor lifts JSD over the floor -> Gate 9 PASSES. So the gate demands
-    # modal-verb relocation, not mere tail diversification. The Stage 3 lever did
-    # the latter, never the former.
+    # attractor lifts JSD over the floor -> Gate 9 PASSES. Modal relocation is ONE
+    # sufficient route to divergence (see the disjoint-secondary test below for
+    # another); the Stage 3 lever achieved neither, only tail diversification.
     rows = _dist_rows(
         {
             "Aki": {"craft": 500, "contribute": 300, "speak": 200},
@@ -240,7 +241,28 @@ def test_gate9_relocating_one_agents_modal_verb_passes():
     )
     g = swm.gate9_verb_diversity(_events_db(rows))
     ch = g["chosen"]
+    assert ch["society_entropy_norm"] == pytest.approx(0.5566, abs=1e-3)
     assert ch["jsd_norm"] == pytest.approx(0.3351, abs=1e-3)  # clears 0.25
+    assert g["pass"] is True
+
+
+def test_gate9_shared_modal_verb_but_disjoint_secondary_mass_passes():
+    # Counter to any "the gate requires moving the modal verb" reading: Gate 9
+    # inspects the FULL distributions, not the mode. Both agents keep `contribute`
+    # as their plurality (60% each), but their remaining 40% is on DISJOINT verbs
+    # (craft vs study). The distributions diverge enough to clear the floor ->
+    # PASS, without either agent relocating its modal verb. Divergence, not modal
+    # relocation specifically, is what the metric demands.
+    rows = _dist_rows(
+        {
+            "Aki": {"contribute": 600, "craft": 400},
+            "Cy": {"contribute": 600, "study": 400},
+        }
+    )
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    ch = g["chosen"]
+    assert ch["society_entropy_norm"] == pytest.approx(0.5304, abs=1e-3)
+    assert ch["jsd_norm"] == pytest.approx(0.4, abs=1e-3)  # clears 0.25
     assert g["pass"] is True
 
 
@@ -254,5 +276,6 @@ def test_gate9_partial_specialization_with_shared_contribute_passes():
         }
     )
     g = swm.gate9_verb_diversity(_events_db(rows))
+    assert g["chosen"]["society_entropy_norm"] == pytest.approx(0.6077, abs=1e-3)
     assert g["chosen"]["jsd_norm"] == pytest.approx(0.6, abs=1e-3)
     assert g["pass"] is True

--- a/tests/test_gate9_verb_diversity.py
+++ b/tests/test_gate9_verb_diversity.py
@@ -167,3 +167,92 @@ def test_gate9_economy_substitution_rate_is_economy_only():
     assert g["substitution_rate"] == pytest.approx(20 / 30, abs=1e-4)
     # Economy-only rate counts just the flagged ones.
     assert g["economy_substitution_rate"] == pytest.approx(10 / 30, abs=1e-4)
+
+
+# --- metric-validity calibration (ADR 0009 follow-up) -----------------------
+#
+# Stage 3 halted on a co-drift read (no mode cleared the JSD floor). Before
+# spending more compute, these tests pin WHAT the 2-agent gate actually demands,
+# so the halt is read as a real behavioral finding and not a measurement floor
+# that 2 agents cannot reach. The disjoint-specialists PASS above already shows
+# the ceiling is 1.0; these characterize the partial-credit middle.
+
+
+def _dist_rows(by_agent: dict[str, dict[str, int]]) -> list[tuple[str, str, dict]]:
+    """Expand {agent: {verb: count}} into free-choice rows (empty payload =>
+    chosen stream == executed stream, which is what `pass` reads)."""
+    rows: list[tuple[str, str, dict]] = []
+    for agent, dist in by_agent.items():
+        for verb, count in dist.items():
+            rows += [(agent, verb, {}) for _ in range(count)]
+    return rows
+
+
+def test_gate9_real_stage3_codrift_flat_s42_fails():
+    # The actual seed-42 `flat` chosen distribution (docs/economy-stage3-findings.md).
+    # Cy is ~93% contribute; Aki diversified to ~51% contribute + a speak/rest/study
+    # tail. Society entropy clears its floor, but because BOTH agents keep contribute
+    # as their plurality the cross-agent JSD is capped well under 0.25 -> Gate 9 fails.
+    # This is the metric reproducing the live read, not a synthetic toy.
+    rows = _dist_rows(
+        {
+            "Aki": {"speak": 415, "craft": 33, "study": 149, "rest": 230, "contribute": 858},
+            "Cy": {"speak": 19, "craft": 20, "study": 21, "rest": 17, "contribute": 968},
+        }
+    )
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    ch = g["chosen"]
+    assert ch["society_entropy_norm"] == pytest.approx(0.5738, abs=1e-3)  # clears 0.35
+    assert ch["jsd_norm"] == pytest.approx(0.1846, abs=1e-3)  # misses 0.25
+    assert g["pass"] is False
+
+
+def test_gate9_shared_modal_verb_caps_divergence_even_with_a_long_tail():
+    # Diagnostic half 1: both agents keep `contribute` as their MODE; Aki grows a
+    # large, diverse tail (speak/rest/study). Society entropy rises but the shared
+    # dominant verb pins cross-agent JSD below the floor. Growing a tail is not
+    # enough.
+    rows = _dist_rows(
+        {
+            "Aki": {"contribute": 520, "speak": 260, "rest": 140, "study": 80},
+            "Cy": {"contribute": 950, "speak": 50},
+        }
+    )
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    ch = g["chosen"]
+    assert ch["society_entropy_norm"] >= 0.35  # entropy floor is cleared...
+    assert ch["jsd_norm"] == pytest.approx(0.2122, abs=1e-3)  # ...but JSD is not
+    assert g["pass"] is False
+
+
+def test_gate9_relocating_one_agents_modal_verb_passes():
+    # Diagnostic half 2: identical heavy `contribute` overlap, but now Aki's MODE
+    # is `craft` (it still contributes, just not as its plurality) while Cy stays
+    # contribute-dominant. Moving a single agent's modal verb off the shared
+    # attractor lifts JSD over the floor -> Gate 9 PASSES. So the gate demands
+    # modal-verb relocation, not mere tail diversification. The Stage 3 lever did
+    # the latter, never the former.
+    rows = _dist_rows(
+        {
+            "Aki": {"craft": 500, "contribute": 300, "speak": 200},
+            "Cy": {"contribute": 800, "speak": 200},
+        }
+    )
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    ch = g["chosen"]
+    assert ch["jsd_norm"] == pytest.approx(0.3351, abs=1e-3)  # clears 0.25
+    assert g["pass"] is True
+
+
+def test_gate9_partial_specialization_with_shared_contribute_passes():
+    # The floor is not punishingly strict: even with 40% of EACH agent's mass on a
+    # shared `contribute`, distinct specialties (craft vs study) clear both floors.
+    rows = _dist_rows(
+        {
+            "Aki": {"craft": 600, "contribute": 400},
+            "Cy": {"study": 600, "contribute": 400},
+        }
+    )
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    assert g["chosen"]["jsd_norm"] == pytest.approx(0.6, abs=1e-3)
+    assert g["pass"] is True


### PR DESCRIPTION
## Summary

ADR 0009 (just merged) left the ADR 0007 arc **twice-halted** on the same failure: agents change behavior but converge rather than differentiate. Before committing more compute, this PR answers the cheap, decisive prerequisite question — **can the Gate 9 cross-agent divergence metric even detect specialization on a 2-resident world?** — by calibrating the production reader against synthetic traces.

Adds 5 characterization tests to `tests/test_gate9_verb_diversity.py` and a "Metric validation" section to `docs/economy-stage3-findings.md`. **No production code changed.**

## Background / Motivation

If 2-agent JSD ≥ 0.25 were unreachable in practice, the Stage 3 halt would be a measurement artifact, not a behavioral finding — and the whole "what's next" decision would change. So validate the ruler before building on it.

## Findings

Feeding synthetic per-agent distributions through the production `_diversity_block` (same code path as the live gate):

| 2-agent scenario | chosen jsd_norm | Gate 9 |
|---|---:|:--:|
| disjoint specialists (craft \| study) | 1.000 | PASS |
| distinct specialties, 40% shared `contribute` each | 0.600 | PASS |
| both `contribute`-modal, disjoint **secondary** mass | 0.400 | PASS |
| one agent's modal verb relocated off `contribute` | 0.335 | PASS |
| both keep `contribute` as mode, one grows a long tail | 0.212 | fail |
| **real `flat-s42` (co-drift)** | 0.185 | fail |
| identical agents | 0.000 | fail (correct) |

1. **The ruler is sound.** Gate 9 is comfortably satisfiable on two agents (up to 1.0) and scores identical agents at 0. The Stage 3 halt is a **real behavioral finding**, not a measurement floor. (The harness reproduces the live `flat-s42` read — entropy 0.574 / jsd 0.185 — exactly.)
2. **Sharper diagnosis than "co-drift."** Gate 9 compares the agents' *full* distributions: it passes when they put **different mass on different verbs** and fails when they cluster near the same corner. The real `flat-s42` agents are asymmetric (Cy ~93% `contribute`; Aki ~51% + a big tail) yet fail because both keep their plurality on `contribute` *and* their tails overlap. The contrast isolates the lever's gap: staying clustered near `contribute` fails (0.212), while divergence passes via **either** route — relocating an agent's modal verb (0.335) **or** keeping `contribute` modal for both but concentrating disjoint *secondary* mass (0.400). The Stage 3 lever did neither.

**→ The target for any next intervention is distributional divergence (different verbs carrying the mass), not merely diversifying a shared one.**

## Design & Reasoning Notes

- Tests use empty-payload rows so the chosen stream == executed stream (what `pass` reads), matching the existing `test_gate9_disjoint_specialists_pass` style.
- The `flat-s42` fixture uses the *actual* per-agent counts pulled from the live run, so it is a regression anchor on real data, not a toy.
- The disjoint-secondary-mass test exists specifically to pin that modal relocation is *one sufficient route*, not a requirement (the metric inspects full distributions) — guarding against that overclaim creeping back in.
- Characterization tests of existing correct behavior (no red phase): they pin the metric's response curve so a future change to the JSD/normalization can't silently move the floor's meaning.

## Documentation

`docs/economy-stage3-findings.md` gains a "Metric validation (ADR 0009 follow-up)" section with the table + diagnosis. No ADR change (0009 is a merged record; this is a follow-up note on the same read).

## Testing

`uv run pytest -q -m 'not integration'` → 601 passed (+5). Full local gate green: ruff check, ruff format --check, mypy, pytest. `pip-audit`/`uv build` unaffected (no deps/package change) and run in CI.

## Post-Merge Recommendations

- The "what's next" decision is now de-risked. If the next move is to **attack differentiation**, the success criterion is sharp and pre-registerable: an intervention must make the two agents' verb distributions *diverge* (JSD ≥ 0.25 across seeds) — i.e. put their mass on *different* verbs, whether by relocating a modal verb or by disjoint secondary specialties — not merely raise one agent's tail entropy.
- Candidate mechanisms to test against that bar: per-**agent** (not per-role) asymmetric cost tables; a larger/heterogeneous roster (2-agent JSD is coarse); or scarcity that makes the dominant verb individually unaffordable for one agent.