### PR TITLE
feat(economy): bal mode — balanced contribute cost to specialize the scholar (ADR 0010 follow-up)

### DIFF
--- a/docs/adr/0011-action-economy-stage5-bal-read.md
+++ b/docs/adr/0011-action-economy-stage5-bal-read.md
@@ -1,0 +1,166 @@
+# ADR 0011: Action-economy Stage 5 — balanced-contribute (`bal`) verb-diversity A/B read (Gate 9)
+
+**Status:** Accepted (measurement record) — records the falsifiable Stage 5 read that tests
+the ADR 0010 follow-up intervention (the balanced `contribute` cost that makes the scholar's
+contribute dear so its scarcity hint fires).
+**Halt decision: HALT stays.** `bal` robustly specializes the *scholar* (the missing half of
+Stage 4) at all three seeds, but cross-agent `jsd_norm` lands a stable ~0.237, ~0.013 short of
+the 0.25 Gate 9 floor. No PASS, so the ADR 0007 substrate thesis remains unproven. The miss is
+small, consistent, and has a single pre-identified cause (R2); see the decision below for the
+one remaining well-motivated lever vs. park.
+
+**Date:** 2026-06-08
+
+## Context
+
+ADR 0010 (Stage 4) found the honest hint (`adv`) robustly specializes the **artisan** (Aki
+chosen-craft → ~0.33) but leaves the **scholar** a ~0.92–0.96 `contribute` monoculture (Cy
+chosen-study flat at ~0.03). Root cause: the scholar's `contribute` costs only 14, so it is
+almost always affordable and the scarcity hint never fires for Cy. Cross-agent `jsd_norm`
+therefore topped out at a stable ~0.16 — one-sided specialization, which cannot clear a
+*cross-agent* divergence floor.
+
+PR #54 shipped the fix as a new feature-flagged mode **`bal`**: `derive_balanced_table` raises
+every role's `contribute` to the dearest in the table (the artisan's 22) while leaving each
+role's cheap specialty untouched. A contribute-heavy scholar now drains, so its (already
+honest, `adv`) hint fires and names `study`, and the executor substitutes its free contributes
+toward `study`. `bal` keeps the `adv` hint selector, so the artisan still specializes into
+`craft`. `bal` vs `adv` isolates exactly one variable: the scholar's contribute cost.
+
+Gate 9 PASS = chosen `entropy_norm ≥ 0.35` AND chosen `jsd_norm ≥ 0.25`. The headline is
+`jsd_norm`. Pre-registered before reading (runbook): pass iff Cy's chosen-study share rises
+materially under `bal` (vs ~0.03 under `adv`) AND its chosen-contribute share falls.
+
+## Method
+
+- Runner (per mode `{0, adv, bal}` × seed `{42, 38, 7}`) into isolated state dirs, model
+  `gemma4:26b`, ~6.3 h / ~3760 agent events each:
+
+  ```bash
+  MICROVERSE_ECONOMY=$MODE uv run python -m microverse.run --ticks 3000 --tempo 0 --seed $SEED
+  ```
+- All run in **one sweep** (concurrent comparators; `gemma4:26b` sampling is unseeded, so
+  `adv`/`0` are paired with `bal`, not reused from Stage 4 — the `adv`/`0` point values differ
+  from ADR 0010 while the qualitative verdict reproduces, see Findings 4).
+- Measurement: `scripts/spike_workshop_measure.py` `gate9_verb_diversity`, chosen stream;
+  scene-forced contributes and parse-fallback rests excluded as non-choices.
+- Quality gate (per-agent OWN specialty): `aki_craft`, `cy_study`, `cy_contrib`, and
+  `novelty_energy_hint_conflict` (cumulative-metric MAX, not SUM) recorded per run.
+
+## Results (chosen stream)
+
+`aki_craft` = Aki's chosen share of the artisan specialty (craft); `cy_study` = Cy's chosen
+share of the scholar specialty (study); `cy_contrib` = Cy's chosen contribute share. Mode `0`
+shares are executed (`parsed_verb` unstamped with the economy off; chosen ≡ executed when
+nothing substitutes). `econ_sub` = economy substitution rate.
+
+| mode  | seed | entropy_norm | jsd_norm | aki_craft | cy_study | cy_contrib | conflict | econ_sub | Gate 9 |
+|-------|------|-------------:|---------:|----------:|---------:|-----------:|---------:|---------:|:------:|
+| `0`   | 42   | 0.253        | 0.014    | 0.028     | 0.012    | 0.930      | 0        | 0.000    | FAIL   |
+| `adv` | 42   | 0.381        | 0.188    | 0.258     | 0.021    | 0.960      | 312      | 0.176    | FAIL   |
+| `bal` | 42   | 0.544        | 0.235    | 0.258     | 0.168    | 0.770      | 432      | 0.233    | FAIL   |
+| `0`   | 38   | 0.256        | 0.016    | 0.023     | 0.020    | 0.923      | 0        | 0.000    | FAIL   |
+| `adv` | 38   | 0.358        | 0.169    | 0.230     | 0.011    | 0.966      | 124      | 0.214    | FAIL   |
+| `bal` | 38   | 0.543        | 0.244    | 0.239     | 0.170    | 0.772      | 431      | 0.259    | FAIL   |
+| `0`   | 7    | 0.253        | 0.012    | 0.021     | 0.014    | 0.923      | 0        | 0.000    | FAIL   |
+| `adv` | 7    | 0.357        | 0.157    | 0.220     | 0.018    | 0.961      | 73       | 0.206    | FAIL   |
+| `bal` | 7    | 0.544        | 0.232    | 0.258     | 0.170    | 0.773      | 424      | 0.249    | FAIL   |
+
+Means: jsd `0`/`adv`/`bal` 0.014 / 0.171 / **0.237**. `cy_study` 0.015 / 0.017 / **0.169**;
+`cy_contrib` 0.925 / 0.962 / **0.772**; `aki_craft` 0.024 / 0.236 / 0.252; entropy 0.254 /
+0.365 / **0.544**.
+
+## Findings
+
+1. **`bal` robustly specializes the scholar — the missing half of Stage 4.** Cy chosen-study
+   ~0.017(adv)→ **~0.169(bal)** and chosen-contribute ~0.962(adv)→ **~0.772(bal)**, near-identical
+   at all three seeds (study 0.168/0.170/0.170; contribute 0.770/0.772/0.773). The pre-registered
+   mechanism criterion (scholar study rises materially AND contribute falls) **passes cleanly and
+   reproducibly**. The lever does exactly what ADR 0010 predicted; the scholar's inertia named as
+   the Stage-4 binding constraint *was* breakable by making its contribute dear.
+
+2. **Gate 9 still FAILS at every seed — but only on `jsd`, and only just.** Cross-agent
+   `jsd_norm` is 0.235 / 0.244 / 0.232 (mean **0.237**), a stable ~0.013 below the 0.25 floor.
+   Entropy clears the 0.35 floor easily and consistently (0.544). Unlike Stage 4 (which missed by
+   a wide ~0.09 margin with a flat scholar), Stage 5 misses by a hair with *both* agents
+   specialized. This is a near-pass, not a structural failure.
+
+3. **The world is now genuinely two-profile.** `bal` lifts entropy to 0.544 (vs `adv` 0.365,
+   `0` 0.254) with both agents holding distinct specialties (Aki craft ~0.25, Cy study ~0.17)
+   over a *shared, reduced* contribute floor (~0.77). The residual contribute mass is the binding
+   term: with each agent still ~0.77 contribute, the distributions overlap too much for jsd to
+   clear 0.25. The lever moved the scholar but did not move it *far enough*.
+
+4. **The `adv`/`0` comparators reproduce Stage 4 qualitatively.** Fresh unseeded `adv` runs give
+   jsd 0.188/0.169/0.157 (Stage-4 was 0.175/0.168/0.143) with the scholar stuck on contribute
+   (~0.96) — the artisan-only specialization reproduces even though point values drift. This
+   confirms the `bal` effect (Finding 1) is causal to the balanced cost, not a sweep artifact.
+
+5. **R4 (novelty vs energy hint) rises but is still not the binding cap.** Conflict counts climb
+   to ~424–432 under `bal` (vs `adv` 73–312) — expected, since both agents are now pushed off
+   their dominant verbs so novelty fights both — but at ~430 over ~3760 events (~11%) it is not
+   what holds jsd under 0.25. The binding term is residual shared contribute (Finding 3), not the
+   hint fight. R2, not R4, is the lever.
+
+## Decision
+
+**`bal` is necessary and effective for the scholar — the first time both agents specialize — but
+the society lands a near-miss. HALT stays (no PASS).**
+
+Stage 4 left the scholar as the missing ingredient; `bal` supplies it, robustly and reproducibly.
+That is a real, falsifiable advance: an identity-independent economy change moved *both* roles to
+their own specialties. But Gate 9 requires the two distributions to diverge past 0.25, and a
+residual ~0.77 shared contribute floor holds the mean at 0.237. Per the Stage-5 pre-registration,
+a failed `bal` would mean "the economy approach is exhausted, park the arc." That framing assumed
+`bal` would fail *because the scholar wouldn't move*. It did move — so the strict "exhausted"
+conclusion does not cleanly apply, and the honest read is a near-pass with a single,
+pre-identified residual cause:
+
+- **R2 (pre-registered in the runbook): cost 22 does not drain the lower-weight scholar enough.**
+  Cy has `soul_tokens=70` (vs Aki 100), is scheduled less often, and regenerates more between
+  actions, so balanced contribute = 22 net-drains it only to ~0.77, not lower. The runbook already
+  flagged the fix: make `derive_balanced_table`'s target a config knob and raise it above 22 to
+  drain the scholar harder → lower `cy_contrib` → higher `jsd`. This is one well-motivated tune,
+  not a new mechanism, and the Stage-5 data (near-identical 3-seed near-miss with a known residual
+  term) makes it the clearest remaining path to a PASS.
+
+**This is a genuine fork for the operator, not a unilateral call**, because (a) it is live-compute
+spend (~6 runs × ~6 h) and (b) chasing a 0.013 gap risks goalpost-tuning the threshold. The two
+honest options:
+
+- **Tune-to-clear (R2):** raise balanced contribute (e.g. 26–30), re-run `{adv, bal}` × `{42, 38,
+  7}`. If `cy_contrib` falls below ~0.6 and jsd crosses 0.25 at all three seeds, Gate 9 PASSes and
+  Phase 2 is unblocked. Pre-register the new target and pass rule before reading.
+- **Park the arc:** treat the consistent ~0.237 near-miss as the economy lever's ceiling on a
+  two-resident roster and pursue a different mechanism (e.g. a larger heterogeneous roster, where
+  the two-agent JSD coarseness noted in Limitations may itself be the constraint).
+
+Recommended: one R2 tune-to-clear run, because the residual cause is specific, pre-identified, and
+mechanical, and the world is already two-profile — but the call is the operator's.
+
+## Limitations
+
+- Three seeds at scale; the qualitative verdict (both agents specialize robustly; jsd misses the
+  floor by a hair at every seed) is stable, but the numeric values are 3-point estimates.
+- Two-resident roster (Aki/artisan, Cy/scholar). JSD across two agents is a coarse divergence
+  estimate; a residual shared-contribute floor caps it. A larger, more heterogeneous roster could
+  change the dynamics and is untested.
+- The spike deliberately did not tune persona prompts (ADR 0008 constraint carried forward); the
+  scholar's residual contribute floor is a property of the unmodified persona + balanced cost
+  table at contribute = 22.
+
+## Reproduction
+
+```bash
+# per mode in {0, adv, bal}, seed in {42, 38, 7}:
+MICROVERSE_ECONOMY=$MODE \
+MICROVERSE_DATA=data/econ-stage5-$MODE-s$SEED \
+MICROVERSE_HARVEST=harvest/econ-stage5-$MODE-s$SEED \
+  uv run python -m microverse.run --ticks 3000 --tempo 0 --seed $SEED
+uv run python scripts/spike_workshop_measure.py \
+  --data data/econ-stage5-$MODE-s$SEED --harvest harvest/econ-stage5-$MODE-s$SEED
+# read .gate_9_verb_diversity.chosen.{society_entropy_norm,jsd_norm} and .pass
+```
+
+Runbook: `docs/economy-stage5-runbook.md`. Findings: `docs/economy-stage5-findings.md`.
+Mechanism + offline tests: PR #54. Stage 4 read: ADR 0010 / `docs/economy-stage4-findings.md`.

--- a/docs/economy-stage5-findings.md
+++ b/docs/economy-stage5-findings.md
@@ -1,0 +1,115 @@
+# Action-economy Stage 5 findings — balanced contribute cost (`bal` mode)
+
+Operator note recording the Stage 5 live A/B that feeds **ADR 0011**. The ADR 0008/0009/0010
+HALT stays in force; this records the read that informs it. Mechanism + offline tests shipped
+in PR #54; this is the deferred live run from `docs/economy-stage5-runbook.md`.
+
+## Setup
+
+- Runner (per mode `{0, adv, bal}` × seed `{42, 38, 7}`), model `gemma4:26b`, isolated
+  `MICROVERSE_DATA`/`MICROVERSE_HARVEST` per run, ~6.3 h / ~3760 agent events each:
+
+  ```bash
+  MICROVERSE_ECONOMY=$MODE uv run python -m microverse.run --ticks 3000 --tempo 0 --seed $SEED
+  ```
+- Modes: `0` (economy off / baseline), `adv` (substitution lever + honest hint, the Stage-4
+  state where only the artisan specializes), `bal` (`adv` + `derive_balanced_table` raising
+  every role's `contribute` to the dearest cost, 22, so the scholar's contribute drains and its
+  scarcity hint fires — ADR 0010 fix).
+- Seeds all run as concurrent comparators — `gemma4:26b` sampling is unseeded, so `0`/`adv`/`bal`
+  were paired in the same sweep, not compared to archived Stage-4 reads.
+- Metric: `gate9_verb_diversity` (`scripts/spike_workshop_measure.py`), **chosen**
+  (`parsed_verb`) stream. **PASS = chosen `entropy_norm ≥ 0.35` AND chosen `jsd_norm ≥ 0.25`.**
+  Primary read is `jsd_norm` (cross-agent divergence — ADR 0007's real target).
+- Pre-registered mechanism criterion (runbook, before reading): pass iff Cy's chosen-study share
+  rises materially under `bal` (vs ~0.03 under `adv`) AND its chosen-contribute share falls.
+
+## Results (all 9 runs)
+
+`aki_craft` = Aki's **chosen** (`parsed_verb`) share of its OWN specialty (artisan: craft).
+`cy_study` = Cy's chosen share of its OWN specialty (scholar: study); `cy_contrib` = Cy's chosen
+contribute share. `conflict` = true `novelty_energy_hint_conflict` count (the cumulative metric's
+MAX; the per-run progress log printed a SUM, ~1000× inflated — disregard that column there).
+`econ_sub` = economy substitution rate. For mode `0` the economy is off so `parsed_verb` is
+unstamped; its shares are executed (chosen ≡ executed when nothing substitutes).
+
+| mode  | seed | entropy_norm | jsd_norm | aki_craft | cy_study | cy_contrib | conflict | econ_sub | Gate 9 |
+|-------|------|-------------:|---------:|----------:|---------:|-----------:|---------:|---------:|:------:|
+| `0`   | 42   | 0.253        | 0.014    | 0.028     | 0.012    | 0.930      | 0        | 0.000    | FAIL   |
+| `adv` | 42   | 0.381        | 0.188    | 0.258     | 0.021    | 0.960      | 312      | 0.176    | FAIL   |
+| `bal` | 42   | 0.544        | **0.235**| 0.258     | **0.168**| **0.770**  | 432      | 0.233    | FAIL   |
+| `0`   | 38   | 0.256        | 0.016    | 0.023     | 0.020    | 0.923      | 0        | 0.000    | FAIL   |
+| `adv` | 38   | 0.358        | 0.169    | 0.230     | 0.011    | 0.966      | 124      | 0.214    | FAIL   |
+| `bal` | 38   | 0.543        | **0.244**| 0.239     | **0.170**| **0.772**  | 431      | 0.259    | FAIL   |
+| `0`   | 7    | 0.253        | 0.012    | 0.021     | 0.014    | 0.923      | 0        | 0.000    | FAIL   |
+| `adv` | 7    | 0.357        | 0.157    | 0.220     | 0.018    | 0.961      | 73       | 0.206    | FAIL   |
+| `bal` | 7    | 0.544        | **0.232**| 0.258     | **0.170**| **0.773**  | 424      | 0.249    | FAIL   |
+
+Means: `0`/`adv`/`bal` jsd 0.014 / 0.171 / **0.237**. `cy_study` 0.015 / 0.017 / **0.169** —
+the scholar moves only under `bal`. `cy_contrib` 0.925 / 0.962 / **0.772** — the scholar's
+contribute monoculture breaks only under `bal`. `aki_craft` 0.024 / 0.236 / 0.252 — the artisan
+holds its `adv` specialty. Entropy 0.254 / 0.365 / **0.544**.
+
+## Read
+
+1. **`bal` robustly specializes the SCHOLAR — the missing half of Stage 4.** Cy's chosen-study
+   share is ~0.017 (adv) → **~0.169 (bal)** and chosen-contribute ~0.962 (adv) → **~0.772 (bal)**,
+   near-identical at all three seeds (study 0.168 / 0.170 / 0.170; contribute 0.770 / 0.772 /
+   0.773). The pre-registered mechanism criterion passes cleanly and reproducibly. Making the
+   scholar's contribute dear fires its scarcity hint and the executor substitutes toward `study`,
+   exactly as ADR 0010 predicted. The scholar inertia named the Stage-4 binding constraint *was*
+   breakable by the cost table alone — no persona tuning.
+
+2. **Both agents now specialize — the world is genuinely two-profile.** `bal` holds the artisan
+   on craft (~0.25) AND moves the scholar onto study (~0.17), over a shared but *reduced*
+   contribute floor (~0.77 vs ~0.96 under `adv`). Entropy jumps to 0.544 (clears the 0.35 floor at
+   every seed). This is the first time in the arc that *both* residents hold distinct specialties.
+
+3. **But Gate 9 still FAILS — on `jsd` alone, by a hair.** Cross-agent `jsd_norm` is 0.235 / 0.244
+   / 0.232 (mean **0.237**), a stable ~0.013 below the 0.25 floor at all three seeds. Stage 4
+   missed by a wide ~0.09 with a flat scholar; Stage 5 misses by a hair with both agents moved.
+   The binding term is the residual ~0.77 shared contribute mass: with each agent still ~0.77
+   contribute, the two distributions overlap too much for jsd to clear 0.25. The lever moved the
+   scholar but not *far enough*.
+
+4. **The `adv`/`0` comparators reproduce Stage 4 qualitatively.** Fresh unseeded `adv` runs give
+   jsd 0.188 / 0.169 / 0.157 (Stage-4: 0.175 / 0.168 / 0.143) with the scholar stuck on contribute
+   (~0.96) — artisan-only specialization reproduces even though point values drift. This confirms
+   the `bal` effect is causal to the balanced cost, not a sweep artifact.
+
+5. **R4 (novelty vs energy hint conflict) rises but is not the binding cap.** Conflict climbs to
+   ~424–432 under `bal` (vs `adv` 73–312) — expected, since both agents are pushed off their
+   dominant verbs so novelty fights both — but at ~430 over ~3760 events (~11%) it is not what
+   holds jsd under 0.25. The binding term is residual shared contribute (Read 3), not the hint
+   fight. R2 (drain margin), not R4, is the lever.
+
+## Decision: HALT stays (see ADR 0011)
+
+`bal` is **necessary and effective for the scholar — the first time both agents specialize** —
+but the society lands a consistent near-miss (jsd ~0.237 vs the 0.25 floor). No PASS, so the ADR
+0008/0009/0010 HALT stays in force.
+
+The Stage-5 pre-registration said a failed `bal` would mean "the economy approach is exhausted,
+park the arc." That framing assumed `bal` would fail *because the scholar wouldn't move*. It moved,
+robustly — so the strict "exhausted" verdict does not cleanly apply. The honest read is a near-pass
+with a single pre-identified residual cause:
+
+- **R2 (pre-registered in the runbook): balanced contribute = 22 does not drain the lower-weight
+  scholar enough.** Cy (`soul_tokens=70`, vs Aki 100) is scheduled less often and regenerates more
+  between actions, so its contribute net-drains only to ~0.77. The runbook already flagged the fix:
+  make `derive_balanced_table`'s target a config knob and raise it above 22 → lower `cy_contrib` →
+  higher `jsd`. One well-motivated tune, not a new mechanism.
+
+**This is a genuine operator fork, not a unilateral call** — it is live-compute spend (~6 runs ×
+~6 h) and chasing a 0.013 gap risks goalpost-tuning the threshold:
+
+- **Tune-to-clear (R2):** raise balanced contribute (e.g. 26–30), re-run `{adv, bal}` × `{42, 38,
+  7}`; pre-register the new target and pass rule before reading. If `cy_contrib` falls below ~0.6
+  and jsd crosses 0.25 at all three seeds, Gate 9 PASSes and Phase 2 is unblocked.
+- **Park the arc:** treat the consistent ~0.237 near-miss as the economy lever's two-resident
+  ceiling and pursue a different mechanism (e.g. a larger heterogeneous roster — the two-agent JSD
+  coarseness may itself be the constraint).
+
+Recommended: one R2 tune-to-clear run (specific, pre-identified, mechanical cause; world already
+two-profile) — but the call is the operator's. See
+`docs/adr/0011-action-economy-stage5-bal-read.md`.

--- a/docs/economy-stage5-runbook.md
+++ b/docs/economy-stage5-runbook.md
@@ -1,0 +1,102 @@
+# Action-economy Stage 5 runbook — balanced contribute cost (`bal` mode)
+
+Operator handoff for the **deferred** Stage 5 live A/B testing the ADR 0010 follow-up: does
+making the scholar's `contribute` dear push it to its `study` specialty and finally clear
+Gate 9? This PR ships the `bal` mechanism + offline tests only; the live run is a separate
+scheduled compute job (~6 runs × ~6 h on `gemma4:26b`). The ADR 0008/0009/0010 HALT stays in
+force until a PASS read.
+
+## Why
+
+Stage 4 (ADR 0010) found the honest hint (`adv`) robustly specializes the **artisan** (Aki
+chosen-craft 0.025→0.33, all three seeds) but leaves the **scholar** a ~0.92–0.94 `contribute`
+monoculture (Cy chosen-study flat at ~0.03). Root cause: the scholar's `contribute` costs only
+14, so it is almost always affordable and the scarcity hint never fires for Cy. Cross-agent jsd
+therefore lands a stable ~0.16, short of the 0.25 floor — one-sided specialization.
+
+Gate 9's calibration says the *target* is reachable on two agents: distinct specialists with
+~40% shared `contribute` each → jsd 0.6 (PASS); fully disjoint → 1.0. So if a lever could push
+the scholar to `study`, the two-agent world plausibly clears 0.25.
+
+`bal` mode does exactly that: `derive_balanced_table` raises every role's `contribute` to the
+dearest in the table (the artisan's 22) while leaving each role's cheap specialty untouched.
+A contribute-heavy scholar now drains, so its (already honest, `adv`) hint fires and names
+`study`, and the executor substitutes its free contributes toward `study`. `bal` keeps the
+`adv` hint selector, so the artisan still specializes into `craft`.
+
+## A/B matrix
+
+| mode  | contribute cost | hint selector | artisan | scholar hint fires? |
+|-------|-----------------|---------------|---------|---------------------|
+| `0`   | role (off)      | —             | n/a     | n/a                 |
+| `adv` | role (art 22, sch 14) | perceived | craft   | rarely (cheap contribute) |
+| `bal` | **22 for every role** | perceived | craft   | **yes** (dear contribute) |
+
+`bal` vs `adv` isolates exactly one variable: the scholar's contribute cost. `adv` vs `0` is
+the prior Stage-4 result (carried as context).
+
+## Run (deferred — separate compute job)
+
+Run `{0, adv, bal}` × seeds `{42, 38, 7}` × 3000 ticks **in one sweep** (concurrent
+comparators — `gemma4:26b` sampling is unseeded). Reuse the Stage-3 runner pattern:
+
+```bash
+for SEED in 42 38 7; do
+  for M in 0 adv bal; do
+    TAG="${M}-s${SEED}"
+    MICROVERSE_ECONOMY=$M \
+    MICROVERSE_DATA=data/econ-stage5-$TAG \
+    MICROVERSE_HARVEST=harvest/econ-stage5-$TAG \
+      uv run python -m microverse.run --ticks 3000 --tempo 0 --seed $SEED
+    uv run python scripts/spike_workshop_measure.py \
+      --data data/econ-stage5-$TAG --harvest harvest/econ-stage5-$TAG
+  done
+done
+```
+
+## Read & acceptance
+
+**Primary bar (Gate 9, chosen stream):** `jsd_norm ≥ 0.25` AND `entropy_norm ≥ 0.35` across all
+three seeds. Pre-register before reading: **pass iff Cy's chosen-study share rises materially
+under `bal` (vs ~0.03 under `adv`) AND its chosen-contribute share falls**, i.e. the scholar
+actually specializes. If Cy stays ~93% contribute, `bal` failed even if jsd wobbles.
+
+**Per-agent specialty shares (the load-bearing read — measure each agent against its OWN
+specialty):**
+- `aki_craft` = Aki chosen `parsed_verb=craft` share (should stay ~0.33, as under `adv`).
+- `cy_study` = Cy chosen `parsed_verb=study` share (the test: does it rise above ~0.03?).
+- `cy_contribute` = Cy chosen contribute share (should fall below ~0.93 if `bal` works).
+
+Extract with:
+```sql
+SELECT printf('%.3f', AVG(CASE WHEN json_extract(payload_json,'$.parsed_verb')='study'
+  THEN 1.0 ELSE 0.0 END)) FROM events WHERE actor='Cy'
+  AND json_extract(payload_json,'$.parsed_verb') IS NOT NULL;
+```
+
+**Quality counters (use `MAX`, not `SUM` — the metric is a cumulative time-series):**
+`novelty_energy_hint_conflict`, `artisan_empty_craft_coerced`, `parse_fallback`. Expect the
+conflict count to rise under `bal` (now both agents are pushed off their dominant verbs, so
+novelty fights both).
+
+## Risks
+
+- **R1 — the scholar still won't move.** Even hinted and drained, `gemma4:26b` may keep choosing
+  `contribute` (persona/sampling inertia; the scholar's factual sampling at temp 0.6 concentrates
+  on its modal verb). The hint is a soft nudge; ADR 0010 showed the artisan took it but the
+  scholar is a different persona. This is the central unknown and only the live run answers it.
+- **R2 — cost 22 may not drain the lower-weight scholar enough.** Cy has `soul_tokens=70` (vs
+  Aki 100) so it is scheduled less often and regenerates more between actions; the per-action
+  drain margin at contribute 22 is thin. It still net-drains under sustained 93% contribute, but
+  if the live `cy_contribute` barely falls, raise `derive_balanced_table`'s target above 22 (make
+  it a config knob) and re-run. Check the live `cy` energy trajectory before concluding R1 vs R2.
+- **R3 — over-correction.** If both agents are pushed hard off contribute, scenes (which need a
+  `contribute` initiator) may thin out; watch `scene_completed`. `bal` is not a scene-gate mode,
+  so scene *initiation* is not energy-gated, but a drained roster contributes less freely.
+- **R4 — novelty vs energy conflict, now two-sided.** With both agents nudged to specialties,
+  the novelty hint fights both; conflict counts will rise. If high, the next step is to suppress
+  the novelty hint for an agent's own specialty under `bal` (flagged in ADR 0010 R4).
+
+After the read, write the Stage 5 findings + ADR follow-up with the per-seed pass/fail table
+and the PASS/HALT decision. If `bal` also fails, the economy approach is exhausted (insufficient
+three times) and the arc should be parked for a different mechanism.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ build-backend = "uv_build"
 [dependency-groups]
 dev = [
     "mypy>=2.1.0",
+    # Pin patched pip: PYSEC-2026-196 affects pip 26.1 (fixed 26.1.2). uv
+    # bootstraps pip into the venv that pip-audit scans, so constrain it here
+    # rather than ignoring a *fixable* advisory (the --ignore-vuln list in CI is
+    # reserved for the unfixable ollama-server false-positives).
+    "pip>=26.1.2",
     "pip-audit>=2.10.0",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",

--- a/scripts/replay_economy.py
+++ b/scripts/replay_economy.py
@@ -197,9 +197,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     p.add_argument(
         "--mode",
         default="1",
-        choices=("1", "flat", "sub", "throttle", "adv"),
-        help="economy cost-table mode (role-advantage for all but 'flat'); 'adv' is "
-        "identical to 'sub' offline — it differs only in the live energy_hint selector",
+        choices=("1", "flat", "sub", "throttle", "adv", "bal"),
+        help="economy cost-table mode (role-advantage for all but 'flat'/'bal'); 'adv' is "
+        "identical to 'sub' offline (it differs only in the live energy_hint selector), while "
+        "'bal' uses the balanced cost table (every role's contribute raised to the dearest)",
     )
     p.add_argument("--ticks", type=int, default=2000, help="Stage 1 tick budget")
     p.add_argument("--seed", type=int, default=42, help="Stage 1 RNG seed")

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -240,11 +240,18 @@ SCENE_MIN_PEERS: int = 1
 # toward its OWN advantage instead of the shared payload-free escape that caused
 # co-drift. The selector differs (run._compute_energy_hint dispatches on adv);
 # the cost table and gates are identical to ``sub``.
-VALID_ECONOMY_MODES: frozenset[str] = frozenset({"0", "1", "flat", "throttle", "sub", "adv"})
+# ``bal`` (balanced contribute, ADR 0010 follow-up) == ``adv`` (honest hint) PLUS
+# a cost table where every role's contribute is raised to the dearest (22), so a
+# contribute-heavy scholar drains and its scarcity hint fires (Stage 4 showed adv
+# specializes the artisan but not the scholar, whose cheap contribute never
+# triggers the hint). Same hint selector as ``adv``; differs only in the table.
+VALID_ECONOMY_MODES: frozenset[str] = frozenset(
+    {"0", "1", "flat", "throttle", "sub", "adv", "bal"}
+)
 ECONOMY_MODE: str = os.environ.get("MICROVERSE_ECONOMY", "0")
 ECONOMY_ENABLED: bool = ECONOMY_MODE != "0"
 _ECONOMY_SCENE_GATE: bool = ECONOMY_MODE in ("1", "flat", "throttle")
-_ECONOMY_SUBSTITUTE: bool = ECONOMY_MODE in ("1", "flat", "sub", "adv")
+_ECONOMY_SUBSTITUTE: bool = ECONOMY_MODE in ("1", "flat", "sub", "adv", "bal")
 
 # Finite stamina pool. Regen sits between the cheap specialty (~6) and the
 # dear contribute (~22) so a role can sustain its specialty indefinitely but

--- a/src/microverse/config.py
+++ b/src/microverse/config.py
@@ -245,9 +245,7 @@ SCENE_MIN_PEERS: int = 1
 # contribute-heavy scholar drains and its scarcity hint fires (Stage 4 showed adv
 # specializes the artisan but not the scholar, whose cheap contribute never
 # triggers the hint). Same hint selector as ``adv``; differs only in the table.
-VALID_ECONOMY_MODES: frozenset[str] = frozenset(
-    {"0", "1", "flat", "throttle", "sub", "adv", "bal"}
-)
+VALID_ECONOMY_MODES: frozenset[str] = frozenset({"0", "1", "flat", "throttle", "sub", "adv", "bal"})
 ECONOMY_MODE: str = os.environ.get("MICROVERSE_ECONOMY", "0")
 ECONOMY_ENABLED: bool = ECONOMY_MODE != "0"
 _ECONOMY_SCENE_GATE: bool = ECONOMY_MODE in ("1", "flat", "throttle")

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -330,12 +330,13 @@ def _select_easy_verb(energy: EnergyLedger, agent: Agent) -> str | None:
     reach). Single source of truth for the selector so the hint text and the R4
     conflict counter never disagree.
 
-    ``adv`` names the agent's TRUE cheapest affordable verb including its payload
-    specialty (craft), so each role is nudged toward its own advantage.
+    ``adv``/``bal`` name the agent's TRUE cheapest affordable verb including its
+    payload specialty (craft), so each role is nudged toward its own advantage
+    (``bal`` adds a balanced cost table so the scholar's hint also fires).
     ``sub``/``1``/``flat`` keep the legacy selector (excludes the payload verbs)
     so their prior reads stay byte-reproducible for the A/B. The executor's
     substitution target is unchanged in every mode (still payload-free)."""
-    if config.ECONOMY_MODE == "adv":
+    if config.ECONOMY_MODE in ("adv", "bal"):
         return energy.cheapest_affordable_perceived(agent.name, agent.role)
     return energy.cheapest_affordable_productive(agent.name, agent.role)
 

--- a/src/microverse/world/economy.py
+++ b/src/microverse/world/economy.py
@@ -86,18 +86,43 @@ def derive_flat_table(table: CostTable) -> dict[str, dict[str, float]]:
     return flat
 
 
+def derive_balanced_table(table: CostTable) -> dict[str, dict[str, float]]:
+    """Balanced-contribute variant of ``table`` (ADR 0010 follow-up, mode ``bal``).
+
+    Raises every role's ``contribute`` to the dearest one in the table (the
+    artisan's 22) and leaves everything else — including each role's cheap
+    specialty — untouched. Stage 4 found the honest hint (``adv``) specializes
+    the artisan but not the scholar, because the scholar's ``contribute`` is
+    cheap (14) and so almost always affordable: its scarcity hint never fires.
+    Making every role's ``contribute`` equally dear means a contribute-heavy
+    scholar drains too, so the (still honest) hint fires and names its ``study``
+    specialty. Comparative advantage is preserved: each role's strict specialty
+    is unchanged, only the shared escape verb ``contribute`` becomes uniformly
+    expensive.
+    """
+    dearest = max(costs["contribute"] for costs in table.values())
+    return {
+        role: {v: (dearest if v == "contribute" else cost) for v, cost in costs.items()}
+        for role, costs in table.items()
+    }
+
+
 def build_cost_table(mode: str) -> dict[str, dict[str, float]]:
     """Resolve the per-mode cost table.
 
-    ``"flat"`` returns the role-agnostic control; every other economy mode
-    (``"1"``, ``"sub"``, ``"throttle"``, ``"adv"``) uses the role-advantage
-    table. ``"adv"`` shares ``"sub"``'s costs and differs only in the
-    ``energy_hint`` selector (see ``run._compute_energy_hint``).
+    ``"flat"`` returns the role-agnostic control; ``"bal"`` returns the
+    balanced-contribute table (every role's contribute raised to the dearest);
+    every other economy mode (``"1"``, ``"sub"``, ``"throttle"``, ``"adv"``)
+    uses the role-advantage table. ``"adv"`` and ``"bal"`` share the ``adv``
+    energy-hint selector (see ``run._compute_energy_hint``); ``"bal"`` adds the
+    balanced cost table so the scholar's scarcity hint actually fires.
     """
     from microverse.config import VERB_COST_BY_ROLE
 
     if mode == "flat":
         return derive_flat_table(VERB_COST_BY_ROLE)
+    if mode == "bal":
+        return derive_balanced_table(VERB_COST_BY_ROLE)
     return {role: dict(costs) for role, costs in VERB_COST_BY_ROLE.items()}
 
 

--- a/src/microverse/world/economy.py
+++ b/src/microverse/world/economy.py
@@ -98,9 +98,13 @@ def derive_balanced_table(table: CostTable) -> dict[str, dict[str, float]]:
     scholar drains too, so the (still honest) hint fires and names its ``study``
     specialty. Comparative advantage is preserved: each role's strict specialty
     is unchanged, only the shared escape verb ``contribute`` becomes uniformly
-    expensive.
+    expensive. A role without a ``contribute`` entry is left untouched (no key is
+    added) and does not contribute to the ``dearest`` max (review).
     """
-    dearest = max(costs["contribute"] for costs in table.values())
+    dearest = max(
+        (costs["contribute"] for costs in table.values() if "contribute" in costs),
+        default=0.0,
+    )
     return {
         role: {v: (dearest if v == "contribute" else cost) for v, cost in costs.items()}
         for role, costs in table.items()

--- a/tests/test_economy_ledger.py
+++ b/tests/test_economy_ledger.py
@@ -11,7 +11,12 @@ from __future__ import annotations
 import pytest
 
 from microverse.config import ENERGY_MAX, ENERGY_REGEN_PER_TICK, VERB_COST_BY_ROLE
-from microverse.world.economy import EnergyLedger, build_cost_table, derive_flat_table
+from microverse.world.economy import (
+    EnergyLedger,
+    build_cost_table,
+    derive_balanced_table,
+    derive_flat_table,
+)
 
 
 @pytest.fixture
@@ -120,6 +125,58 @@ def test_build_cost_table_selects_by_mode():
     # ``adv`` (advantage-perception, ADR 0009 follow-up) is a substitution mode
     # that keeps the role-advantage table; only the energy-HINT selector differs.
     assert build_cost_table("adv") == VERB_COST_BY_ROLE
+    # ``bal`` (balanced contribute, ADR 0010 follow-up) raises every role's
+    # contribute to the dearest (the artisan's 22) so the scarcity hint fires for
+    # the scholar too; otherwise it is the advantage table.
+    assert build_cost_table("bal") == derive_balanced_table(VERB_COST_BY_ROLE)
+
+
+# --- bal mode: balanced (symmetric-dear) contribute cost (ADR 0010 follow-up) ---
+# Stage 4 found the honest hint specializes the artisan but not the scholar,
+# because the scholar's contribute is cheap (14) so its scarcity hint rarely
+# fires. ``bal`` raises every role's contribute to the dearest one (22) so a
+# contribute-heavy scholar drains and is hinted toward its study specialty, while
+# each role's cheap specialty (artisan craft 6, scholar study 6) is untouched.
+
+
+def test_derive_balanced_table_raises_every_contribute_to_the_dearest():
+    bal = derive_balanced_table(VERB_COST_BY_ROLE)
+    dearest = max(costs["contribute"] for costs in VERB_COST_BY_ROLE.values())  # artisan 22
+    for role, costs in VERB_COST_BY_ROLE.items():
+        assert bal[role]["contribute"] == dearest, f"{role} contribute must be the dearest"
+        assert bal[role]["rest"] == 0.0
+        # Every non-contribute, non-rest verb is unchanged: the specialty survives.
+        for v in costs:
+            if v not in ("contribute", "rest"):
+                assert bal[role][v] == costs[v], f"{role} {v} must be unchanged"
+
+
+def test_balanced_table_preserves_strict_specialty():
+    # Raising contribute must not disturb each role's single strict specialty.
+    bal = derive_balanced_table(VERB_COST_BY_ROLE)
+    assert min(bal["artisan"], key=lambda v: bal["artisan"][v]) == "rest"  # rest is 0
+    non_rest = {v: c for v, c in bal["scholar"].items() if v != "rest"}
+    assert min(non_rest, key=lambda v: non_rest[v]) == "study"  # scholar specialty intact
+
+
+def test_balanced_scholar_contribute_drains_while_study_sustains():
+    # Under the balanced table a contribute-heavy scholar drains below its
+    # (now-dear) contribute cost so the lever/hint can fire, while a study-heavy
+    # scholar stays sustainable (its specialty is untouched).
+    bal = derive_balanced_table(VERB_COST_BY_ROLE)
+    drained = EnergyLedger.fresh(["Cy"], max_energy=100.0, regen_per_tick=8.0, cost_table=bal)
+    for _ in range(40):  # contribute 22 > regen 8: drains to empty
+        drained.regen("Cy")
+        drained.deduct("Cy", "scholar", "contribute")
+    drained.regen("Cy")  # next tick's regen, before the action: pool ~8
+    assert not drained.can_afford("Cy", "scholar", "contribute")  # 22 out of reach
+    assert drained.can_afford("Cy", "scholar", "study")  # specialty (6) affordable
+
+    sustained = EnergyLedger.fresh(["Cy"], max_energy=100.0, regen_per_tick=8.0, cost_table=bal)
+    for _ in range(40):  # study 6 < regen 8: sustainable
+        sustained.regen("Cy")
+        sustained.deduct("Cy", "scholar", "study")
+    assert sustained.can_afford("Cy", "scholar", "contribute")
 
 
 def _events(n: int) -> list[tuple[str, str, str]]:

--- a/tests/test_economy_ledger.py
+++ b/tests/test_economy_ledger.py
@@ -154,9 +154,12 @@ def test_derive_balanced_table_raises_every_contribute_to_the_dearest():
 def test_balanced_table_preserves_strict_specialty():
     # Raising contribute must not disturb each role's single strict specialty.
     bal = derive_balanced_table(VERB_COST_BY_ROLE)
-    assert min(bal["artisan"], key=lambda v: bal["artisan"][v]) == "rest"  # rest is 0
-    non_rest = {v: c for v, c in bal["scholar"].items() if v != "rest"}
-    assert min(non_rest, key=lambda v: non_rest[v]) == "study"  # scholar specialty intact
+    # Excluding the always-free rest, each role's strict cheapest verb is still
+    # its specialty (raising contribute must not steal the title).
+    art = {v: c for v, c in bal["artisan"].items() if v != "rest"}
+    assert min(art, key=lambda v: art[v]) == "craft"  # artisan specialty intact
+    sch = {v: c for v, c in bal["scholar"].items() if v != "rest"}
+    assert min(sch, key=lambda v: sch[v]) == "study"  # scholar specialty intact
 
 
 def test_balanced_scholar_contribute_drains_while_study_sustains():

--- a/tests/test_economy_ledger.py
+++ b/tests/test_economy_ledger.py
@@ -151,6 +151,22 @@ def test_derive_balanced_table_raises_every_contribute_to_the_dearest():
                 assert bal[role][v] == costs[v], f"{role} {v} must be unchanged"
 
 
+def test_derive_balanced_table_leaves_role_without_contribute_untouched():
+    # The docstring promises a role with no "contribute" entry is left untouched
+    # (no key added) and is excluded from the dearest max. Exercise that branch
+    # directly with a synthetic table (Codex review): the cheaper-contribute role
+    # is still raised to the dearest, the contribute-less role is byte-identical.
+    synthetic = {
+        "artisan": {"contribute": 22.0, "craft": 6.0, "rest": 0.0},
+        "scholar": {"contribute": 14.0, "study": 6.0, "rest": 0.0},
+        "wanderer": {"travel": 4.0, "rest": 0.0},  # no contribute key
+    }
+    bal = derive_balanced_table(synthetic)
+    assert bal["scholar"]["contribute"] == 22.0  # cheaper contribute raised to dearest
+    assert "contribute" not in bal["wanderer"]  # no key fabricated
+    assert bal["wanderer"] == synthetic["wanderer"]  # role left wholly untouched
+
+
 def test_balanced_table_preserves_strict_specialty():
     # Raising contribute must not disturb each role's single strict specialty.
     bal = derive_balanced_table(VERB_COST_BY_ROLE)

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -37,7 +37,7 @@ def _economy(mode: str, *, energy_max: float = 100.0):
         patch.object(config, "ECONOMY_MODE", mode),
         patch.object(config, "ECONOMY_ENABLED", mode != "0"),
         patch.object(config, "_ECONOMY_SCENE_GATE", mode in ("1", "flat", "throttle")),
-        patch.object(config, "_ECONOMY_SUBSTITUTE", mode in ("1", "flat", "sub", "adv")),
+        patch.object(config, "_ECONOMY_SUBSTITUTE", mode in ("1", "flat", "sub", "adv", "bal")),
         patch.object(config, "ENERGY_MAX", energy_max),
     ):
         yield
@@ -230,6 +230,76 @@ def test_adv_is_a_valid_economy_mode():
     # adv is a recognized mode so run() does not fail-fast on it (it is the new
     # honest-hint substitution arm).
     assert "adv" in config.VALID_ECONOMY_MODES
+
+
+# --- bal mode: balanced contribute cost so the scholar's hint fires (ADR 0010 follow-up) ---
+# bal == adv (honest hint) PLUS a balanced cost table where every role's
+# contribute is dear (22). Under adv the scholar's cheap contribute (14) means
+# its scarcity hint rarely fires; bal makes a contribute-heavy scholar drain so
+# the hint fires and names its study specialty.
+
+
+def _bal_scholar_ledger(level: float) -> EnergyLedger:
+    from microverse.world.economy import derive_balanced_table
+
+    led = EnergyLedger.fresh(
+        ["Cy"],
+        max_energy=100.0,
+        regen_per_tick=8.0,
+        cost_table=derive_balanced_table(VERB_COST_BY_ROLE),
+    )
+    led._pool["Cy"] = level
+    return led
+
+
+def test_bal_is_a_valid_economy_mode():
+    assert "bal" in config.VALID_ECONOMY_MODES
+
+
+def test_bal_hint_fires_for_drained_scholar_naming_study():
+    # At pool 10 the balanced scholar affords study(6) but not contribute(22),
+    # speak(10 is exactly affordable -> not unaffordable), craft(18), travel(16):
+    # the hint fires and names study, the scholar's specialty.
+    led = _bal_scholar_ledger(10.0)
+    with _economy("bal"):
+        hint = _compute_energy_hint(led, Scholar(name="Cy"))
+    assert "study" in hint
+    assert "contribute" in hint  # contribute is now out of reach for the scholar
+
+
+def test_bal_uses_perceived_hint_like_adv_for_artisan():
+    # bal must keep the adv honest-hint selector so the artisan is still nudged to
+    # craft (its payload specialty), not the shared payload-free escape.
+    from microverse.world.economy import derive_balanced_table
+
+    led = EnergyLedger.fresh(
+        ["Aki"],
+        max_energy=100.0,
+        regen_per_tick=8.0,
+        cost_table=derive_balanced_table(VERB_COST_BY_ROLE),
+    )
+    led._pool["Aki"] = 15.0  # affords craft(6) but not study(14)/speak(16)/...
+    with _economy("bal"):
+        assert _energy_hint_verb(led, Artisan(name="Aki")) == "craft"
+
+
+def test_bal_pushes_scholar_off_contribute_where_adv_leaves_it_affordable():
+    # The isolation that motivates bal. At pool 16 the scholar can still afford
+    # contribute under the advantage table (cost 14) but NOT under the balanced
+    # table (cost 22). So adv's hint never flags contribute as out of reach,
+    # while bal's hint does and points the scholar at study.
+    adv_led = EnergyLedger.fresh(
+        ["Cy"], max_energy=100.0, regen_per_tick=8.0, cost_table=VERB_COST_BY_ROLE
+    )
+    adv_led._pool["Cy"] = 16.0  # advantage scholar contribute (14) still affordable
+    bal_led = _bal_scholar_ledger(16.0)  # balanced scholar contribute (22) out of reach
+    with _economy("adv"):
+        adv_hint = _compute_energy_hint(adv_led, Scholar(name="Cy"))
+    with _economy("bal"):
+        bal_hint = _compute_energy_hint(bal_led, Scholar(name="Cy"))
+    assert "contribute" not in adv_hint  # adv: scholar's contribute is cheap, never flagged
+    assert "contribute" in bal_hint  # bal: contribute is dear and out of reach
+    assert "study" in bal_hint  # ... so the scholar is nudged to its specialty
 
 
 # --- R4: novelty/energy hint conflict instrumentation (ADR 0009) ---

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import subprocess
+import sys
 from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
@@ -261,10 +263,17 @@ def test_bal_hint_fires_for_drained_scholar_naming_study():
     # speak(10 is exactly affordable -> not unaffordable), craft(18), travel(16):
     # the hint fires and names study, the scholar's specialty.
     led = _bal_scholar_ledger(10.0)
+    cy = Scholar(name="Cy")
     with _economy("bal"):
-        hint = _compute_energy_hint(led, Scholar(name="Cy"))
-    assert "study" in hint
-    assert "contribute" in hint  # contribute is now out of reach for the scholar
+        hint = _compute_energy_hint(led, cy)
+        easy_verb = _energy_hint_verb(led, cy)
+    # Structural, not substring: "study" must be the "comes easily" verb and
+    # "contribute" must sit in the out-of-reach clause, not merely appear
+    # somewhere in the free text (Codex review).
+    assert easy_verb == "study"
+    out_of_reach = hint.split(" feel out of reach", 1)[0]
+    assert "contribute" in out_of_reach  # contribute is now out of reach for the scholar
+    assert "study" not in out_of_reach  # ... and study is the escape, not blocked
 
 
 def test_bal_uses_perceived_hint_like_adv_for_artisan():
@@ -412,6 +421,30 @@ def test_lazy_attach_energy_noop_when_economy_off():
     spawned = Artisan(name="Zix")
     _lazy_attach_energy(spawned, None)  # economy off: no ledger to attach
     assert spawned._energy is None
+
+
+def test_bal_cold_import_wiring_matches_economy_helper():
+    """The _economy() helper hand-mirrors config's membership tuples, so a drift
+    between it and the real import-time derivation would be invisible to every
+    test that uses the helper. Import config COLD in a subprocess with
+    MICROVERSE_ECONOMY=bal and assert the three flags the run loop actually
+    reads (Codex review): bal == enabled + substitute + no scene gate."""
+    code = (
+        "import os, json\n"
+        "os.environ['MICROVERSE_ECONOMY'] = 'bal'\n"
+        "import microverse.config as c\n"
+        "print(json.dumps([c.ECONOMY_ENABLED, c._ECONOMY_SUBSTITUTE, c._ECONOMY_SCENE_GATE]))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    enabled, substitute, scene_gate = json.loads(result.stdout.strip().splitlines()[-1])
+    assert enabled is True
+    assert substitute is True  # bal substitutes like adv/sub
+    assert scene_gate is False  # ... and, unlike 1/flat/throttle, does not scene-gate
 
 
 def test_invalid_economy_mode_fails_fast(tmp_path: Path):

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -278,7 +278,7 @@ def test_bal_uses_perceived_hint_like_adv_for_artisan():
         regen_per_tick=8.0,
         cost_table=derive_balanced_table(VERB_COST_BY_ROLE),
     )
-    led._pool["Aki"] = 15.0  # affords craft(6) but not study(14)/speak(16)/...
+    led._pool["Aki"] = 15.0  # affords craft(6) and study(14) but not speak(16)/travel(18)/...
     with _economy("bal"):
         assert _energy_hint_verb(led, Artisan(name="Aki")) == "craft"
 

--- a/uv.lock
+++ b/uv.lock
@@ -468,6 +468,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pip" },
     { name = "pip-audit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -488,6 +489,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pip", specifier = ">=26.1.2" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -634,11 +636,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a new feature-flagged economy mode **`bal`** (balanced contribute) targeting the failure ADR 0010 isolated: the honest hint (`adv`) specializes the **artisan** but not the **scholar**, because the scholar's `contribute` is cheap (14) and almost always affordable, so its scarcity hint never fires.

`bal` raises **every role's `contribute` to the dearest in the table (the artisan's 22)** while leaving each role's cheap specialty untouched. A contribute-heavy scholar now drains, so its (already honest, `adv`) hint fires and names `study` — and the executor substitutes its free contributes toward study. `bal` keeps the `adv` hint selector, so the artisan still specializes into `craft`.

Ships the **mechanism + offline tests only**. The Stage 5 live A/B is deferred (see `docs/economy-stage5-runbook.md`). The ADR 0008/0009/0010 **HALT stays** until a PASS read.

## Background / Motivation

Stage 4 (ADR 0010): under `adv`, Aki chosen-craft 0.025→0.33 (robust across 3 seeds) but Cy chosen-study stays flat at ~0.03 and Cy is ~0.92–0.94 contribute in every mode → cross-agent jsd lands a stable ~0.16 < 0.25. Gate 9's calibration says distinct specialists with ~40% shared contribute pass at jsd 0.6, so the target is reachable *if the scholar can be moved*. The blocker is purely that the scholar's cheap contribute never triggers its scarcity hint.

## What changed

- **`EnergyLedger` / `derive_balanced_table`** (`world/economy.py`) — raises every role's `contribute` to `max(contribute)` (22), leaves specialty + `rest` untouched. Returns a fresh dict (no aliasing of the config table).
- **`build_cost_table("bal")`** → balanced table. `bal` is a substitute mode, **not** a scene-gate mode (scene initiation stays un-gated, as for `adv`/`sub`).
- **`config`** — `bal` added to `VALID_ECONOMY_MODES` and `_ECONOMY_SUBSTITUTE`.
- **`run._select_easy_verb`** — dispatches the perceived (honest) selector for `{adv, bal}`, so the artisan still gets `craft`.
- `adv`/`sub`/`flat`/`0` are byte-unchanged, so prior reads stay reproducible and the Stage 5 A/B isolates exactly one variable (the scholar's contribute cost).

### A/B matrix

| mode | contribute cost | hint | scholar hint fires? |
|---|---|---|---|
| `adv` | art 22, **sch 14** | perceived | rarely (cheap contribute) |
| `bal` | **22 for every role** | perceived | **yes** (dear contribute) |

## Testing

Strict TDD (red → green). All offline (`-m 'not integration'`).

- **Ledger**: balanced table raises every contribute to the dearest while preserving each role's strict specialty; a contribute-heavy scholar drains below contribute(22) while study(6) stays affordable; a study-heavy scholar stays solvent.
- **Run wiring**: `bal` fires the drained scholar's hint naming `study`; keeps the artisan's `craft` hint (perceived selector); flags `contribute` as out of reach where `adv` leaves it affordable (the isolation that motivates `bal`); `bal` is a valid substitution mode.
- 2-tick `bal` smoke runs end-to-end.

Full local gate green: `ruff check`, `ruff format --check`, `mypy src/microverse`, `pip-audit` (clean on `main`), `pytest -q -m 'not integration'` (622 passed), `uv build`. Reviewed by the code-reviewer agent; addressed the one CI-blocker (config formatting) and two test-comment/assertion improvements.

## Design & Reasoning Notes

- **Why balance all roles, not just the scholar?** Symmetric: every role's contribute is equally dear, so the scarcity pressure to leave the shared escape verb is uniform, and each role's distinct cheap specialty is what remains affordable. (For the 2-agent roster only the scholar matters today; a mid-run Stranger also benefits.)
- **No persona tuning** (ADR 0008 constraint carried forward) — this is a cost-table change, not a prompt change.
- **Honest caveat**: this is the last well-motivated economy lever. If `bal`'s live run also fails to move the scholar (R1 in the runbook — persona/sampling inertia), the economy approach is exhausted (insufficient three times) and the arc should be parked for a different mechanism.

## Documentation

`docs/economy-stage5-runbook.md` — deferred live A/B (`{0, adv, bal}` × `{42, 38, 7}` × 3000 ticks), the load-bearing per-specialty read (does `cy_study` rise above ~0.03 and `cy_contribute` fall below ~0.93?), quality counters via `MAX`, and risks R1–R4 (scholar inertia, thin drain margin at the lower-weight scholar, scene thinning, two-sided novelty conflict).

## Post-Merge Recommendations

1. **Deferred Stage 5 live A/B** per the runbook (~6 live runs). Pre-register: pass iff the scholar actually specializes (`cy_study` up, `cy_contribute` down) AND Gate 9 jsd ≥ 0.25 across seeds.
2. If R2 (thin drain margin) shows the lower-weight scholar barely drains, promote `derive_balanced_table`'s target to a config knob and raise it above 22.
3. If `bal` also fails, write the verdict and park the economy arc.