### PR TITLE
docs(economy): Stage 4 adv honest-hint live A/B read — HALT stays (ADR 0010)

### DIFF
--- a/docs/adr/0010-action-economy-stage4-adv-read.md
+++ b/docs/adr/0010-action-economy-stage4-adv-read.md
@@ -30,43 +30,56 @@ Gate 9 PASS = chosen `entropy_norm ≥ 0.35` AND chosen `jsd_norm ≥ 0.25`. The
 
 ## Method
 
-- Runner: `MICROVERSE_ECONOMY={mode} uv run python -m microverse.run --ticks 3000 --tempo 0
-  --seed {seed}` into isolated state dirs, model `gemma4:26b`. ~5.7–6.3 h / ~3760 agent events.
-- Modes `{0, sub, adv}` × seeds `{42, 38, 7}`, all run in **one sweep** (concurrent comparators;
-  `gemma4:26b` sampling is unseeded, so `sub`/`0` are paired with `adv`, not reused from Stage 3).
+- Runner (per mode `{0, sub, adv}` × seed `{42, 38, 7}`) into isolated state dirs, model
+  `gemma4:26b`, ~5.7–6.3 h / ~3760 agent events each:
+
+  ```bash
+  MICROVERSE_ECONOMY=$MODE uv run python -m microverse.run --ticks 3000 --tempo 0 --seed $SEED
+  ```
+- All run in **one sweep** (concurrent comparators; `gemma4:26b` sampling is unseeded, so
+  `sub`/`0` are paired with `adv`, not reused from Stage 3).
 - Measurement: `scripts/spike_workshop_measure.py` `gate9_verb_diversity`, chosen stream;
   scene-forced contributes and parse-fallback rests excluded as non-choices.
-- Quality gate (ADR 0009 R-mitigations): per-agent chosen-craft share, `artisan_empty_craft_
-  coerced`, `parse_fallback`, and `novelty_energy_hint_conflict` recorded per run.
+- Quality gate (ADR 0009 R-mitigations): each agent's chosen share of its OWN specialty
+  (artisan→craft, scholar→study), `artisan_empty_craft_coerced`, `parse_fallback`, and
+  `novelty_energy_hint_conflict` recorded per run.
 
 ## Results (chosen stream)
 
-| mode  | seed | entropy_norm | jsd_norm | aki_craft | cy_craft | conflict | Gate 9 |
-|-------|------|-------------:|---------:|----------:|---------:|---------:|:------:|
-| `0`   | 42   | 0.259        | 0.019    | 0.000     | 0.000    | 0        | FAIL   |
-| `sub` | 42   | 0.426        | 0.119    | 0.024     | 0.014    | 5        | FAIL   |
-| `adv` | 42   | 0.380        | 0.175    | 0.350     | 0.011    | 177      | FAIL   |
-| `0`   | 38   | 0.257        | 0.010    | 0.000     | 0.000    | 0        | FAIL   |
-| `sub` | 38   | 0.497        | 0.171    | 0.020     | 0.013    | 25       | FAIL   |
-| `adv` | 38   | 0.378        | 0.168    | 0.336     | 0.011    | 51       | FAIL   |
-| `0`   | 7    | 0.267        | 0.014    | 0.000     | 0.000    | 0        | FAIL   |
-| `sub` | 7    | 0.456        | 0.119    | 0.027     | 0.009    | 5        | FAIL   |
-| `adv` | 7    | 0.374        | 0.143    | 0.312     | 0.015    | 79       | FAIL   |
+`aki_craft` = Aki's chosen share of the artisan specialty (craft); `cy_study` = Cy's chosen
+share of the scholar specialty (study); `cy_contrib` = Cy's chosen contribute share. Each
+agent is measured against the verb it *should* specialize into. Mode `0` shares are executed
+(`parsed_verb` is unstamped with the economy off; chosen ≡ executed when nothing substitutes).
 
-Means: jsd `0` 0.014 / `sub` 0.136 / `adv` 0.162. `adv` aki_craft 0.333, cy_craft 0.012.
+| mode  | seed | entropy_norm | jsd_norm | aki_craft | cy_study | cy_contrib | conflict | Gate 9 |
+|-------|------|-------------:|---------:|----------:|---------:|-----------:|---------:|:------:|
+| `0`   | 42   | 0.259        | 0.019    | 0.028     | 0.018    | 0.923      | 0        | FAIL   |
+| `sub` | 42   | 0.426        | 0.119    | 0.024     | 0.022    | 0.934      | 5        | FAIL   |
+| `adv` | 42   | 0.380        | 0.175    | 0.350     | 0.031    | 0.938      | 177      | FAIL   |
+| `0`   | 38   | 0.257        | 0.010    | 0.025     | 0.011    | 0.926      | 0        | FAIL   |
+| `sub` | 38   | 0.497        | 0.171    | 0.020     | 0.032    | 0.925      | 25       | FAIL   |
+| `adv` | 38   | 0.378        | 0.168    | 0.336     | 0.030    | 0.929      | 51       | FAIL   |
+| `0`   | 7    | 0.267        | 0.014    | 0.023     | 0.014    | 0.915      | 0        | FAIL   |
+| `sub` | 7    | 0.456        | 0.119    | 0.027     | 0.037    | 0.923      | 5        | FAIL   |
+| `adv` | 7    | 0.374        | 0.143    | 0.312     | 0.030    | 0.926      | 79       | FAIL   |
+
+Means: jsd `0`/`sub`/`adv` 0.014 / 0.136 / 0.162. `aki_craft` 0.025 / 0.024 / **0.333**;
+`cy_study` 0.014 / 0.030 / 0.030 (flat); `cy_contrib` ~0.92–0.94 in every mode.
 
 `conflict` is the true `novelty_energy_hint_conflict` count (cumulative metric MAX). The
 per-run progress log printed a SUM over the time-series snapshots (~1000× inflated); use MAX.
 
 ## Findings
 
-1. **The honest hint robustly specializes the artisan.** Aki chosen-craft 0.00→0.024(sub)→
+1. **The honest hint robustly specializes the artisan.** Aki chosen-craft ~0.025(off/sub)→
    **0.33(adv)**, stable across all three seeds. The ADR 0009 fix does exactly what it was
    designed to: an identity-independent change to the perception channel moves the artisan to
    its own cheap specialty. `sub` does not (Aki craft ~0.024), so the effect is hint-specific.
 
-2. **It does not specialize the scholar — Gate 9 FAILS in every run.** Cy chosen-craft ~0.012
-   everywhere; Cy stays contribute-dominated. Cross-agent `jsd_norm` lands a stable ~0.16
+2. **It does not specialize the scholar — Gate 9 FAILS in every run.** Measured against the
+   scholar's *own* specialty (`study`): Cy chosen-study is flat at ~0.03 under `adv`,
+   indistinguishable from `sub` and barely above baseline (~0.014); Cy stays a ~0.92–0.94
+   `contribute` monoculture in every mode. Cross-agent `jsd_norm` lands a stable ~0.16
    (0.175/0.168/0.143), below the 0.25 floor at all three seeds. `adv` edges `sub` on the mean
    (0.162 vs 0.136) but within the seed-variance band and never near the floor.
 

--- a/docs/adr/0010-action-economy-stage4-adv-read.md
+++ b/docs/adr/0010-action-economy-stage4-adv-read.md
@@ -1,0 +1,120 @@
+# ADR 0010: Action-economy Stage 4 — honest-hint (`adv`) verb-diversity A/B read (Gate 9)
+
+**Status:** Accepted (measurement record) — records the falsifiable Stage 4 read that tests
+the ADR 0009 follow-up intervention (the honest per-agent scarcity hint).
+**Halt decision: HALT stays.** The honest hint robustly specializes the *artisan* but not the
+*scholar*, so cross-agent specialization (Gate 9 JSD) does not emerge; the ADR 0007 substrate
+thesis remains unproven.
+
+**Date:** 2026-06-05
+
+## Context
+
+ADR 0009 (Stage 3) found the action economy breaks the `contribute` monoculture (society
+entropy rises) but FAILS Gate 9 cross-agent specialization: the two residents co-drift onto
+the *same* alternative verbs, jsd_norm topping out at 0.185. Root cause (verified in code):
+Gate 9 reads the **chosen** (`parsed_verb`) stream, and the only economy→chosen channel is the
+per-agent `energy_hint`, which named `cheapest_affordable_productive` — a selector that excludes
+the payload verbs (`contribute`/`craft`). So the **artisan**, whose cheap specialty *is*
+`craft`, was pointed at the shared payload-free escape `study` (the **scholar's** specialty),
+producing co-drift instead of differentiation.
+
+PR #52 shipped the fix as a new feature-flagged mode **`adv`**: the `energy_hint` names
+`cheapest_affordable_perceived` (excludes only `rest`, so it may name a role's payload
+specialty), while the blind executor's substitution target stays payload-free. `adv` is
+otherwise identical to `sub`. This ADR records the deferred live A/B that tests whether the
+honest hint clears Gate 9.
+
+Gate 9 PASS = chosen `entropy_norm ≥ 0.35` AND chosen `jsd_norm ≥ 0.25`. The headline is
+`jsd_norm`.
+
+## Method
+
+- Runner: `MICROVERSE_ECONOMY={mode} uv run python -m microverse.run --ticks 3000 --tempo 0
+  --seed {seed}` into isolated state dirs, model `gemma4:26b`. ~5.7–6.3 h / ~3760 agent events.
+- Modes `{0, sub, adv}` × seeds `{42, 38, 7}`, all run in **one sweep** (concurrent comparators;
+  `gemma4:26b` sampling is unseeded, so `sub`/`0` are paired with `adv`, not reused from Stage 3).
+- Measurement: `scripts/spike_workshop_measure.py` `gate9_verb_diversity`, chosen stream;
+  scene-forced contributes and parse-fallback rests excluded as non-choices.
+- Quality gate (ADR 0009 R-mitigations): per-agent chosen-craft share, `artisan_empty_craft_
+  coerced`, `parse_fallback`, and `novelty_energy_hint_conflict` recorded per run.
+
+## Results (chosen stream)
+
+| mode  | seed | entropy_norm | jsd_norm | aki_craft | cy_craft | conflict | Gate 9 |
+|-------|------|-------------:|---------:|----------:|---------:|---------:|:------:|
+| `0`   | 42   | 0.259        | 0.019    | 0.000     | 0.000    | 0        | FAIL   |
+| `sub` | 42   | 0.426        | 0.119    | 0.024     | 0.014    | 5        | FAIL   |
+| `adv` | 42   | 0.380        | 0.175    | 0.350     | 0.011    | 177      | FAIL   |
+| `0`   | 38   | 0.257        | 0.010    | 0.000     | 0.000    | 0        | FAIL   |
+| `sub` | 38   | 0.497        | 0.171    | 0.020     | 0.013    | 25       | FAIL   |
+| `adv` | 38   | 0.378        | 0.168    | 0.336     | 0.011    | 51       | FAIL   |
+| `0`   | 7    | 0.267        | 0.014    | 0.000     | 0.000    | 0        | FAIL   |
+| `sub` | 7    | 0.456        | 0.119    | 0.027     | 0.009    | 5        | FAIL   |
+| `adv` | 7    | 0.374        | 0.143    | 0.312     | 0.015    | 79       | FAIL   |
+
+Means: jsd `0` 0.014 / `sub` 0.136 / `adv` 0.162. `adv` aki_craft 0.333, cy_craft 0.012.
+
+`conflict` is the true `novelty_energy_hint_conflict` count (cumulative metric MAX). The
+per-run progress log printed a SUM over the time-series snapshots (~1000× inflated); use MAX.
+
+## Findings
+
+1. **The honest hint robustly specializes the artisan.** Aki chosen-craft 0.00→0.024(sub)→
+   **0.33(adv)**, stable across all three seeds. The ADR 0009 fix does exactly what it was
+   designed to: an identity-independent change to the perception channel moves the artisan to
+   its own cheap specialty. `sub` does not (Aki craft ~0.024), so the effect is hint-specific.
+
+2. **It does not specialize the scholar — Gate 9 FAILS in every run.** Cy chosen-craft ~0.012
+   everywhere; Cy stays contribute-dominated. Cross-agent `jsd_norm` lands a stable ~0.16
+   (0.175/0.168/0.143), below the 0.25 floor at all three seeds. `adv` edges `sub` on the mean
+   (0.162 vs 0.136) but within the seed-variance band and never near the floor.
+
+3. **The move is specialization, not just diversity.** `adv` entropy (0.377) < `sub` (0.460)
+   while `adv` cxe (~0.11) > `sub` (~0.06): `adv` concentrates each agent toward a profile
+   rather than spreading both. That is the right qualitative direction — it just stops at one
+   agent. One-sided specialization cannot clear a *cross-agent* divergence floor.
+
+4. **R4 (novelty vs energy hint) is real but not the binding cap.** True conflict counts are
+   higher under `adv` (51–177) than `sub` (5–25) — the novelty hint does fight craft once it
+   dominates — but at ~50–180 ticks over ~3760 events it is modest. The binding constraint is
+   the scholar's inertia, not the novelty/energy fight.
+
+## Decision
+
+**The honest hint is necessary and effective for the artisan but insufficient for the society.
+HALT stays.**
+
+ADR 0009 diagnosed the co-drift as the hint laundering both roles' specialties into the same
+payload-free escape. The fix removes that for the artisan (robustly, across seeds), proving the
+chosen stream *can* be moved toward a role's specialty by an identity-independent economy
+change. But Gate 9 requires *both* agents to put mass on *different* verbs, and the scholar does
+not move: its `contribute` is cheap (cost 14) so it rarely triggers the scarcity hint, and its
+persona/sampling keep it on contribute even when hinted. Do not start Phase 2 on the strength of
+the economy lever; the missing ingredient is a force that differentiates the *scholar* (and, more
+generally, every non-artisan role), not merely the artisan.
+
+## Limitations
+
+- Three seeds at scale; the qualitative verdict (artisan specializes robustly, jsd misses the
+  floor by a wide margin at every seed) is stable, but the numeric values are 3-point estimates.
+- Two-resident roster (Aki/artisan, Cy/scholar). JSD across two agents is a coarse divergence
+  estimate; a larger, more heterogeneous roster could change the dynamics and is untested.
+- The spike deliberately did not tune persona prompts (ADR 0008 constraint carried forward); the
+  scholar's contribute-inertia is therefore a property of the unmodified persona + cost table.
+
+## Reproduction
+
+```bash
+# per mode in {0, sub, adv}, seed in {42, 38, 7}:
+MICROVERSE_ECONOMY=$MODE \
+MICROVERSE_DATA=data/econ-stage4-$MODE-s$SEED \
+MICROVERSE_HARVEST=harvest/econ-stage4-$MODE-s$SEED \
+  uv run python -m microverse.run --ticks 3000 --tempo 0 --seed $SEED
+uv run python scripts/spike_workshop_measure.py \
+  --data data/econ-stage4-$MODE-s$SEED --harvest harvest/econ-stage4-$MODE-s$SEED
+# read .gate_9_verb_diversity.chosen.{society_entropy_norm,jsd_norm} and .pass
+```
+
+Runbook: `docs/economy-stage4-runbook.md`. Findings: `docs/economy-stage4-findings.md`.
+Mechanism + offline tests: PR #52. Stage 3 read: ADR 0009 / `docs/economy-stage3-findings.md`.

--- a/docs/economy-stage4-findings.md
+++ b/docs/economy-stage4-findings.md
@@ -6,50 +6,64 @@ shipped in PR #52; this is the deferred live run from `docs/economy-stage4-runbo
 
 ## Setup
 
-- Runner: `MICROVERSE_ECONOMY={mode} uv run python -m microverse.run --ticks 3000
-  --tempo 0 --seed {seed}`, model `gemma4:26b`, isolated `MICROVERSE_DATA`/
-  `MICROVERSE_HARVEST` per run. Each run ~5.7–6.3 h / ~3760 agent events.
+- Runner (per mode `{0, sub, adv}` × seed `{42, 38, 7}`), model `gemma4:26b`, isolated
+  `MICROVERSE_DATA`/`MICROVERSE_HARVEST` per run, ~5.7–6.3 h / ~3760 agent events each:
+
+  ```bash
+  MICROVERSE_ECONOMY=$MODE uv run python -m microverse.run --ticks 3000 --tempo 0 --seed $SEED
+  ```
 - Modes: `0` (economy off / baseline), `sub` (substitution lever, legacy hint naming
   `cheapest_affordable_productive`), `adv` (substitution lever, **honest** hint naming
   `cheapest_affordable_perceived` — includes the agent's payload specialty, ADR 0009 fix).
-- Seeds `{42, 38, 7}`, all run (concurrent comparators — `gemma4:26b` sampling is unseeded,
-  so `0`/`sub`/`adv` were paired in the same sweep, not compared to archived Stage-3 reads).
+- Seeds all run as concurrent comparators — `gemma4:26b` sampling is unseeded, so `0`/`sub`/`adv`
+  were paired in the same sweep, not compared to archived Stage-3 reads.
 - Metric: `gate9_verb_diversity` (`scripts/spike_workshop_measure.py`), **chosen**
-  (`parsed_verb`) stream. **PASS = chosen `entropy_norm ≥ 0.35` AND chosen `jsd_norm ≥
-  0.25`.** Primary read is `jsd_norm` (cross-agent divergence — ADR 0007's real target).
+  (`parsed_verb`) stream. **PASS = chosen `entropy_norm ≥ 0.35` AND chosen `jsd_norm ≥ 0.25`.**
+  Primary read is `jsd_norm` (cross-agent divergence — ADR 0007's real target).
 
 ## Results (all 9 runs)
 
-`aki_craft`/`cy_craft` = each agent's **chosen** (`parsed_verb`) craft share. `conflict` =
-true `novelty_energy_hint_conflict` count (the cumulative metric's MAX; the per-run progress
-log printed a SUM over the time-series, ~1000× inflated — disregard that column there).
+`aki_craft` = Aki's **chosen** (`parsed_verb`) share of its OWN specialty (artisan: craft).
+`cy_study` = Cy's chosen share of its OWN specialty (scholar: study); `cy_contrib` = Cy's
+chosen contribute share. (Each agent measured against the verb it *should* specialize into,
+not the other's — the scholar's specialty is study, not craft.) `conflict` = true
+`novelty_energy_hint_conflict` count (the cumulative metric's MAX; the per-run progress log
+printed a SUM over the time-series, ~1000× inflated — disregard that column there). For mode
+`0` the economy is off so `parsed_verb` is unstamped; its shares are executed (chosen ≡
+executed when nothing substitutes).
 
-| mode  | seed | entropy_norm | jsd_norm | aki_craft | cy_craft | conflict | Gate 9 |
-|-------|------|-------------:|---------:|----------:|---------:|---------:|:------:|
-| `0`   | 42   | 0.259        | 0.019    | 0.000     | 0.000    | 0        | FAIL   |
-| `sub` | 42   | 0.426        | 0.119    | 0.024     | 0.014    | 5        | FAIL   |
-| `adv` | 42   | 0.380        | **0.175**| **0.350** | 0.011    | 177      | FAIL   |
-| `0`   | 38   | 0.257        | 0.010    | 0.000     | 0.000    | 0        | FAIL   |
-| `sub` | 38   | 0.497        | 0.171    | 0.020     | 0.013    | 25       | FAIL   |
-| `adv` | 38   | 0.378        | **0.168**| **0.336** | 0.011    | 51       | FAIL   |
-| `0`   | 7    | 0.267        | 0.014    | 0.000     | 0.000    | 0        | FAIL   |
-| `sub` | 7    | 0.456        | 0.119    | 0.027     | 0.009    | 5        | FAIL   |
-| `adv` | 7    | 0.374        | **0.143**| **0.312** | 0.015    | 79       | FAIL   |
+| mode  | seed | entropy_norm | jsd_norm | aki_craft | cy_study | cy_contrib | conflict | Gate 9 |
+|-------|------|-------------:|---------:|----------:|---------:|-----------:|---------:|:------:|
+| `0`   | 42   | 0.259        | 0.019    | 0.028     | 0.018    | 0.923      | 0        | FAIL   |
+| `sub` | 42   | 0.426        | 0.119    | 0.024     | 0.022    | 0.934      | 5        | FAIL   |
+| `adv` | 42   | 0.380        | **0.175**| **0.350** | 0.031    | 0.938      | 177      | FAIL   |
+| `0`   | 38   | 0.257        | 0.010    | 0.025     | 0.011    | 0.926      | 0        | FAIL   |
+| `sub` | 38   | 0.497        | 0.171    | 0.020     | 0.032    | 0.925      | 25       | FAIL   |
+| `adv` | 38   | 0.378        | **0.168**| **0.336** | 0.030    | 0.929      | 51       | FAIL   |
+| `0`   | 7    | 0.267        | 0.014    | 0.023     | 0.014    | 0.915      | 0        | FAIL   |
+| `sub` | 7    | 0.456        | 0.119    | 0.027     | 0.037    | 0.923      | 5        | FAIL   |
+| `adv` | 7    | 0.374        | **0.143**| **0.312** | 0.030    | 0.926      | 79       | FAIL   |
 
-Means: `0` jsd 0.014 / `sub` 0.136 / `adv` 0.162. `adv` aki_craft mean **0.333**;
-`adv` cy_craft mean **0.012**. `adv` entropy mean 0.377; `sub` entropy mean 0.460.
+Means: `0`/`sub`/`adv` jsd 0.014 / 0.136 / 0.162. `aki_craft` 0.025 / 0.024 / **0.333** —
+the artisan moves only under `adv`. `cy_study` 0.014 / 0.030 / 0.030 — flat; the scholar
+never moves toward its specialty, and stays ~0.92–0.94 `contribute` in every mode. `adv`
+entropy mean 0.377; `sub` 0.460.
 
 ## Read
 
 1. **The honest hint robustly specializes the ARTISAN.** Aki's chosen-craft share is
-   0.00 (off) → 0.024 (sub) → **0.33 (adv)**, stable across all three seeds (0.350 / 0.336 /
-   0.312). The ADR 0009 fix works exactly as designed: naming `craft` as "comes easily" moves
-   the artisan to its own cheap specialty instead of the shared payload-free escape (`study`).
+   ~0.025 (off/sub) → **0.33 (adv)**, stable across all three seeds (0.350 / 0.336 / 0.312).
+   The ADR 0009 fix works exactly as designed: naming `craft` as "comes easily" moves the
+   artisan to its own cheap specialty instead of the shared payload-free escape (`study`).
    `sub` never does this (Aki craft ~0.024) — it is specific to the honest hint.
 
-2. **But it does NOT specialize the SCHOLAR.** Cy's chosen-craft is ~0.012 everywhere, and Cy
-   stays contribute-dominated under `adv` (its plurality remains `contribute`). The
-   differentiation is one-sided: one role retreats to its specialty, the other does not.
+2. **But it does NOT specialize the SCHOLAR.** Measured against the scholar's *own* specialty
+   (`study`, not craft): Cy's chosen-study share is flat at ~0.03 under `adv`, indistinguishable
+   from `sub` (~0.03) and barely above baseline (~0.014) — the honest hint does not move the
+   scholar at all. Cy stays a ~0.92–0.94 `contribute` monoculture in every mode. The
+   differentiation is one-sided: the artisan retreats to its specialty, the scholar does not.
+   (The scholar's `contribute` costs only 14, so it is usually affordable and the scarcity hint
+   rarely fires for Cy; even when it does, its persona/sampling keep it on contribute.)
 
 3. **So cross-agent JSD never clears the floor — Gate 9 FAILS in every run.** `adv` jsd lands a
    stable ~0.16 (0.175 / 0.168 / 0.143), below the 0.25 floor at all three seeds. `adv` edges

--- a/docs/economy-stage4-findings.md
+++ b/docs/economy-stage4-findings.md
@@ -1,0 +1,78 @@
+# Action-economy Stage 4 findings — honest per-agent scarcity hint (`adv` mode)
+
+Operator note recording the Stage 4 live A/B that feeds **ADR 0010**. The ADR 0008/0009
+HALT stays in force; this records the read that informs it. Mechanism + offline tests
+shipped in PR #52; this is the deferred live run from `docs/economy-stage4-runbook.md`.
+
+## Setup
+
+- Runner: `MICROVERSE_ECONOMY={mode} uv run python -m microverse.run --ticks 3000
+  --tempo 0 --seed {seed}`, model `gemma4:26b`, isolated `MICROVERSE_DATA`/
+  `MICROVERSE_HARVEST` per run. Each run ~5.7–6.3 h / ~3760 agent events.
+- Modes: `0` (economy off / baseline), `sub` (substitution lever, legacy hint naming
+  `cheapest_affordable_productive`), `adv` (substitution lever, **honest** hint naming
+  `cheapest_affordable_perceived` — includes the agent's payload specialty, ADR 0009 fix).
+- Seeds `{42, 38, 7}`, all run (concurrent comparators — `gemma4:26b` sampling is unseeded,
+  so `0`/`sub`/`adv` were paired in the same sweep, not compared to archived Stage-3 reads).
+- Metric: `gate9_verb_diversity` (`scripts/spike_workshop_measure.py`), **chosen**
+  (`parsed_verb`) stream. **PASS = chosen `entropy_norm ≥ 0.35` AND chosen `jsd_norm ≥
+  0.25`.** Primary read is `jsd_norm` (cross-agent divergence — ADR 0007's real target).
+
+## Results (all 9 runs)
+
+`aki_craft`/`cy_craft` = each agent's **chosen** (`parsed_verb`) craft share. `conflict` =
+true `novelty_energy_hint_conflict` count (the cumulative metric's MAX; the per-run progress
+log printed a SUM over the time-series, ~1000× inflated — disregard that column there).
+
+| mode  | seed | entropy_norm | jsd_norm | aki_craft | cy_craft | conflict | Gate 9 |
+|-------|------|-------------:|---------:|----------:|---------:|---------:|:------:|
+| `0`   | 42   | 0.259        | 0.019    | 0.000     | 0.000    | 0        | FAIL   |
+| `sub` | 42   | 0.426        | 0.119    | 0.024     | 0.014    | 5        | FAIL   |
+| `adv` | 42   | 0.380        | **0.175**| **0.350** | 0.011    | 177      | FAIL   |
+| `0`   | 38   | 0.257        | 0.010    | 0.000     | 0.000    | 0        | FAIL   |
+| `sub` | 38   | 0.497        | 0.171    | 0.020     | 0.013    | 25       | FAIL   |
+| `adv` | 38   | 0.378        | **0.168**| **0.336** | 0.011    | 51       | FAIL   |
+| `0`   | 7    | 0.267        | 0.014    | 0.000     | 0.000    | 0        | FAIL   |
+| `sub` | 7    | 0.456        | 0.119    | 0.027     | 0.009    | 5        | FAIL   |
+| `adv` | 7    | 0.374        | **0.143**| **0.312** | 0.015    | 79       | FAIL   |
+
+Means: `0` jsd 0.014 / `sub` 0.136 / `adv` 0.162. `adv` aki_craft mean **0.333**;
+`adv` cy_craft mean **0.012**. `adv` entropy mean 0.377; `sub` entropy mean 0.460.
+
+## Read
+
+1. **The honest hint robustly specializes the ARTISAN.** Aki's chosen-craft share is
+   0.00 (off) → 0.024 (sub) → **0.33 (adv)**, stable across all three seeds (0.350 / 0.336 /
+   0.312). The ADR 0009 fix works exactly as designed: naming `craft` as "comes easily" moves
+   the artisan to its own cheap specialty instead of the shared payload-free escape (`study`).
+   `sub` never does this (Aki craft ~0.024) — it is specific to the honest hint.
+
+2. **But it does NOT specialize the SCHOLAR.** Cy's chosen-craft is ~0.012 everywhere, and Cy
+   stays contribute-dominated under `adv` (its plurality remains `contribute`). The
+   differentiation is one-sided: one role retreats to its specialty, the other does not.
+
+3. **So cross-agent JSD never clears the floor — Gate 9 FAILS in every run.** `adv` jsd lands a
+   stable ~0.16 (0.175 / 0.168 / 0.143), below the 0.25 floor at all three seeds. `adv` edges
+   `sub` on the mean (0.162 vs 0.136) but the gap is inside the seed-variance band (`sub` itself
+   swings 0.119–0.171), and `adv` never approaches 0.25. One-sided specialization is not enough:
+   Gate 9 needs **both** agents to put mass on **different** verbs, and only Aki moved.
+
+4. **The signature is specialization, not just diversity.** `adv` entropy (0.377) is *lower*
+   than `sub` (0.460) while `adv` cxe (~0.11) is *higher* than `sub` (~0.06): `adv` concentrates
+   each agent toward a profile (Aki→craft) rather than spreading both across many verbs. That is
+   the right qualitative move — it just stops at one agent.
+
+5. **R4 (novelty vs energy hint conflict) is real but modest.** True conflict counts are higher
+   under `adv` (51–177) than `sub` (5–25) — the novelty hint does push back once Aki leans into
+   craft — but at ~50–180 ticks over a ~3760-event run it is not the dominant cap. The binding
+   constraint is the scholar's inertia, not the novelty/energy fight.
+
+## Decision: HALT stays (see ADR 0010)
+
+The honest hint is **necessary and effective for the artisan but insufficient for the
+society**. It refutes "the economy cannot move the chosen stream toward a role's specialty"
+(it clearly can — robustly, across seeds), but it does not unlock cross-agent specialization
+(Gate 9 JSD), because the scholar stays a contribute monoculture. The ADR 0008/0009 HALT
+stays in force. The next lever must move the **scholar** specifically: its `contribute` is
+cheap (cost 14) so it rarely triggers the scarcity hint, and its persona/sampling keep it on
+contribute even when hinted. See `docs/adr/0010-action-economy-stage4-adv-read.md`.


### PR DESCRIPTION
## Summary

Records the deferred **Stage 4 live A/B** (`docs/economy-stage4-runbook.md`) that tests the ADR 0009 honest-hint fix shipped in #52. Modes `{0, sub, adv}` × seeds `{42, 38, 7}` × 3000 ticks on `gemma4:26b`, all paired in one sweep. **Verdict: HALT stays.**

Docs-only PR (no code). Adds `docs/economy-stage4-findings.md` (operator note) and `docs/adr/0010-action-economy-stage4-adv-read.md` (decision record).

## Background / Motivation

ADR 0009 (Stage 3) found the action economy broke the `contribute` monoculture but failed Gate 9 cross-agent specialization (jsd ≤ 0.185): the `energy_hint` named a selector that excluded the artisan's `craft` specialty, so both agents co-drifted onto the shared escape `study`. PR #52 shipped `adv` mode — the hint names the agent's *true* cheapest verb including its payload specialty. This is the live read of whether that clears Gate 9 (`jsd_norm ≥ 0.25 AND entropy_norm ≥ 0.35`, chosen stream).

## Results (chosen stream, all 9 runs)

| mode | seed | entropy | jsd | aki_craft | cy_craft | Gate 9 |
|---|---|---|---|---|---|---|
| `0`/`sub`/`adv` | 42 | 0.259/0.426/0.380 | 0.019/0.119/**0.175** | 0/0.024/**0.350** | ~0.01 | FAIL |
| `0`/`sub`/`adv` | 38 | 0.257/0.497/0.378 | 0.010/0.171/**0.168** | 0/0.020/**0.336** | ~0.01 | FAIL |
| `0`/`sub`/`adv` | 7 | 0.267/0.456/0.374 | 0.014/0.119/**0.143** | 0/0.027/**0.312** | ~0.01 | FAIL |

Means: jsd `0` 0.014 / `sub` 0.136 / `adv` 0.162. `adv` aki_craft 0.333, cy_craft 0.012.

## Read / Decision

1. **The honest hint robustly specializes the artisan** — Aki chosen-craft 0.00→0.33 under `adv`, stable across all three seeds; `sub` never does this. The ADR 0009 fix works as designed: an identity-independent economy change *can* move the chosen stream toward a role's specialty.
2. **But not the scholar** — Cy chosen-craft ~0.012 everywhere; it stays contribute-dominated. The differentiation is one-sided.
3. **So Gate 9 FAILS at every seed** — `adv` jsd lands a stable ~0.16, below 0.25; it edges `sub` on the mean but within the seed-variance band and never near the floor. One-sided specialization cannot clear a cross-agent divergence floor.
4. **Specialization, not just diversity** — `adv` entropy (0.377) < `sub` (0.460) with higher cxe: `adv` concentrates each agent toward a profile rather than spreading both.
5. **R4 modest** — true `novelty_energy_hint_conflict` MAX 51–177 (`adv`) vs 5–25 (`sub`); real but not the binding cap. (The progress-log SUM column is a ~1000× time-series artifact; use MAX.)

**HALT stays.** The next lever must move the *scholar* specifically (its `contribute` is cheap at 14, so it rarely triggers the scarcity hint, and its persona/sampling keep it on contribute even when hinted). Do not start Phase 2 on the strength of the economy lever.

## Design & Reasoning Notes

- Concurrent comparators (not archived Stage-3 reuse): `gemma4:26b` sampling is unseeded, so `0`/`sub`/`adv` were paired in the same sweep.
- The HALT verdict is qualitative-robust (artisan specializes; jsd misses the floor by a wide margin at every seed); numeric values are 3-point estimates.
- No persona tuning (ADR 0008 constraint carried forward) — the scholar's contribute-inertia is a property of the unmodified persona + cost table.

## Documentation

`docs/economy-stage4-findings.md`, `docs/adr/0010-action-economy-stage4-adv-read.md`. Generated run data (`data/econ-stage4-*`, `harvest/econ-stage4-*`) is untracked and will be cleared after merge.

## Post-Merge Recommendations

1. Clear the Stage-4 run artifacts (`data/econ-stage4-*`, `harvest/econ-stage4-*`, `/tmp/econ-stage4-*`) — all numbers are preserved here.
2. If the arc continues, the next intervention targets scholar differentiation (e.g. make the scholar's `contribute` expensive, or give it individual scarcity on contribute) against the same bar: jsd ≥ 0.25 across seeds. Otherwise park the arc — the economy lever is necessary-ish but not sufficient (now shown twice: ADR 0009 co-drift, ADR 0010 one-sided).