### PR TITLE
feat(economy): adv mode — honest per-agent scarcity hint (ADR 0009 follow-up)

### DIFF
--- a/docs/economy-stage4-runbook.md
+++ b/docs/economy-stage4-runbook.md
@@ -55,6 +55,14 @@ reuse the archived Stage-3 `sub`/`0` reads as the comparator: `gemma4:26b` sampl
 unseeded, so even a byte-identical harness produces different draws — the only causally
 clean `adv`-vs-`sub` contrast is paired in the same sweep.
 
+`flat` is in the A/B matrix above but is **intentionally omitted from this run**: the
+hint fix is inert under `flat` (it removes specialties, so there is nothing to name —
+proven by `test_cheapest_affordable_perceived_under_flat_table_is_role_symmetric`), so
+`flat` is identical to its Stage-3 read and adds no information about the `adv`
+intervention. Reuse the Stage-3 `flat` numbers (ADR 0009) only as a static reference for
+"specialty removed"; do not treat it as a paired comparator. Add it back to the loop
+only if a reviewer wants a fresh `flat` baseline at the same wall-clock as `adv`.
+
 ```bash
 for SEED in 42 38 7; do
   for M in 0 sub adv; do

--- a/docs/economy-stage4-runbook.md
+++ b/docs/economy-stage4-runbook.md
@@ -1,0 +1,109 @@
+# Action-economy Stage 4 runbook — honest per-agent scarcity hint (`adv` mode)
+
+Operator handoff for the **deferred** Stage 4 live A/B that tests the ADR 0009
+follow-up intervention. The ADR 0008/0009 HALT stays in force until a PASS read.
+This PR ships the mechanism (`adv` mode) + offline tests only; the live run below
+is a separate scheduled compute job (~9 runs × 5-6 h on `gemma4:26b`).
+
+## Why
+
+Stage 3 (ADR 0009) found the action economy breaks the `contribute` monoculture
+(society entropy 0.27 → 0.57) but **fails Gate 9 cross-agent specialization**:
+`jsd_norm` topped out at 0.185 (< 0.25 floor). Root cause (verified in code): Gate 9
+reads the **chosen** (`parsed_verb`, model-pick) stream, and the only channel the
+economy has into that stream is the per-agent `energy_hint`. That hint named
+`cheapest_affordable_productive`, which excludes the payload verbs `{contribute,
+craft}` — so the **artisan**, whose cheap specialty *is* `craft`, was told to fall
+back to `study` (the **scholar's** specialty). Both agents' scarcity hints pointed
+at the same payload-free escape → co-drift, not differentiation.
+
+`adv` mode fixes the hint: `EnergyLedger.cheapest_affordable_perceived` names the
+agent's **true** cheapest affordable verb including its payload specialty (excludes
+only `rest`), while the blind executor's substitution target stays payload-free
+(it cannot fabricate a `craft` artifact). Intended effect: artisan hint → "craft
+comes easily", scholar hint → "study comes easily", pushing the chosen
+distributions apart.
+
+### This is a correctness fix, not prompt-tuning (ADR 0008 constraint)
+
+No persona template (`prompts/persona_*.j2`) is touched; the hint string format and
+firing condition are unchanged. Only *which verb the existing scarcity signal names*
+changes — from a verb the agent cannot cheaply do to its true cheapest affordable
+one, computed mechanically from the cost table. It is symmetric across agents and
+**inert under the `flat` control** (which removes specialties, so there is no
+specialty to name). The artisan getting `craft` is emergent from `craft` costing 6
+for it, not an authored preference. It also makes code match the `economy.py`
+comment that already claimed the artisan "diversifies through the perception channel
+(energy_hint lets the model choose craft)".
+
+## A/B matrix
+
+| mode   | scene_gate | substitute | hint selector                     | specialty | honest hint |
+|--------|-----------|-----------|-----------------------------------|-----------|-------------|
+| `0`    | no        | no        | —                                 | n/a       | no          |
+| `flat` | yes       | yes       | (inert — no specialty)            | removed   | n/a         |
+| `sub`  | no        | yes       | `cheapest_affordable_productive`  | present   | no          |
+| `adv`  | no        | yes       | `cheapest_affordable_perceived`   | present   | **yes**     |
+
+`adv` vs `sub` isolates the hint fix as the single changed variable; `adv` vs `flat`
+isolates specialization given the honest hint; `adv` vs `0` is the total economy effect.
+
+## Run (deferred — separate compute job)
+
+Run `{0, sub, adv}` × seeds `{42, 38, 7}` × 3000 ticks **in the same sweep**. Do NOT
+reuse the archived Stage-3 `sub`/`0` reads as the comparator: `gemma4:26b` sampling is
+unseeded, so even a byte-identical harness produces different draws — the only causally
+clean `adv`-vs-`sub` contrast is paired in the same sweep.
+
+```bash
+for SEED in 42 38 7; do
+  for M in 0 sub adv; do
+    TAG="${M}-s${SEED}"
+    MICROVERSE_ECONOMY=$M \
+    MICROVERSE_DATA=data/econ-stage4-$TAG \
+    MICROVERSE_HARVEST=harvest/econ-stage4-$TAG \
+      uv run python -m microverse.run --ticks 3000 --tempo 0 --seed $SEED
+    uv run python scripts/spike_workshop_measure.py \
+      --data data/econ-stage4-$TAG --harvest harvest/econ-stage4-$TAG
+  done
+done
+```
+
+## Read & acceptance
+
+**Primary bar (Gate 9, chosen stream):** `jsd_norm ≥ 0.25` AND `entropy_norm ≥ 0.35`
+across all three seeds (Stage-3 `sub` topped at 0.185). Pre-register before reading:
+*pass iff Aki's modal chosen verb relocates to `craft` OR Aki/Cy secondary mass goes
+disjoint* (per the Gate 9 calibration tests in `tests/test_gate9_verb_diversity.py`).
+
+**Quality gate (JSD alone is insufficient).** Also record, per run, so a
+`parsed_verb="craft"` cannot inflate chosen JSD without real work product:
+- Aki chosen-craft share and executed-craft share,
+- `artisan_empty_craft_coerced` count (hollow crafts the guard rewrote),
+- parse-fallback rate,
+- `novelty_energy_hint_conflict` count (R4 — how often the two hints opposed; see below).
+
+## Risks (the offline fix cannot resolve these — live run decides)
+
+- **R1 — model ignores the soft hint.** `gemma4:26b` may not shift its chosen verb.
+  Crossing 0.25 needs Aki's *chosen* mass to move to `craft` (~hundreds of ticks);
+  Cy → study alone is insufficient.
+- **R2 — free (non-scene) craft (de-risked offline).** The mocked-chat go/no-go
+  (`tests/test_run_economy.py::test_adv_model_chosen_craft_survives_to_chosen_stream_unsubstituted`)
+  confirms a model-chosen `craft` under `adv` lands in the chosen stream and executes
+  un-substituted. The channel is mechanically open.
+- **R3 — chosen/executed inconsistency.** Hint says craft but the model picks an
+  unaffordable verb, executor rewrites to study, reinforcing co-drift. `craft` (cost 6)
+  is cheaply affordable, so this should be rare; the per-event override rate bounds it.
+- **R4 — novelty hint FIGHTS the energy hint (instrumented).** `_compute_novelty_hint`
+  (`dominance_threshold=0.50`) steers an agent away from whatever verb dominates its
+  recent mix. The moment Aki specializes into `craft`, novelty pushes it back off, and
+  the diversity lever (30% substitution of a dominant non-contribute verb) rewrites
+  executed craft. The run loop now counts `novelty_energy_hint_conflict` per tick (the
+  honest energy hint naming the very verb novelty discourages). If that count is high
+  in the live read, a follow-up may need to suppress the novelty hint for an agent's
+  *own* cheap specialty under `adv` — a known limitation, recorded here rather than
+  silently patched.
+
+After the live read, write the ADR 0009 follow-up with the per-seed pass/fail table and
+the decision (PASS unblocks Phase 2; HALT stays otherwise).

--- a/scripts/replay_economy.py
+++ b/scripts/replay_economy.py
@@ -197,8 +197,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument(
         "--mode",
         default="1",
-        choices=("1", "flat", "sub", "throttle"),
-        help="economy cost-table mode (role-advantage for all but 'flat')",
+        choices=("1", "flat", "sub", "throttle", "adv"),
+        help="economy cost-table mode (role-advantage for all but 'flat'); 'adv' is "
+        "identical to 'sub' offline — it differs only in the live energy_hint selector",
     )
     p.add_argument("--ticks", type=int, default=2000, help="Stage 1 tick budget")
     p.add_argument("--seed", type=int, default=42, help="Stage 1 RNG seed")

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -234,11 +234,17 @@ SCENE_MIN_PEERS: int = 1
 # The full set of recognized modes. An unrecognized value (e.g. a typo) would
 # otherwise build a ledger with neither gate nor substitution — a silent,
 # unlabeled experiment arm — so run() validates against this set and fails fast.
-VALID_ECONOMY_MODES: frozenset[str] = frozenset({"0", "1", "flat", "throttle", "sub"})
+# ``adv`` (advantage-perception, ADR 0009 follow-up) == ``sub`` (substitution +
+# hint, no scene gate) EXCEPT the energy_hint names the agent's TRUE cheapest
+# affordable verb including its payload specialty (craft), so each role is nudged
+# toward its OWN advantage instead of the shared payload-free escape that caused
+# co-drift. The selector differs (run._compute_energy_hint dispatches on adv);
+# the cost table and gates are identical to ``sub``.
+VALID_ECONOMY_MODES: frozenset[str] = frozenset({"0", "1", "flat", "throttle", "sub", "adv"})
 ECONOMY_MODE: str = os.environ.get("MICROVERSE_ECONOMY", "0")
 ECONOMY_ENABLED: bool = ECONOMY_MODE != "0"
 _ECONOMY_SCENE_GATE: bool = ECONOMY_MODE in ("1", "flat", "throttle")
-_ECONOMY_SUBSTITUTE: bool = ECONOMY_MODE in ("1", "flat", "sub")
+_ECONOMY_SUBSTITUTE: bool = ECONOMY_MODE in ("1", "flat", "sub", "adv")
 
 # Finite stamina pool. Regen sits between the cheap specialty (~6) and the
 # dear contribute (~22) so a role can sustain its specialty indefinitely but

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -307,7 +307,9 @@ def _compute_energy_hint(energy: EnergyLedger | None, agent: Agent) -> str:
     ]
     if not unaffordable:
         return ""
-    cheapest = _energy_hint_verb(energy, agent)
+    # Preconditions already checked above; dispatch the selector directly rather
+    # than re-running them through _energy_hint_verb (CodeRabbit/Gemini review).
+    cheapest = _select_easy_verb(energy, agent)
     out_of_reach = ", ".join(unaffordable)
     if cheapest:
         return (
@@ -322,19 +324,29 @@ def _compute_energy_hint(energy: EnergyLedger | None, agent: Agent) -> str:
 _ENERGY_HINT_PRODUCTIVE = ("speak", "craft", "study", "travel", "contribute")
 
 
-def _energy_hint_verb(energy: EnergyLedger | None, agent: Agent) -> str | None:
-    """The verb :func:`_compute_energy_hint` names as "comes easily" (mode-aware),
-    or ``None`` when the economy is off, reserves are ample, or even the cheapest
-    productive verb is unaffordable (then the hint shows the "rest before ..."
-    message and names no easy verb). Exposed so the run loop can detect the
-    novelty/energy hint conflict (ADR 0009 R4) without re-parsing the hint string.
+def _select_easy_verb(energy: EnergyLedger, agent: Agent) -> str | None:
+    """The mode-aware "comes easily" verb, assuming the caller has already
+    confirmed the hint fires (energy present, substitution mode, some verb out of
+    reach). Single source of truth for the selector so the hint text and the R4
+    conflict counter never disagree.
 
     ``adv`` names the agent's TRUE cheapest affordable verb including its payload
     specialty (craft), so each role is nudged toward its own advantage.
     ``sub``/``1``/``flat`` keep the legacy selector (excludes the payload verbs)
     so their prior reads stay byte-reproducible for the A/B. The executor's
-    substitution target is unchanged in every mode (still payload-free).
-    """
+    substitution target is unchanged in every mode (still payload-free)."""
+    if config.ECONOMY_MODE == "adv":
+        return energy.cheapest_affordable_perceived(agent.name, agent.role)
+    return energy.cheapest_affordable_productive(agent.name, agent.role)
+
+
+def _energy_hint_verb(energy: EnergyLedger | None, agent: Agent) -> str | None:
+    """Gated wrapper of :func:`_select_easy_verb`: the verb
+    :func:`_compute_energy_hint` names as "comes easily", or ``None`` when the
+    economy is off, reserves are ample, or even the cheapest productive verb is
+    unaffordable (then the hint shows the "rest before ..." message and names no
+    easy verb). Exposed so the run loop can detect the novelty/energy hint
+    conflict (ADR 0009 R4) without re-parsing the hint string."""
     if energy is None or not config._ECONOMY_SUBSTITUTE:
         return None
     unaffordable = any(
@@ -342,9 +354,7 @@ def _energy_hint_verb(energy: EnergyLedger | None, agent: Agent) -> str | None:
     )
     if not unaffordable:
         return None
-    if config.ECONOMY_MODE == "adv":
-        return energy.cheapest_affordable_perceived(agent.name, agent.role)
-    return energy.cheapest_affordable_productive(agent.name, agent.role)
+    return _select_easy_verb(energy, agent)
 
 
 def _hints_conflict(energy_easy_verb: str | None, novelty_dominant_verb: str) -> bool:

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -306,7 +306,15 @@ def _compute_energy_hint(energy: EnergyLedger | None, agent: Agent) -> str:
     unaffordable = [v for v in productive if not energy.can_afford(agent.name, agent.role, v)]
     if not unaffordable:
         return ""
-    cheapest = energy.cheapest_affordable_productive(agent.name, agent.role)
+    # ``adv`` (ADR 0009 follow-up): name the agent's TRUE cheapest affordable
+    # verb including its payload specialty (craft), so each role is nudged toward
+    # its own advantage. ``sub``/``1``/``flat`` keep the legacy selector (excludes
+    # payload verbs) so their prior reads stay byte-reproducible for the A/B. The
+    # executor's substitution target is unchanged in every mode (still payload-free).
+    if config.ECONOMY_MODE == "adv":
+        cheapest = energy.cheapest_affordable_perceived(agent.name, agent.role)
+    else:
+        cheapest = energy.cheapest_affordable_productive(agent.name, agent.role)
     out_of_reach = ", ".join(unaffordable)
     if cheapest:
         return (

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -302,19 +302,12 @@ def _compute_energy_hint(energy: EnergyLedger | None, agent: Agent) -> str:
     """
     if energy is None or not config._ECONOMY_SUBSTITUTE:
         return ""
-    productive = ["speak", "craft", "study", "travel", "contribute"]
-    unaffordable = [v for v in productive if not energy.can_afford(agent.name, agent.role, v)]
+    unaffordable = [
+        v for v in _ENERGY_HINT_PRODUCTIVE if not energy.can_afford(agent.name, agent.role, v)
+    ]
     if not unaffordable:
         return ""
-    # ``adv`` (ADR 0009 follow-up): name the agent's TRUE cheapest affordable
-    # verb including its payload specialty (craft), so each role is nudged toward
-    # its own advantage. ``sub``/``1``/``flat`` keep the legacy selector (excludes
-    # payload verbs) so their prior reads stay byte-reproducible for the A/B. The
-    # executor's substitution target is unchanged in every mode (still payload-free).
-    if config.ECONOMY_MODE == "adv":
-        cheapest = energy.cheapest_affordable_perceived(agent.name, agent.role)
-    else:
-        cheapest = energy.cheapest_affordable_productive(agent.name, agent.role)
+    cheapest = _energy_hint_verb(energy, agent)
     out_of_reach = ", ".join(unaffordable)
     if cheapest:
         return (
@@ -322,6 +315,45 @@ def _compute_energy_hint(energy: EnergyLedger | None, agent: Agent) -> str:
             f"but {cheapest} still comes easily."
         )
     return f"Your reserves are spent; rest before attempting {out_of_reach}."
+
+
+# Verbs whose unaffordability triggers the scarcity hint (``rest`` is always free
+# and so never "out of reach"). Shared by the hint text and the named-verb helper.
+_ENERGY_HINT_PRODUCTIVE = ("speak", "craft", "study", "travel", "contribute")
+
+
+def _energy_hint_verb(energy: EnergyLedger | None, agent: Agent) -> str | None:
+    """The verb :func:`_compute_energy_hint` names as "comes easily" (mode-aware),
+    or ``None`` when the economy is off, reserves are ample, or even the cheapest
+    productive verb is unaffordable (then the hint shows the "rest before ..."
+    message and names no easy verb). Exposed so the run loop can detect the
+    novelty/energy hint conflict (ADR 0009 R4) without re-parsing the hint string.
+
+    ``adv`` names the agent's TRUE cheapest affordable verb including its payload
+    specialty (craft), so each role is nudged toward its own advantage.
+    ``sub``/``1``/``flat`` keep the legacy selector (excludes the payload verbs)
+    so their prior reads stay byte-reproducible for the A/B. The executor's
+    substitution target is unchanged in every mode (still payload-free).
+    """
+    if energy is None or not config._ECONOMY_SUBSTITUTE:
+        return None
+    unaffordable = any(
+        not energy.can_afford(agent.name, agent.role, v) for v in _ENERGY_HINT_PRODUCTIVE
+    )
+    if not unaffordable:
+        return None
+    if config.ECONOMY_MODE == "adv":
+        return energy.cheapest_affordable_perceived(agent.name, agent.role)
+    return energy.cheapest_affordable_productive(agent.name, agent.role)
+
+
+def _hints_conflict(energy_easy_verb: str | None, novelty_dominant_verb: str) -> bool:
+    """ADR 0009 R4: the honest ``energy_hint`` nudges toward the agent's cheap
+    specialty while ``novelty_hint`` steers AWAY from whatever verb has come to
+    dominate the recent mix. They contradict when the energy hint names the very
+    verb novelty is discouraging (the now-dominant specialty). ``False`` when no
+    easy verb is named or novelty is inactive (empty dominant verb)."""
+    return bool(energy_easy_verb) and energy_easy_verb == novelty_dominant_verb
 
 
 def _lazy_attach_energy(agent: Agent, energy: EnergyLedger | None) -> None:
@@ -921,6 +953,12 @@ def run(
             novelty_hint, novelty_dominant_verb, novelty_suggested_verb = _compute_novelty_hint(
                 episodic, agent
             )
+            # ADR 0009 R4: count ticks where the honest energy_hint nudges toward
+            # the very verb the novelty hint is steering away from (the agent's
+            # now-dominant specialty). High counts mean the two levers fight, which
+            # would cap chosen-verb specialization; the live Stage-4 read inspects it.
+            if _hints_conflict(_energy_hint_verb(energy, agent), novelty_dominant_verb):
+                metrics.bump("novelty_energy_hint_conflict", agent=agent.name)
             # Path-3: pull the agent's watermark. ``setdefault`` seeds
             # first-encounter to ``time.time()`` so a mid-run Stranger
             # does not see all weather/world events since process

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -963,12 +963,6 @@ def run(
             novelty_hint, novelty_dominant_verb, novelty_suggested_verb = _compute_novelty_hint(
                 episodic, agent
             )
-            # ADR 0009 R4: count ticks where the honest energy_hint nudges toward
-            # the very verb the novelty hint is steering away from (the agent's
-            # now-dominant specialty). High counts mean the two levers fight, which
-            # would cap chosen-verb specialization; the live Stage-4 read inspects it.
-            if _hints_conflict(_energy_hint_verb(energy, agent), novelty_dominant_verb):
-                metrics.bump("novelty_energy_hint_conflict", agent=agent.name)
             # Path-3: pull the agent's watermark. ``setdefault`` seeds
             # first-encounter to ``time.time()`` so a mid-run Stranger
             # does not see all weather/world events since process
@@ -1195,6 +1189,15 @@ def run(
                     time.sleep(sleep_s)
                 continue
 
+            # ADR 0009 R4: count single-action ticks where the honest energy_hint
+            # nudges toward the very verb the novelty hint is steering away from
+            # (the agent's now-dominant specialty). Bumped HERE, on the non-scene
+            # path, because scene turns force energy_hint="" (ADR 0006) — the model
+            # never sees the energy hint in a scene, so the two levers cannot fight
+            # there (CodeRabbit review). High counts mean the levers fight on the
+            # ticks that matter, capping specialization; the Stage-4 read inspects it.
+            if _hints_conflict(_energy_hint_verb(energy, agent), novelty_dominant_verb):
+                metrics.bump("novelty_energy_hint_conflict", agent=agent.name)
             try:
                 action = agent.think(world)
             except Exception:

--- a/src/microverse/world/economy.py
+++ b/src/microverse/world/economy.py
@@ -38,9 +38,14 @@ CostTable = Mapping[str, Mapping[str, float]]
 # unharvestable, yet still counts as productive verb diversity in Gate 9 — i.e.
 # the diagnostic could report improvement without any real work (review). A
 # role whose specialty is a payload verb (the Artisan's ``craft``) therefore
-# diversifies through the perception channel (``energy_hint`` lets the model
-# *choose* craft and author the artifact) and rests when truly drained; the
-# hard executor only ever falls back to payload-free verbs or ``rest``.
+# diversifies through the perception channel: ``energy_hint`` (mode ``adv``, via
+# :meth:`EnergyLedger.cheapest_affordable_perceived`) names ``craft`` so the
+# model can *choose* it and author the artifact, while the hard executor only
+# ever falls back to payload-free verbs or ``rest``. NOTE: the legacy ``sub``
+# hint named :meth:`cheapest_affordable_productive` (which excludes ``craft``),
+# so it pointed the Artisan at the shared payload-free escape (``study`` — the
+# Scholar's specialty) instead of its own ``craft`` — co-drift, not
+# differentiation (ADR 0009). ``adv`` is the corrected, honest-hint arm.
 _PAYLOAD_VERBS = frozenset({"contribute", "craft"})
 
 # Excluded from the *primary* substitution candidates: the payload verbs (above)
@@ -80,7 +85,9 @@ def build_cost_table(mode: str) -> dict[str, dict[str, float]]:
     """Resolve the per-mode cost table.
 
     ``"flat"`` returns the role-agnostic control; every other economy mode
-    (``"1"``, ``"sub"``, ``"throttle"``) uses the role-advantage table.
+    (``"1"``, ``"sub"``, ``"throttle"``, ``"adv"``) uses the role-advantage
+    table. ``"adv"`` shares ``"sub"``'s costs and differs only in the
+    ``energy_hint`` selector (see ``run._compute_energy_hint``).
     """
     from microverse.config import VERB_COST_BY_ROLE
 
@@ -183,6 +190,32 @@ class EnergyLedger:
 
         order = [k.value for k in ActionKind]
         productive = [v for v in order if v not in _SUBSTITUTION_EXCLUDED]
+        affordable = self.affordable_verbs(name, role, productive)
+        if not affordable:
+            return None
+        return min(affordable, key=lambda v: (self.cost(role, v), order.index(v)))
+
+    def cheapest_affordable_perceived(self, name: str, role: str) -> str | None:
+        """The cheapest affordable productive verb to name in the ``energy_hint``
+        (mode ``adv``), or ``None`` if the agent can afford none (then the hint
+        falls back to the "rest before ..." message).
+
+        Unlike :meth:`cheapest_affordable_productive` — the blind EXECUTOR's
+        substitution target, which excludes the payload verbs it cannot
+        fabricate (``contribute``/``craft``) — this is a PERCEPTION signal to a
+        model that, when it *chooses* ``craft``, authors a real artifact. So it
+        excludes only ``rest`` (the idle last resort) and may name a role's
+        payload specialty. This is what lets the Artisan's hint name ``craft``
+        (cost 6) rather than the shared payload-free escape ``study`` (the
+        Scholar's specialty) — the fix for the ADR 0009 co-drift. Ties are
+        broken by ``ActionKind`` declaration order for determinism, identical to
+        the executor selector, so under the flat control (no specialty) both
+        roles resolve to the same verb and the fix is inert.
+        """
+        from microverse.agents.base import ActionKind
+
+        order = [k.value for k in ActionKind]
+        productive = [v for v in order if v != "rest"]
         affordable = self.affordable_verbs(name, role, productive)
         if not affordable:
             return None

--- a/src/microverse/world/economy.py
+++ b/src/microverse/world/economy.py
@@ -54,6 +54,11 @@ _PAYLOAD_VERBS = frozenset({"contribute", "craft"})
 # every constrained tick onto rest.
 _SUBSTITUTION_EXCLUDED = _PAYLOAD_VERBS | {"rest"}
 
+# The energy_hint perception selector (mode ``adv``) excludes ONLY ``rest``: the
+# model authoring a payload verb does real work, so the hint may name a role's
+# payload specialty (the Artisan's ``craft``). See ``cheapest_affordable_perceived``.
+_PERCEIVED_EXCLUDED = frozenset({"rest"})
+
 # Verbs excluded from the flat-control flattening: ``contribute`` keeps its
 # per-role cost (so the scene-initiation throttle is identical across arms) and
 # ``rest`` stays free. Everything else — including ``craft`` — collapses to the
@@ -186,14 +191,7 @@ class EnergyLedger:
         so the realistic targets are ``speak``/``study``/``travel``. Ties are
         broken by ``ActionKind`` declaration order for determinism.
         """
-        from microverse.agents.base import ActionKind
-
-        order = [k.value for k in ActionKind]
-        productive = [v for v in order if v not in _SUBSTITUTION_EXCLUDED]
-        affordable = self.affordable_verbs(name, role, productive)
-        if not affordable:
-            return None
-        return min(affordable, key=lambda v: (self.cost(role, v), order.index(v)))
+        return self._cheapest_affordable(name, role, excluded=_SUBSTITUTION_EXCLUDED)
 
     def cheapest_affordable_perceived(self, name: str, role: str) -> str | None:
         """The cheapest affordable productive verb to name in the ``energy_hint``
@@ -207,16 +205,25 @@ class EnergyLedger:
         excludes only ``rest`` (the idle last resort) and may name a role's
         payload specialty. This is what lets the Artisan's hint name ``craft``
         (cost 6) rather than the shared payload-free escape ``study`` (the
-        Scholar's specialty) — the fix for the ADR 0009 co-drift. Ties are
-        broken by ``ActionKind`` declaration order for determinism, identical to
-        the executor selector, so under the flat control (no specialty) both
-        roles resolve to the same verb and the fix is inert.
+        Scholar's specialty) — the fix for the ADR 0009 co-drift. It shares
+        :meth:`_cheapest_affordable`'s ``ActionKind`` tie-break with the executor
+        selector, so under the flat control (no specialty) both roles resolve to
+        the same verb and the fix is inert.
         """
+        return self._cheapest_affordable(name, role, excluded=_PERCEIVED_EXCLUDED)
+
+    def _cheapest_affordable(self, name: str, role: str, *, excluded: frozenset[str]) -> str | None:
+        """Cheapest affordable verb not in ``excluded``, or ``None`` if none is
+        affordable. Shared body of :meth:`cheapest_affordable_productive` (the
+        executor's payload-free substitution target) and
+        :meth:`cheapest_affordable_perceived` (the hint's perception signal);
+        they differ ONLY in ``excluded``, so the ``ActionKind`` tie-break stays in
+        lock-step (the flat-control symmetry invariant cannot drift)."""
         from microverse.agents.base import ActionKind
 
         order = [k.value for k in ActionKind]
-        productive = [v for v in order if v != "rest"]
-        affordable = self.affordable_verbs(name, role, productive)
+        candidates = [v for v in order if v not in excluded]
+        affordable = self.affordable_verbs(name, role, candidates)
         if not affordable:
             return None
         return min(affordable, key=lambda v: (self.cost(role, v), order.index(v)))

--- a/tests/test_economy_ledger.py
+++ b/tests/test_economy_ledger.py
@@ -236,6 +236,6 @@ def test_cheapest_affordable_perceived_under_flat_table_is_role_symmetric():
         regen_per_tick=12.0,
         cost_table=derive_flat_table(VERB_COST_BY_ROLE),
     )
-    assert led.cheapest_affordable_perceived(
-        "Aki", "artisan"
-    ) == led.cheapest_affordable_perceived("Cy", "scholar")
+    assert led.cheapest_affordable_perceived("Aki", "artisan") == led.cheapest_affordable_perceived(
+        "Cy", "scholar"
+    )

--- a/tests/test_economy_ledger.py
+++ b/tests/test_economy_ledger.py
@@ -117,6 +117,9 @@ def test_build_cost_table_selects_by_mode():
     assert build_cost_table("sub") == VERB_COST_BY_ROLE
     assert build_cost_table("throttle") == VERB_COST_BY_ROLE
     assert build_cost_table("flat") == derive_flat_table(VERB_COST_BY_ROLE)
+    # ``adv`` (advantage-perception, ADR 0009 follow-up) is a substitution mode
+    # that keeps the role-advantage table; only the energy-HINT selector differs.
+    assert build_cost_table("adv") == VERB_COST_BY_ROLE
 
 
 def _events(n: int) -> list[tuple[str, str, str]]:
@@ -174,3 +177,65 @@ def test_resolve_executed_verb_never_substitutes_toward_craft():
     # A model that CHOOSES craft and can afford it still crafts (craft is only
     # excluded as a substitution TARGET, never as an affordable pass-through).
     assert led.resolve_executed_verb("Aki", "artisan", "craft") == "craft"
+
+
+# --- cheapest_affordable_perceived: the energy-HINT selector (ADR 0009 follow-up) ---
+# The hint is a perception nudge to a model that, when it CHOOSES a payload verb,
+# authors a real payload. So unlike the blind executor's substitution target
+# (cheapest_affordable_productive, which excludes craft/contribute), the hint may
+# name an agent's payload specialty. It excludes ONLY rest (the idle last resort).
+
+
+def test_cheapest_affordable_perceived_names_craft_for_artisan():
+    # Artisan's cheap specialty is craft(6); the honest hint names it so the
+    # model is nudged toward its OWN advantage, not the shared payload-free escape.
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    assert led.cheapest_affordable_perceived("Aki", "artisan") == "craft"
+
+
+def test_cheapest_affordable_perceived_names_study_for_scholar():
+    # Scholar's cheap specialty is study(6): each role is nudged to a DISTINCT verb.
+    led = EnergyLedger.fresh(
+        ["Cy"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    assert led.cheapest_affordable_perceived("Cy", "scholar") == "study"
+
+
+def test_cheapest_affordable_perceived_includes_payload_unlike_executor_target():
+    # Load-bearing: the two selectors diverge exactly on the payload boundary.
+    # At pool 7.0 the artisan affords craft(6) but no payload-free verb (>=14):
+    # the executor target is None (falls back to rest), but the perception hint
+    # names craft (the model can author it).
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool["Aki"] = 7.0
+    assert led.cheapest_affordable_productive("Aki", "artisan") is None
+    assert led.cheapest_affordable_perceived("Aki", "artisan") == "craft"
+
+
+def test_cheapest_affordable_perceived_returns_none_when_fully_drained():
+    # Nothing productive affordable (even craft(6)) -> None, so the hint falls
+    # back to the "rest before ..." message rather than naming an unaffordable verb.
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool["Aki"] = 0.0
+    assert led.cheapest_affordable_perceived("Aki", "artisan") is None
+
+
+def test_cheapest_affordable_perceived_under_flat_table_is_role_symmetric():
+    # Flat control removes the specialty, so the honest hint has no specialty to
+    # name: both roles resolve to the SAME verb. The fix is inert under flat by
+    # construction, which keeps the A/B's role-agnostic control clean.
+    led = EnergyLedger.fresh(
+        ["Aki", "Cy"],
+        max_energy=100.0,
+        regen_per_tick=12.0,
+        cost_table=derive_flat_table(VERB_COST_BY_ROLE),
+    )
+    assert led.cheapest_affordable_perceived(
+        "Aki", "artisan"
+    ) == led.cheapest_affordable_perceived("Cy", "scholar")

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -20,7 +20,13 @@ from microverse import config
 from microverse.agents.artisan import Artisan
 from microverse.agents.scholar import Scholar
 from microverse.config import VERB_COST_BY_ROLE
-from microverse.run import _compute_energy_hint, _lazy_attach_energy, run
+from microverse.run import (
+    _compute_energy_hint,
+    _energy_hint_verb,
+    _hints_conflict,
+    _lazy_attach_energy,
+    run,
+)
 from microverse.world.economy import EnergyLedger
 
 
@@ -196,6 +202,44 @@ def test_adv_is_a_valid_economy_mode():
     # adv is a recognized mode so run() does not fail-fast on it (it is the new
     # honest-hint substitution arm).
     assert "adv" in config.VALID_ECONOMY_MODES
+
+
+# --- R4: novelty/energy hint conflict instrumentation (ADR 0009) ---
+# The honest energy_hint nudges an agent toward its cheap specialty, but
+# _compute_novelty_hint steers AWAY from whatever verb has come to dominate the
+# agent's recent mix. Once the artisan specializes into craft, the two hints
+# contradict. We expose the energy-hint's named verb and a pure conflict
+# predicate so the run loop can count the contradiction for the live read.
+
+
+def test_energy_hint_verb_names_specialty_in_adv_and_escape_in_sub():
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool["Aki"] = 15.0  # craft(6)+study(14) affordable; speak/travel/contribute not
+    agent = Artisan(name="Aki")
+    with _economy("adv"):
+        assert _energy_hint_verb(led, agent) == "craft"
+    with _economy("sub"):
+        assert _energy_hint_verb(led, agent) == "study"
+
+
+def test_energy_hint_verb_none_when_ample_or_off():
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    agent = Artisan(name="Aki")
+    with _economy("adv"):
+        assert _energy_hint_verb(led, agent) is None  # full reserves: nothing out of reach
+    assert _energy_hint_verb(None, agent) is None  # economy off
+
+
+def test_hints_conflict_only_when_energy_names_the_discouraged_verb():
+    # novelty discourages its dominant verb; conflict iff the energy hint names it.
+    assert _hints_conflict("craft", "craft") is True
+    assert _hints_conflict("craft", "study") is False
+    assert _hints_conflict(None, "craft") is False  # no verb named -> no conflict
+    assert _hints_conflict("study", "") is False  # novelty inactive -> no conflict
 
 
 def test_flag_off_run_is_deterministic(tmp_path: Path):

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -173,8 +173,10 @@ def test_adv_mode_hint_differs_from_sub_mode_hint_for_artisan():
         sub_hint = _compute_energy_hint(led, agent)
     with _economy("adv"):
         adv_hint = _compute_energy_hint(led, agent)
-    assert "study" in sub_hint and "craft" not in sub_hint
-    assert "craft" in adv_hint and "study" not in adv_hint
+    assert "study" in sub_hint
+    assert "craft" not in sub_hint
+    assert "craft" in adv_hint
+    assert "study" not in adv_hint
 
 
 def test_adv_is_substitution_mode_but_executor_still_never_fabricates_craft():

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -31,7 +31,7 @@ def _economy(mode: str, *, energy_max: float = 100.0):
         patch.object(config, "ECONOMY_MODE", mode),
         patch.object(config, "ECONOMY_ENABLED", mode != "0"),
         patch.object(config, "_ECONOMY_SCENE_GATE", mode in ("1", "flat", "throttle")),
-        patch.object(config, "_ECONOMY_SUBSTITUTE", mode in ("1", "flat", "sub")),
+        patch.object(config, "_ECONOMY_SUBSTITUTE", mode in ("1", "flat", "sub", "adv")),
         patch.object(config, "ENERGY_MAX", energy_max),
     ):
         yield

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -121,6 +121,34 @@ def test_scene_gate_blocked_when_initiator_cannot_afford_contribute(tmp_path: Pa
     assert "scene.open" not in actions
 
 
+def _craft_with_artifact() -> dict:
+    return {
+        "content": '{"thought": "I shape the clay.", "action": "craft", '
+        '"target": null, "artifact": "a small clay bowl"}',
+        "thinking": "",
+        "raw": {},
+    }
+
+
+def test_adv_model_chosen_craft_survives_to_chosen_stream_unsubstituted(tmp_path: Path):
+    """Offline go/no-go (ADR 0009 R2): under adv a solo Artisan that CHOOSES craft
+    lands craft in the chosen (parsed_verb) stream AND executes it un-substituted
+    (craft is affordable at full reserves), proving the perception channel is
+    mechanically open end-to-end. Whether the REAL model takes the honest hint is
+    the only remaining question, and that is live-only."""
+    data_dir = tmp_path / "data"
+    with (
+        _economy("adv"),
+        patch("microverse.agents.artisan.DIVERSITY_SUBSTITUTE_PROB", 0.0),
+        patch("microverse.agents.artisan.chat", return_value=_craft_with_artifact()),
+    ):
+        run(ticks=12, seed=1, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h", solo=True)
+    payloads = _payloads(data_dir)
+    assert any(p.get("parsed_verb") == "craft" for p in payloads), "chosen craft not recorded"
+    actions = {a for _, a in _events(data_dir)}
+    assert "craft" in actions, "model-chosen craft was not executed (substituted away?)"
+
+
 def test_energy_hint_only_in_substitution_modes():
     """The energy_hint (prompt-level scarcity signal) is paired with the
     substitution lever, so the scene-gate-only ``throttle`` ablation stays

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -18,6 +18,7 @@ import pytest
 
 from microverse import config
 from microverse.agents.artisan import Artisan
+from microverse.agents.scholar import Scholar
 from microverse.config import VERB_COST_BY_ROLE
 from microverse.run import _compute_energy_hint, _lazy_attach_energy, run
 from microverse.world.economy import EnergyLedger
@@ -127,6 +128,72 @@ def test_energy_hint_only_in_substitution_modes():
         assert _compute_energy_hint(led, agent) == ""  # scene-gate-only: no hint
     with _economy("sub"):
         assert _compute_energy_hint(led, agent) != ""  # substitution arm: hint on
+
+
+# --- adv mode: honest per-agent scarcity hint (ADR 0009 follow-up) ---
+# adv == sub (substitution + hint, no scene gate) EXCEPT the energy_hint names
+# the agent's TRUE cheapest affordable verb including its payload specialty, so
+# the artisan is nudged toward craft and the scholar toward study instead of both
+# co-drifting onto the shared payload-free escape (study/speak). The fix is the
+# hint selector only; the blind executor still never fabricates a craft payload.
+
+
+def test_energy_hint_names_craft_for_drained_artisan_in_adv_mode():
+    # At pool 15 the artisan can afford craft(6) and study(14) but not
+    # speak/travel/contribute, so the hint fires; adv names the role specialty.
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool["Aki"] = 15.0
+    with _economy("adv"):
+        assert "craft" in _compute_energy_hint(led, Artisan(name="Aki"))
+
+
+def test_energy_hint_names_study_for_drained_scholar_in_adv_mode():
+    # Symmetric: the scholar is nudged to its own specialty (study), a DISTINCT
+    # verb from the artisan's craft -> the chosen distributions are pushed apart.
+    led = EnergyLedger.fresh(
+        ["Cy"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool["Cy"] = 15.0
+    with _economy("adv"):
+        assert "study" in _compute_energy_hint(led, Scholar(name="Cy"))
+
+
+def test_adv_mode_hint_differs_from_sub_mode_hint_for_artisan():
+    # Same drained artisan: the buggy sub hint names study (Cy's specialty, the
+    # shared escape that causes co-drift); the honest adv hint names craft. This
+    # single-variable difference is exactly what the live A/B isolates.
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool["Aki"] = 15.0
+    agent = Artisan(name="Aki")
+    with _economy("sub"):
+        sub_hint = _compute_energy_hint(led, agent)
+    with _economy("adv"):
+        adv_hint = _compute_energy_hint(led, agent)
+    assert "study" in sub_hint and "craft" not in sub_hint
+    assert "craft" in adv_hint and "study" not in adv_hint
+
+
+def test_adv_is_substitution_mode_but_executor_still_never_fabricates_craft():
+    # adv must be a substitution mode (hint fires), yet the perception fix must
+    # NOT weaken the executor contract: a drained artisan whose chosen verb is
+    # unaffordable still falls back to rest, never a hollow fabricated craft.
+    led = EnergyLedger.fresh(
+        ["Aki"], max_energy=100.0, regen_per_tick=12.0, cost_table=VERB_COST_BY_ROLE
+    )
+    led._pool["Aki"] = 7.0  # affords craft(6) but nothing payload-free
+    with _economy("adv"):
+        assert _compute_energy_hint(led, Artisan(name="Aki")) != ""  # hint on
+    assert led.resolve_executed_verb("Aki", "artisan", "study") == "rest"
+
+
+def test_adv_is_a_valid_economy_mode():
+    # adv is a recognized mode so run() does not fail-fast on it (it is the new
+    # honest-hint substitution arm).
+    assert "adv" in config.VALID_ECONOMY_MODES
 
 
 def test_flag_off_run_is_deterministic(tmp_path: Path):


### PR DESCRIPTION
## Summary

Adds a new feature-flagged economy mode **`adv`** (advantage-perception) that fixes the differentiation failure ADR 0009 recorded: the action economy broke the `contribute` monoculture (society entropy 0.27 → 0.57) but the two residents **co-drifted onto the same alternative verbs** instead of specializing, so Gate 9 cross-agent `jsd_norm` topped out at 0.185 (< 0.25 floor).

This PR ships the **mechanism + offline tests only**. The Stage 4 live A/B that reads Gate 9 under `adv` is a deferred, separately-scheduled compute job (see `docs/economy-stage4-runbook.md`). The ADR 0008/0009 **HALT stays in force** until a PASS read.

## Background / Motivation

Gate 9 reads the **chosen** (`parsed_verb`, model-pick) verb stream. The economy's substitution lever only rewrites the *executed* stream, so the **only** channel the economy has into the chosen stream is the per-agent `energy_hint` injected into the persona prompt (`run._compute_energy_hint`).

That hint named `EnergyLedger.cheapest_affordable_productive`, which excludes the payload verbs `{contribute, craft}` (the blind executor cannot fabricate their payloads). Consequence: the **artisan**, whose cheap specialty *is* `craft` (cost 6), was never told "craft comes easily" — its hint pointed at the cheapest payload-free verb, `study` (cost 14), which is the **scholar's** specialty. Both agents' scarcity hints named the same escape verb → co-drift, not differentiation. The `economy.py` comment even *claimed* the artisan "diversifies through the perception channel (energy_hint lets the model choose craft)" while the selector structurally excluded craft.

## What changed

- **`EnergyLedger.cheapest_affordable_perceived`** (`world/economy.py`) — the energy-hint perception selector. Names the agent's true cheapest affordable verb **including payload specialties** (excludes only `rest`), distinct from the executor's substitution target `cheapest_affordable_productive` (kept payload-free, unchanged). When the model *chooses* craft it authors a real artifact, so naming craft in the hint is honest.
- **`run._compute_energy_hint`** dispatches the selector on `ECONOMY_MODE == "adv"`; `sub`/`1`/`flat` keep the legacy selector, so their prior reads stay **byte-reproducible**. Refactored the named verb into `_energy_hint_verb` (single source of truth for hint text + instrumentation).
- **R4 instrumentation** — `_hints_conflict` predicate + `novelty_energy_hint_conflict` metric: counts ticks where the honest energy hint nudges toward the very verb `_compute_novelty_hint` is steering *away* from (the now-dominant specialty). The two levers can fight once an agent specializes; the live read quantifies how often.
- **`config`** — `adv` added to `VALID_ECONOMY_MODES` and `_ECONOMY_SUBSTITUTE`. `build_cost_table` already routes any non-`flat` mode to the role-advantage table.
- **`scripts/replay_economy.py`** — `adv` added to `--mode` choices (identical to `sub` offline; the hint difference is live-only).

### A/B matrix

| mode | scene_gate | substitute | hint selector | honest hint |
|---|---|---|---|---|
| `0` | no | no | — | no |
| `flat` | yes | yes | inert (no specialty) | n/a |
| `sub` | no | yes | `cheapest_affordable_productive` | no |
| `adv` | no | yes | `cheapest_affordable_perceived` | **yes** |

`adv` vs `sub` isolates the hint fix as the single variable; `adv` vs `flat` isolates specialization given the honest hint.

## Design & Reasoning Notes

**Why a new mode, not a bugfix to `sub`:** keeps every prior Stage-3 arm byte-reproducible so the A/B isolates exactly one variable.

**Why this is NOT prompt-tuning (ADR 0008 constraint):** no persona template is touched; the hint string format and firing condition are unchanged. Only *which verb the existing scarcity signal names* changes — computed mechanically from the cost table, symmetric across agents, and **inert under the `flat` control** (which removes specialties, so there is nothing to name). The artisan getting `craft` is emergent from `craft` costing 6 for it, not an authored preference. It makes code match its own documented contract.

**Executor contract preserved:** `resolve_executed_verb` still uses the payload-free `cheapest_affordable_productive` in every mode — the executor never fabricates a hollow craft. The perceived selector is hint-only.

## Testing

Strict TDD (red commit `6aacadc`, then green). All offline (`-m 'not integration'`).

- **Ledger** (`tests/test_economy_ledger.py`): perceived names craft for artisan / study for scholar; **diverges from the executor target exactly at the payload boundary** (pool 7.0: perceived = craft, productive = None); None when fully drained; role-symmetric under flat (inertness); `build_cost_table("adv")` = role-advantage.
- **Run wiring** (`tests/test_run_economy.py`): adv-mode hint names the role specialty; differs from the buggy `sub` hint (study → craft for the artisan); adv is a substitution mode yet the executor still never fabricates craft; `_energy_hint_verb`/`_hints_conflict` unit tests; **offline go/no-go** — a mocked-chat `run()` proving a model-chosen craft under `adv` lands in the chosen (`parsed_verb`) stream and executes un-substituted (R2 de-risked: the channel is mechanically open).

Full local gate green: `ruff check`, `ruff format --check`, `mypy src/microverse`, `pip-audit`, `pytest -q -m 'not integration'` (615 passed), `uv build`.

## Documentation

`docs/economy-stage4-runbook.md` — operator handoff for the deferred live A/B: the not-prompt-tuning argument, the `{0,sub,adv}` × `{42,38,7}` × 3000-tick sweep (concurrent comparator required — `gemma4:26b` sampling is unseeded, so archived `sub` reads are not a clean baseline), the Gate 9 primary bar, a **quality gate** (craft shares, `artisan_empty_craft_coerced`, parse-fallback rate, `novelty_energy_hint_conflict`), and risks R1–R4.

## Post-Merge Recommendations

1. **Deferred Stage 4 live A/B** (~9 runs × 5–6 h on `gemma4:26b`) per the runbook. Pre-register the success rule before reading. The HALT stays until Gate 9 PASS across all seeds.
2. If `novelty_energy_hint_conflict` is high in the live read (R4), a follow-up may suppress the novelty hint for an agent's *own* cheap specialty under `adv`. Flagged as a known limitation, not silently patched.
3. After the read, write the ADR 0009 follow-up with the per-seed pass/fail table and the PASS/HALT decision.