### PR TITLE
feat(audit): mechanism audit — Stage 6 hint CONFIRMED as the operative channel

### DIFF
--- a/docs/adr/0013-action-economy-mechanism-audit.md
+++ b/docs/adr/0013-action-economy-mechanism-audit.md
@@ -1,0 +1,86 @@
+# ADR 0013: Action-economy mechanism audit — the scarcity hint IS the operative channel
+
+**Status:** Accepted (measurement record) — records the offline mechanism audit (ADR 0012
+Phase 2 item 2) of the Stage 6 Gate 9 PASS. **Verdict: CONFIRMED.** The pre-registered C5
+(reconstruction fidelity), C1 (dose), C2 (conditional shift, with the deconfound stratum), and
+C3 (decomposition consistency) all pass at all three seeds with wide margins. C4 failed as
+literally drafted — a criterion mis-specification, not a spillover signal; its underlying
+falsification (no cross-role identity bleed) holds. The Stage 6 causal narrative survives.
+
+**Date:** 2026-06-12
+
+## Context
+
+ADR 0012 lifted the arc's HALT on the first Gate 9 PASS (`bal@30`, all three seeds) but scoped
+the claim deliberately: the PASS read only aggregate verb distributions, while the causal story —
+dear contribute drains the scholar → the scarcity hint fires and names `study` → the model obeys
+— had its middle links unmeasured. Phase 2 item 2 demanded a cheap, offline audit on the existing
+nine Stage 6 runs before investing in held-out replication (item 3) and roster generality
+(item 4): Cy energy traces, hint firing at 22 vs 30, chosen verb conditional on hint
+present/absent, Aki top-verb stability.
+
+The hint text is never persisted. The audit reconstructs it deterministically: replay the
+EnergyLedger over the LOGGED executed-verb stream (live deducts the committed verb, run.py:1222;
+whole-roster regen once per tick with scenes collapsed, run.py:1127) and re-evaluate the live
+hint predicate pre-deduct at each free turn (live computes it pre-think, run.py:983). The logged
+`economy_substituted` flag gives an in-band fidelity check (C5); a parity unit test pins the
+offline predicate to `run._compute_energy_hint` / `_energy_hint_verb` so they cannot drift.
+
+## Method
+
+`scripts/replay_economy.py --audit MODE[@TARGET]=PATH` (this PR), one pass over the nine frozen
+Stage 6 dirs at the live energy knobs (max 100, regen 8). Streams mirror `gate9_verb_diversity`
+filters. Decision criteria C1–C5 were committed to git **before** the instrument first read a
+real event table (`docs/economy-phase2-mechanism-audit.md`, the full write-up).
+
+## Results (summary — full tables in the findings doc)
+
+- **C5 PASS.** Predicted-vs-logged substitution agreement: hint-off **1.000 in all nine runs**
+  (no phantom scarcity), hint-on 0.919–0.948 (floor 0.90).
+- **C1 PASS.** Cy hint firing: `adv` 0.014–0.038, `bal@22` 0.39–0.42, `bal@30` 0.66 at every
+  seed; bal-pair gaps +0.24 to +0.27 (floor 0.15). The offline rule's prediction (~0.24 → ~0.56)
+  was directionally right and conservative.
+- **C2 PASS.** `P(Cy study | hint)` 0.56–0.67 vs `P(study | absent)` ≤ 0.003 in the bal arms;
+  contribute suppressed under the hint in every run. **Deconfound stratum:** on hint-absent turns
+  energetically adjacent to the threshold (`absent_low`, n = 149–200 per bal run) study stays at
+  ~0, identical to comfortable turns — the hint TEXT moves the model, not the energy level.
+- **C3 PASS.** Observed ΔCy-study (bal@22→bal@30) +0.169 vs predicted Δfiring × conditional
+  effect +0.153; fit ratio 1.10 (band 0.5–1.5).
+- **C4 FAIL as drafted.** The criterion assumed `craft` was Aki's top chosen verb; `contribute`
+  tops all nine runs (0.56–0.68), a pre-Stage-6 fact the drafting missed, and Aki's mix moved
+  across arms because `bal` raises AKI's contribute cost too (its own firing 0.70→0.85, craft
+  0.32→0.42 — same mechanism, decomposition fit 0.80). The intent (no cross-role bleed) holds:
+  the hint named `craft` on 100% of Aki's fired turns and `study` on 100% of Cy's; Aki-study
+  ≤ 0.02 and Cy-craft ≤ 0.01 everywhere.
+- **Obedience (advisory) PASS.** Cy follows the named verb at 0.50–0.67 per run (floor 0.30).
+
+## Decision
+
+1. **The mechanism claim is confirmed.** ADR 0012's bounded PASS is upgraded from "the tuned
+   economy produced divergence" to "the tuned economy produced divergence THROUGH the measured
+   hint channel, at quantified firing/obedience rates, with the raw-energy confound excluded."
+2. **Phase 2 item 3 (held-out replication, T fixed at 30) proceeds** on this foundation. Its
+   pre-registration must carry the corrected stability criterion: Aki's top NON-contribute
+   chosen verb is `craft` and neither agent drifts toward the other's specialty — not the
+   mis-drafted C4.
+3. **No live hint logging is needed for the audit's sake** (C5 passed without it), but stamping
+   `energy_hint_fired` / named verb into the payload remains worth doing in the replication
+   runs to retire the reconstruction caveat entirely. Decide in the item 3 PR.
+4. C4's literal failure is recorded, not patched away: the pre-registered criterion text stands
+   as written and scored FAIL in the findings doc, per the arc's pre-registration discipline.
+
+## Scope and limitations
+
+- The reconstruction is exact for ledger arithmetic but approximate for lever interleaving (the
+  diversity lever and engagement gate sit between `parsed_verb` and the economy lever); C5
+  bounds that slack at ≤ 8% of hint-on turns, hint-off exact.
+- Everything ADR 0012 carries forward still binds: two-resident roster, single model
+  (`gemma4:26b`), three seeds, target-selected T = 30. This audit settles the *mechanism*
+  question only; generality is items 3–4.
+- The nine runs had no mid-run restarts; a restarted run would weaken the reconstruction and
+  needs the fidelity gate re-checked.
+
+## Reproduction
+
+See `docs/economy-phase2-mechanism-audit.md` (Setup + Reproduction). Raw report:
+`data/econ-phase2-mechanism-audit.json` (untracked, with the frozen run dirs).

--- a/docs/adr/0013-action-economy-mechanism-audit.md
+++ b/docs/adr/0013-action-economy-mechanism-audit.md
@@ -1,11 +1,15 @@
 # ADR 0013: Action-economy mechanism audit — the scarcity hint IS the operative channel
 
 **Status:** Accepted (measurement record) — records the offline mechanism audit (ADR 0012
-Phase 2 item 2) of the Stage 6 Gate 9 PASS. **Verdict: CONFIRMED.** The pre-registered C5
-(reconstruction fidelity), C1 (dose), C2 (conditional shift, with the deconfound stratum), and
-C3 (decomposition consistency) all pass at all three seeds with wide margins. C4 failed as
-literally drafted — a criterion mis-specification, not a spillover signal; its underlying
-falsification (no cross-role identity bleed) holds. The Stage 6 causal narrative survives.
+Phase 2 item 2) of the Stage 6 Gate 9 PASS. **Verdict: CONFIRMED, under one disclosed
+deviation from the pre-registered rule.** C5 (reconstruction fidelity), C1 (dose), C2
+(conditional shift, with the deconfound stratum), and C3 (decomposition consistency) all pass
+at all three seeds with wide margins. C4 failed as literally drafted; since the rule read
+"confirmed iff all of C1–C4 hold", the strict literal reading is INCONCLUSIVE. The verdict is
+issued under an amended rule — C4's predicate was mis-specified against already-published facts
+(it tested a baseline that never existed), and the corrected falsification (no cross-role
+identity bleed) passes everywhere. The amendment is disclosed, not silently substituted; see
+the findings doc's "Verdict under the rule". The Stage 6 causal narrative survives.
 
 **Date:** 2026-06-12
 
@@ -56,7 +60,8 @@ real event table (`docs/economy-phase2-mechanism-audit.md`, the full write-up).
 
 ## Decision
 
-1. **The mechanism claim is confirmed.** ADR 0012's bounded PASS is upgraded from "the tuned
+1. **The mechanism claim is confirmed (under the disclosed C4 amendment).** ADR 0012's bounded
+   PASS is upgraded from "the tuned
    economy produced divergence" to "the tuned economy produced divergence THROUGH the measured
    hint channel, at quantified firing/obedience rates, with the raw-energy confound excluded."
 2. **Phase 2 item 3 (held-out replication, T fixed at 30) proceeds** on this foundation. Its

--- a/docs/economy-phase2-mechanism-audit.md
+++ b/docs/economy-phase2-mechanism-audit.md
@@ -15,7 +15,10 @@ an in-band fidelity check on that reconstruction. Parity between the offline pre
 `run._compute_energy_hint` / `run._energy_hint_verb` is pinned by unit test
 (`tests/test_economy_audit.py::test_hint_state_parity_with_run_helpers`).
 
-**Headline: TBD (criteria below committed before the audit read any real event table).**
+**Headline: CONFIRMED — the hint is the operative channel. C5 (fidelity), C1 (dose), C2
+(conditional shift), C3 (decomposition) pass at all three seeds with wide margins; the
+deconfound stratum rules out a raw-energy channel. C4 failed as literally drafted — a
+mis-specification of the criterion, not a spillover signal (see Findings F5).**
 
 ## Setup
 
@@ -78,11 +81,79 @@ failure (claim stands but unaudited until live hint logging exists).
 
 ## Results
 
-TBD — filled in after the locked run of the command above.
+Per run (Cy = scholar, Aki = artisan; all shares on the free chosen stream, gate9 filters;
+`fire` = hint firing rate over free turns; `p(v|h)` / `p(v|a)` = chosen-verb probability given
+hint present / absent; `fid_on` = predicted-vs-logged substitution agreement on predicted-hint-on
+turns — hint-off agreement was **1.0000 in all nine runs**):
+
+| arm    | seed | cy_fire | p(study\|h) | p(study\|a) | cy_obed | aki_fire | p(craft\|h) | p(craft\|a) | fid_on |
+|--------|-----:|--------:|------------:|------------:|--------:|---------:|------------:|------------:|-------:|
+| adv    | 42   | 0.038   | 0.525       | 0.023       | 0.525   | 0.680    | 0.443       | 0.025       | 0.942  |
+| bal@22 | 42   | 0.422   | 0.621       | 0.002       | 0.621   | 0.698    | 0.531       | 0.031       | 0.919  |
+| bal@30 | 42   | 0.658   | 0.603       | 0.003       | 0.603   | 0.849    | 0.455       | 0.041       | 0.934  |
+| adv    | 38   | 0.023   | 0.542       | 0.011       | 0.542   | 0.715    | 0.426       | 0.026       | 0.948  |
+| bal@22 | 38   | 0.420   | 0.602       | 0.002       | 0.602   | 0.727    | 0.478       | 0.036       | 0.929  |
+| bal@30 | 38   | 0.663   | 0.608       | 0.000       | 0.608   | 0.853    | 0.493       | 0.045       | 0.928  |
+| adv    | 7    | 0.014   | 0.500       | 0.018       | 0.500   | 0.709    | 0.475       | 0.041       | 0.945  |
+| bal@22 | 7    | 0.389   | 0.557       | 0.002       | 0.557   | 0.702    | 0.506       | 0.011       | 0.944  |
+| bal@30 | 7    | 0.661   | 0.667       | 0.000       | 0.667   | 0.850    | 0.503       | 0.040       | 0.936  |
+
+Deconfound stratum (Cy, study share among hint-ABSENT turns, split by the energy band):
+`P(study | absent_low)` is 0.000–0.006 in every bal run (n = 149–200 per run) and
+`P(study | absent_comfortable)` is 0.000–0.003 (n = 185–437) — indistinguishable from each
+other and from zero, against 0.56–0.67 under the hint.
+
+Decomposition (aggregate, bal@22 → bal@30): Cy observed Δstudy **+0.169** vs predicted
+Δfiring × conditional effect = 0.251 × 0.612 = **+0.153**, fit ratio **1.10**. Aki observed
+Δcraft +0.053 vs predicted +0.065, fit ratio 0.80.
+
+Cy energy equilibria (mean of last quarter of free turns): ~71–83 in `adv`, ~27–31 in `bal@22`,
+~24–27 in `bal@30` — the bal arms hold the scholar hovering at the affordability threshold,
+exactly the drain regime the R2 story requires.
+
+Raw report: `data/econ-phase2-mechanism-audit.json` (untracked, alongside the frozen run dirs).
+
+## Criteria scorecard
+
+- **C5 PASS** — hint-on agreement 0.919–0.948, hint-off 1.000, all nine runs (floor 0.90).
+- **C1 PASS** — Cy firing ordered `adv ≤ bal@22 < bal@30` at every seed; bal-pair gaps
+  +0.237 / +0.243 / +0.272 (floor 0.15).
+- **C2 PASS** — conditional study shift +0.600 / +0.608 / +0.667 at bal@30 (floor 0.10);
+  contribute suppressed under the hint in every run (0.26–0.31 vs 0.88–0.92). Deconfound
+  stratum flat at ~0 (see above): the effect follows the hint TEXT, not the energy level.
+- **C3 PASS** — Cy fit ratio 1.10 (band 0.5–1.5; even within ±30%).
+- **C4 FAIL as drafted** — see F5. Aki's top chosen verb is `contribute` in all nine runs
+  (never `craft`), and its top-verb share moved −0.108 across arms (band ±0.08).
+- **Obedience (advisory) PASS** — Cy 0.50–0.67 per run (floor 0.30); the named verb was
+  `study` on 100% of Cy's fired turns, `craft` on 100% of Aki's.
 
 ## Findings
 
-TBD.
+- **F1 — the dose-response chain is real and quantified.** Raising the balanced contribute
+  target 22→30 raises Cy's hint firing 0.41→0.66 (and `adv` explains itself: firing 1–4%,
+  which is why the honest hint alone never specialized the scholar — ADR 0010's diagnosis,
+  now measured). Firing × obedience reproduces the observed study rise within 10% (C3).
+- **F2 — the hint text, not the energy level, moves the model.** On energetically-adjacent
+  hint-absent turns (`absent_low`) Cy chooses study at ~0, identical to comfortable turns.
+  There is no path from the pool level into the prompt except the hint string, and the
+  behavior confirms it.
+- **F3 — the model obeys the named verb at ~0.5–0.67**, far above the 0.30 floor; the
+  remainder mostly stays on contribute (which the executor then substitutes). Specialization
+  is perception-mediated, with the hard lever as backstop — the ADR 0009 design intent.
+- **F4 — reconstruction validity.** Hint-off turns agree perfectly (no phantom scarcity);
+  hint-on agreement 0.92–0.95, the slack matching the known lever ordering (diversity lever
+  and engagement gate sit between `parsed_verb` and the economy lever; see Limitations).
+- **F5 — C4 was mis-specified, and the underlying falsification still passes.** The criterion
+  assumed `craft` was Aki's top chosen verb; it never was — `contribute` tops every arm
+  including `adv` (0.56–0.68), a fact already visible in pre-Stage-6 data. The share movement
+  across arms is also not spillover: `bal` raises AKI's contribute cost too (22→30), so Aki's
+  own firing rises 0.70→0.85 and its craft share 0.32→0.42 — the same mechanism, the same
+  comparative-advantage direction, decomposition-consistent (fit 0.80). The intent of C4
+  (no cross-role identity bleed) holds cleanly: the hint named `craft` on 100% of Aki's fired
+  turns and `study` on 100% of Cy's; neither agent drifted toward the other's specialty
+  (Aki study ≤ 0.02, Cy craft ≤ 0.01 everywhere). Recorded as FAIL-as-drafted per
+  pre-registration discipline; the corrected falsification belongs to the Phase 2 item 3
+  replication's pre-registration.
 
 ## Limitations
 

--- a/docs/economy-phase2-mechanism-audit.md
+++ b/docs/economy-phase2-mechanism-audit.md
@@ -15,10 +15,13 @@ an in-band fidelity check on that reconstruction. Parity between the offline pre
 `run._compute_energy_hint` / `run._energy_hint_verb` is pinned by unit test
 (`tests/test_economy_audit.py::test_hint_state_parity_with_run_helpers`).
 
-**Headline: CONFIRMED — the hint is the operative channel. C5 (fidelity), C1 (dose), C2
-(conditional shift), C3 (decomposition) pass at all three seeds with wide margins; the
-deconfound stratum rules out a raw-energy channel. C4 failed as literally drafted — a
-mis-specification of the criterion, not a spillover signal (see Findings F5).**
+**Headline: CONFIRMED, with one disclosed deviation. C5 (fidelity), C1 (dose), C2 (conditional
+shift), C3 (decomposition) pass at all three seeds with wide margins; the deconfound stratum
+rules out a raw-energy channel. C4 fails as literally drafted — a criterion mis-specified
+against already-published facts (Findings F5) — so under the strict literal rule the read is
+INCONCLUSIVE. The CONFIRMED verdict is issued under an amended rule (C4 replaced by the
+corrected no-cross-role-bleed falsification, which passes), with the amendment disclosed in the
+scorecard below and carried into the item 3 pre-registration.**
 
 ## Setup
 
@@ -126,6 +129,19 @@ Raw report: `data/econ-phase2-mechanism-audit.json` (untracked, alongside the fr
   (never `craft`), and its top-verb share moved −0.108 across arms (band ±0.08).
 - **Obedience (advisory) PASS** — Cy 0.50–0.67 per run (floor 0.30); the named verb was
   `study` on 100% of Cy's fired turns, `craft` on 100% of Aki's.
+
+**Verdict under the rule.** The pre-registered rule reads "confirmed iff all of C1–C4 hold";
+C4 failed, so the strict literal reading is INCONCLUSIVE. The verdict issued here is
+**CONFIRMED under a post-hoc amended rule**, and the amendment is disclosed rather than
+silently substituted: C4's predicate ("Aki's top chosen verb is craft") was false in the
+already-frozen pre-Stage-6 data at the moment it was drafted — it tested a baseline that never
+existed, not a hypothesis the audit could inform — and its share-stability clause contradicts
+the audited design itself (`bal` raises Aki's contribute cost too, so Aki's mix moving WITH its
+own firing rate is the mechanism working, not spillover). The amended C4 — Aki's top
+NON-contribute chosen verb is `craft` in all nine runs, and neither agent drifts toward the
+other's specialty — passes everywhere (F5). Readers who reject post-hoc amendments on principle
+should treat this audit as INCONCLUSIVE-pending-replication; the item 3 replication carries the
+corrected criterion as a properly pre-registered test either way (ADR 0013 Decision 2).
 
 ## Findings
 

--- a/docs/economy-phase2-mechanism-audit.md
+++ b/docs/economy-phase2-mechanism-audit.md
@@ -1,0 +1,106 @@
+# Action-economy Phase 2 — mechanism audit (is the hint the operative channel?)
+
+Operator note for **ADR 0012 Phase 2 item 2**. Stage 6 (`docs/economy-stage6-findings.md`,
+ADR 0012) locked the first Gate 9 PASS at `bal@30`, with a causal narrative: the dear balanced
+contribute drains the scholar, the scarcity hint fires and names `study`, the model obeys. The
+PASS read only the *aggregate* verb distributions; this audit checks the narrative's middle links
+offline, on the existing nine Stage 6 runs, with **zero new LLM compute**.
+
+The hint text is never persisted, but its per-turn state is deterministically reconstructable:
+replay the energy ledger over the LOGGED executed-verb stream (the exact live arithmetic — live
+deducts the committed verb at run.py:1222 and regenerates the whole roster once per tick, scenes
+collapsed, run.py:1127) and re-evaluate `run.py`'s hint predicate at each free turn pre-deduct
+(live computes the hint before `think()`, run.py:983). The logged `economy_substituted` flag is
+an in-band fidelity check on that reconstruction. Parity between the offline predicate and
+`run._compute_energy_hint` / `run._energy_hint_verb` is pinned by unit test
+(`tests/test_economy_audit.py::test_hint_state_parity_with_run_helpers`).
+
+**Headline: TBD (criteria below committed before the audit read any real event table).**
+
+## Setup
+
+- Instrument: `scripts/replay_economy.py --audit MODE[@TARGET]=PATH` (this PR), one process over
+  all nine frozen Stage 6 run dirs:
+
+  ```bash
+  uv run python scripts/replay_economy.py \
+    --audit adv=data/econ-stage6-adv-s42    --audit bal@22=data/econ-stage6-bal22-s42 \
+    --audit bal@30=data/econ-stage6-bal30-s42 \
+    --audit adv=data/econ-stage6-adv-s38    --audit bal@22=data/econ-stage6-bal22-s38 \
+    --audit bal@30=data/econ-stage6-bal30-s38 \
+    --audit adv=data/econ-stage6-adv-s7     --audit bal@22=data/econ-stage6-bal22-s7 \
+    --audit bal@30=data/econ-stage6-bal30-s7
+  ```
+- Energy knobs: config defaults (`ENERGY_MAX=100`, `ENERGY_REGEN_PER_TICK=8`), exactly what the
+  live sweep ran with. Cost tables rebuilt per arm from the spec (`adv`, `bal@22`, `bal@30`).
+- Streams mirror `gate9_verb_diversity` filters: scene turns excluded everywhere (forced
+  contributes, hint silenced live); parse-fallback RESTs excluded from the chosen-verb
+  conditionals (not free choices) but kept in the hint-rate denominator (the hint is computed
+  live regardless of how the output parses).
+- Strata per free turn: `hint` (predicate fires), `absent_low` (contribute affordable but within
+  one regen of the threshold — the deconfound band: energetically adjacent to hint turns, no hint
+  text), `absent_comfortable` (everything else).
+
+## Pre-registered decision criteria (locked before the read)
+
+Honesty note: the Stage 6 *aggregate* verb shifts are already known from the sweep. What is
+genuinely unseen here are the reconstructed hint firing rates, the conditional (per-turn)
+probabilities, the strata, and the fidelity rates. The criteria below were committed to git
+before `--audit` first touched a real `episodic.sqlite`.
+
+The hint is confirmed as the operative channel iff all of C1–C4 hold at **all three seeds**, with
+C5 as a validity precondition:
+
+- **C5 (fidelity gate, precondition):** predicted-vs-logged `economy_substituted` agreement
+  ≥ 0.90 per run, on BOTH the predicted-hint-on and predicted-hint-off subsets (an overall 0.90
+  is too easy when hint turns are rare). Below that the reconstruction cannot carry C1–C3 and the
+  audit verdict is **INCONCLUSIVE** (fallback: stamp hint state into the live payload for the
+  Phase 2 item 3 replication runs — a follow-up, not this PR).
+- **C1 (dose):** Cy hint firing rate ordered `adv ≤ bal@22 < bal@30`, with the gap criterion
+  `bal@30 − bal@22 ≥ 0.15` absolute applied ONLY to the bal pair (`adv` firing may be near zero
+  by construction; a small adv→bal22 gap is not a failure).
+- **C2 (conditional shift):** `P(Cy chosen=study | hint) − P(study | absent) ≥ 0.10` absolute,
+  and `P(Cy chosen=contribute | hint) < P(contribute | absent)`. The `absent_low` stratum is
+  reported alongside: if `P(study | absent_low) ≈ P(study | absent_comfortable)`, the effect is
+  attributable to the hint text rather than the raw energy level.
+- **C3 (decomposition consistency):** observed ΔCy-study (bal@30 − bal@22, chosen share) within
+  ±50% of Δfiring × (P(study|hint) − P(study|absent)) pooled over the bal arms. A consistency
+  check, not a model fit; the fit ratio is reported, not just pass/fail.
+- **C4 (Aki spillover falsification):** Aki's top chosen verb is `craft` in all 9 runs and its
+  top-verb share shifts < ±0.08 across arms.
+- **Obedience floor (reported, advisory):** `P(Cy chosen = named easy verb | hint)`. A value
+  < 0.30 undercuts the causal claim even if the correlations hold.
+
+What would weaken Stage 6: conditional probabilities flat while firing rose (the study rise was
+unconditional drift — novelty lever or sampling, hint not operative → ADR 0012's causal narrative
+needs revision); or bal@30 firing not above bal@22 (the R2 mechanism story itself wrong); or a C5
+failure (claim stands but unaudited until live hint logging exists).
+
+## Results
+
+TBD — filled in after the locked run of the command above.
+
+## Findings
+
+TBD.
+
+## Limitations
+
+- **Reconstruction, not ground truth.** The hint state is recomputed, not logged. The known
+  near-miss sources: the diversity lever and engagement gate run between `parsed_verb` capture
+  and the economy lever, so the logged `economy_substituted` compares the economy lever's own
+  input/output, not `parsed_verb` — C5 measures exactly this slack.
+- **No mid-run restarts** occurred in the nine Stage 6 dirs; a restarted run would only support
+  approximate reconstruction (`EnergyLedger.reconstruct_from_events` is per-actor, not
+  whole-roster) and would need the fidelity gate re-examined.
+- Everything ADR 0012 carries forward still binds: two-resident roster, single model, three
+  seeds, target-selected T. This audit strengthens (or weakens) the *mechanism* claim only;
+  replication and roster generality are Phase 2 items 3–4.
+
+## Reproduction
+
+```bash
+git checkout feat/economy-mechanism-audit
+uv run pytest -q tests/test_economy_audit.py
+# then the Setup command above against the frozen data/econ-stage6-* dirs
+```

--- a/scripts/replay_economy.py
+++ b/scripts/replay_economy.py
@@ -174,7 +174,7 @@ def _trace_from_episodic(path: Path) -> list[tuple[str, str, str, bool, str | No
     the executor must deduct without substituting (review). ``scene_id`` lets the
     replay group a scene's three forced contributes into one regen tick, matching
     the live loop's single whole-roster regen per scene (run.py:1127)."""
-    conn = sqlite3.connect(str(path))
+    conn = sqlite3.connect(path)
     try:
         rows = conn.execute(
             "SELECT actor, action, payload_json FROM events "
@@ -297,7 +297,7 @@ def _audit_trace_from_episodic(path: Path) -> list[AuditEvent]:
     of :func:`_trace_from_episodic` (kept separate so Stage-0 replay output
     stays byte-stable) that also carries the EXECUTED verb (the ``action``
     column — what live deducted) and the gate9 telemetry flags."""
-    conn = sqlite3.connect(str(path))
+    conn = sqlite3.connect(path)
     try:
         rows = conn.execute(
             "SELECT actor, action, payload_json FROM events "

--- a/scripts/replay_economy.py
+++ b/scripts/replay_economy.py
@@ -37,6 +37,7 @@ import sqlite3
 import sys
 from collections import Counter
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 from microverse.config import ENERGY_MAX, ENERGY_REGEN_PER_TICK
@@ -195,6 +196,411 @@ def _trace_from_episodic(path: Path) -> list[tuple[str, str, str, bool, str | No
     return out
 
 
+# --- Mechanism audit (ADR 0012 Phase 2 item 2) -------------------------------
+#
+# The Stage 6 PASS claims the scarcity hint is the operative channel: the
+# balanced contribute cost drains the scholar, the hint fires and names study,
+# the model obeys. The hint text itself is never persisted, but its state is
+# deterministically reconstructable: replay the energy ledger over the LOGGED
+# executed-verb stream (exact live arithmetic — live deducts the committed
+# verb, run.py:1222) and re-evaluate run.py's hint predicate at each free turn
+# pre-deduct (the live hint is computed before think(), run.py:983). The
+# logged ``economy_substituted`` flag provides a per-event fidelity check on
+# the reconstruction (the audit's C5 gate).
+
+# Mirrors run.py's _ENERGY_HINT_PRODUCTIVE; the parity test in
+# tests/test_economy_audit.py pins the two against each other so they cannot
+# drift silently.
+_HINT_PRODUCTIVE = ("speak", "craft", "study", "travel", "contribute")
+# Modes whose live prompts carry the scarcity hint (config._ECONOMY_SUBSTITUTE).
+_SUBSTITUTE_MODES = frozenset({"1", "flat", "sub", "adv", "bal"})
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    """One committed agent action with both verb streams + telemetry flags."""
+
+    actor: str
+    role: str
+    chosen: str
+    executed: str
+    forced: bool = False
+    scene_id: str | None = None
+    parse_fallback: bool = False
+    economy_substituted: bool = False
+
+
+@dataclass(frozen=True)
+class AuditSpec:
+    """One ``--audit MODE[@TARGET]=PATH`` run assignment. The run dir does not
+    record its economy mode, so the operator must restate it (the dir naming
+    convention ``econ-stage6-<arm>-s<seed>`` carries it)."""
+
+    mode: str
+    target: float | None
+    path: Path
+    arm: str
+
+
+def parse_audit_spec(spec: str) -> AuditSpec:
+    """Parse ``MODE[@TARGET]=PATH``. Raises ``ValueError`` (never clamps) on a
+    malformed spec so a typo cannot silently audit the wrong cost table."""
+    arm, sep, path = spec.partition("=")
+    if not sep or not path or not arm:
+        raise ValueError(f"invalid audit spec {spec!r}: expected MODE[@TARGET]=PATH")
+    mode, tsep, traw = arm.partition("@")
+    target: float | None = None
+    if tsep:
+        if mode != "bal":
+            raise ValueError(f"invalid audit spec {spec!r}: a @TARGET is only valid for mode 'bal'")
+        try:
+            target = float(traw)
+        except ValueError:
+            raise ValueError(
+                f"invalid audit spec {spec!r}: target {traw!r} is not a number"
+            ) from None
+        if not math.isfinite(target) or target <= 0:
+            raise ValueError(
+                f"invalid audit spec {spec!r}: target must be a positive finite number"
+            )
+    if mode not in _SUBSTITUTE_MODES:
+        raise ValueError(
+            f"invalid audit spec {spec!r}: mode {mode!r} has no live scarcity hint "
+            f"(expected one of {sorted(_SUBSTITUTE_MODES)})"
+        )
+    return AuditSpec(mode=mode, target=target, path=Path(path), arm=arm)
+
+
+def _hint_state(
+    ledger: EnergyLedger, actor: str, role: str, *, mode: str
+) -> tuple[bool, str | None]:
+    """Offline reimplementation of run.py's live hint predicate + selector:
+    ``(fired, easy_verb)``. Fires iff any productive verb is unaffordable
+    (``_compute_energy_hint``); the named "comes easily" verb is the perceived
+    selector for ``adv``/``bal`` and the legacy productive selector otherwise
+    (``_select_easy_verb``). Takes ``mode`` explicitly — run.py reads the
+    process-global ``config.ECONOMY_MODE``, which cannot audit three arms in
+    one process. ``easy_verb`` is ``None`` when nothing productive is
+    affordable (live shows the "rest before ..." message)."""
+    if mode not in _SUBSTITUTE_MODES:
+        return (False, None)
+    unaffordable = any(not ledger.can_afford(actor, role, v) for v in _HINT_PRODUCTIVE)
+    if not unaffordable:
+        return (False, None)
+    if mode in ("adv", "bal"):
+        return (True, ledger.cheapest_affordable_perceived(actor, role))
+    return (True, ledger.cheapest_affordable_productive(actor, role))
+
+
+def _audit_trace_from_episodic(path: Path) -> list[AuditEvent]:
+    """Chronological :class:`AuditEvent` stream from a committed run. Sibling
+    of :func:`_trace_from_episodic` (kept separate so Stage-0 replay output
+    stays byte-stable) that also carries the EXECUTED verb (the ``action``
+    column — what live deducted) and the gate9 telemetry flags."""
+    conn = sqlite3.connect(str(path))
+    try:
+        rows = conn.execute(
+            "SELECT actor, action, payload_json FROM events "
+            "WHERE actor NOT IN ('world','harvester','scene') ORDER BY id ASC"
+        ).fetchall()
+    finally:
+        conn.close()
+    out: list[AuditEvent] = []
+    for actor, action, payload_json in rows:
+        if action not in _VERBS:
+            continue
+        payload = json.loads(payload_json) if payload_json else {}
+        role = str(payload.get("role", ""))
+        if not role:
+            continue
+        chosen = payload.get("parsed_verb") or action
+        if chosen not in _VERBS:
+            chosen = action
+        scene_id = payload.get("scene_id")
+        out.append(
+            AuditEvent(
+                actor=actor,
+                role=role,
+                chosen=chosen,
+                executed=action,
+                forced=bool(scene_id),
+                scene_id=scene_id,
+                parse_fallback=bool(payload.get("parse_fallback")),
+                economy_substituted=bool(payload.get("economy_substituted")),
+            )
+        )
+    return out
+
+
+def _rate(num: int, den: int) -> float:
+    return round(num / den, 4) if den else 0.0
+
+
+def _shares(counts: Counter) -> dict[str, float]:
+    total = sum(counts.values())
+    return {v: round(n / total, 4) for v, n in sorted(counts.items())} if total else {}
+
+
+def audit_run(events: Sequence[AuditEvent], *, ledger: EnergyLedger, mode: str) -> dict:
+    """Single chronological pass over a run's committed actions.
+
+    Per free (non-scene) turn, BEFORE deducting (matching live, where the hint
+    is computed pre-think and the deduct lands post-commit): snapshot the
+    actor's energy, evaluate the hint predicate, classify the turn's stratum
+    (``hint`` / ``absent_low`` / ``absent_comfortable`` — low means contribute
+    is affordable but within one regen of the threshold, the deconfound band),
+    and compare the offline executor's predicted substitution against the
+    logged ``economy_substituted`` flag (fidelity). Then deduct the LOGGED
+    executed verb and regen the whole roster once per live tick, collapsing a
+    scene's forced turns into a single regen (same tick model as
+    :func:`replay_executor`, PR #55 fidelity fix).
+
+    Conditional chosen-verb streams exclude parse-fallback RESTs (gate9
+    parity: a malformed payload is not a free verb choice); the hint-rate
+    denominator keeps them (live computed the hint regardless of how the
+    think() output parsed)."""
+
+    def _new_acc(role: str) -> dict:
+        return {
+            "role": role,
+            "free": 0,
+            "energies": [],
+            "contribute_out": 0,
+            "hint_fired": 0,
+            "easy": Counter(),
+            "chosen": {"hint": Counter(), "absent_low": Counter(), "absent_comfortable": Counter()},
+            "obey": 0,
+            "obey_total": 0,
+        }
+
+    acc: dict[str, dict] = {}
+    fid = {"hint_on": [0, 0], "hint_off": [0, 0]}  # [events, agreements]
+    ev_list = list(events)
+    for idx, ev in enumerate(ev_list):
+        st = acc.setdefault(ev.actor, _new_acc(ev.role))
+        if not ev.forced:
+            energy = ledger.current(ev.actor)
+            fired, easy = _hint_state(ledger, ev.actor, ev.role, mode=mode)
+            contribute_cost = ledger.cost(ev.role, "contribute")
+            st["free"] += 1
+            st["energies"].append(energy)
+            if energy < contribute_cost:
+                st["contribute_out"] += 1
+            if fired:
+                st["hint_fired"] += 1
+                st["easy"][easy or "none"] += 1
+            if not ev.parse_fallback:
+                if fired:
+                    stratum = "hint"
+                elif energy < contribute_cost + ledger.regen_per_tick:
+                    stratum = "absent_low"
+                else:
+                    stratum = "absent_comfortable"
+                st["chosen"][stratum][ev.chosen] += 1
+                if fired and easy is not None:
+                    st["obey_total"] += 1
+                    if ev.chosen == easy:
+                        st["obey"] += 1
+                predicted = ledger.resolve_executed_verb(ev.actor, ev.role, ev.chosen) != ev.chosen
+                bucket = fid["hint_on" if fired else "hint_off"]
+                bucket[0] += 1
+                if predicted == ev.economy_substituted:
+                    bucket[1] += 1
+        ledger.deduct(ev.actor, ev.role, ev.executed)
+        nxt = ev_list[idx + 1] if idx + 1 < len(ev_list) else None
+        in_same_scene = (
+            ev.forced
+            and ev.scene_id is not None
+            and nxt is not None
+            and nxt.forced
+            and nxt.scene_id == ev.scene_id
+        )
+        if not in_same_scene:
+            ledger.regen_all()
+
+    agents: dict[str, dict] = {}
+    for actor, st in acc.items():
+        samples: list[float] = st["energies"]
+        tail = samples[-max(1, len(samples) // 4) :] if samples else []
+        absent = st["chosen"]["absent_low"] + st["chosen"]["absent_comfortable"]
+        agents[actor] = {
+            "role": st["role"],
+            "free_turns": st["free"],
+            "energy": {
+                "min": round(min(samples), 4) if samples else None,
+                "mean": round(sum(samples) / len(samples), 4) if samples else None,
+                "equilibrium": round(sum(tail) / len(tail), 4) if tail else None,
+                "contribute_unaffordable_rate": _rate(st["contribute_out"], st["free"]),
+            },
+            "hint": {
+                "fired": st["hint_fired"],
+                "rate": _rate(st["hint_fired"], st["free"]),
+                "easy_verbs": dict(sorted(st["easy"].items())),
+            },
+            "chosen": {k: dict(sorted(c.items())) for k, c in st["chosen"].items()},
+            "p_chosen": {
+                "hint": _shares(st["chosen"]["hint"]),
+                "absent": _shares(absent),
+                "absent_low": _shares(st["chosen"]["absent_low"]),
+                "absent_comfortable": _shares(st["chosen"]["absent_comfortable"]),
+            },
+            "obedience_rate": _rate(st["obey"], st["obey_total"]) if st["obey_total"] else None,
+        }
+
+    def _fid_block(events_n: int, agree_n: int) -> dict:
+        return {
+            "events": events_n,
+            "agreements": agree_n,
+            "rate": round(agree_n / events_n, 4) if events_n else None,
+        }
+
+    on_n, on_a = fid["hint_on"]
+    off_n, off_a = fid["hint_off"]
+    return {
+        "events": len(ev_list),
+        "mode": mode,
+        "agents": agents,
+        "fidelity": {
+            **_fid_block(on_n + off_n, on_a + off_a),
+            "hint_on": _fid_block(on_n, on_a),
+            "hint_off": _fid_block(off_n, off_a),
+        },
+    }
+
+
+def _combined_chosen(report_agent: dict) -> Counter:
+    out: Counter = Counter()
+    for counts in report_agent["chosen"].values():
+        out.update(counts)
+    return out
+
+
+def aggregate_audit(runs: Sequence[dict]) -> dict:
+    """Cross-run aggregate of ``audit_run`` reports (each wrapped as
+    ``{"arm", "run", "report"}``): per-arm per-agent means, per-agent top-verb
+    stability across every run, and — when two or more ``bal@T`` arms are
+    present — the decomposition check (is the observed chosen-share delta of
+    the agent's modal easy verb consistent with delta-firing-rate times the
+    pooled conditional effect?). Conditional probabilities are POOLED (counts
+    summed before dividing) across a (arm, agent) group: more stable than a
+    mean of per-run ratios when hint turns are scarce."""
+    by_arm: dict[str, list[dict]] = {}
+    for item in runs:
+        by_arm.setdefault(item["arm"], []).append(item)
+
+    def _agent_names(items: Sequence[dict]) -> list[str]:
+        names: list[str] = []
+        for it in items:
+            for name in it["report"]["agents"]:
+                if name not in names:
+                    names.append(name)
+        return names
+
+    arms: dict[str, dict] = {}
+    pooled: dict[tuple[str, str], dict[str, Counter]] = {}
+    for arm, items in by_arm.items():
+        arm_out: dict[str, dict] = {}
+        for name in _agent_names(items):
+            reports = [
+                it["report"]["agents"][name] for it in items if name in it["report"]["agents"]
+            ]
+            hint_counts: Counter = Counter()
+            absent_counts: Counter = Counter()
+            combined: Counter = Counter()
+            easy: Counter = Counter()
+            for rep in reports:
+                hint_counts.update(rep["chosen"]["hint"])
+                absent_counts.update(rep["chosen"]["absent_low"])
+                absent_counts.update(rep["chosen"]["absent_comfortable"])
+                combined.update(_combined_chosen(rep))
+                easy.update(rep["hint"]["easy_verbs"])
+            pooled[(arm, name)] = {
+                "hint": hint_counts,
+                "absent": absent_counts,
+                "combined": combined,
+                "easy": easy,
+            }
+            arm_out[name] = {
+                "runs": len(reports),
+                "hint_rate_mean": round(sum(r["hint"]["rate"] for r in reports) / len(reports), 4),
+                "chosen_share": _shares(combined),
+                "p_chosen_hint_pooled": _shares(hint_counts),
+                "p_chosen_absent_pooled": _shares(absent_counts),
+            }
+        arms[arm] = arm_out
+
+    stability: dict[str, dict] = {}
+    for name in _agent_names(list(runs)):
+        top_by_run: dict[str, str] = {}
+        top_shares: list[float] = []
+        for item in runs:
+            rep = item["report"]["agents"].get(name)
+            if rep is None:
+                continue
+            combined = _combined_chosen(rep)
+            total = sum(combined.values())
+            if not total:
+                continue
+            verb, count = combined.most_common(1)[0]
+            top_by_run[f"{item['arm']}/{item['run']}"] = verb
+            top_shares.append(count / total)
+        stability[name] = {
+            "top_verb_by_run": top_by_run,
+            "stable": len(set(top_by_run.values())) == 1 if top_by_run else False,
+            "top_share_spread": round(max(top_shares) - min(top_shares), 4) if top_shares else None,
+        }
+
+    decomposition: dict[str, dict] = {}
+    bal_targets: list[tuple[float, str]] = []
+    for arm in by_arm:
+        mode, tsep, traw = arm.partition("@")
+        if mode == "bal" and tsep:
+            bal_targets.append((float(traw), arm))
+    if len(bal_targets) >= 2:
+        bal_targets.sort()
+        (_, low_arm), (_, high_arm) = bal_targets[0], bal_targets[-1]
+        bal_arms = [arm for _, arm in bal_targets]
+        for name in _agent_names(list(runs)):
+            if name not in arms.get(low_arm, {}) or name not in arms.get(high_arm, {}):
+                continue
+            hint_counts = Counter()
+            absent_counts = Counter()
+            easy = Counter()
+            for arm in bal_arms:
+                grp = pooled.get((arm, name))
+                if grp:
+                    hint_counts.update(grp["hint"])
+                    absent_counts.update(grp["absent"])
+                    easy.update(grp["easy"])
+            easy.pop("none", None)
+            if not easy:
+                continue
+            verb = easy.most_common(1)[0][0]
+            p_hint = _shares(hint_counts).get(verb, 0.0)
+            p_absent = _shares(absent_counts).get(verb, 0.0)
+            cond_effect = round(p_hint - p_absent, 4)
+            d_firing = round(
+                arms[high_arm][name]["hint_rate_mean"] - arms[low_arm][name]["hint_rate_mean"], 4
+            )
+            observed = round(
+                arms[high_arm][name]["chosen_share"].get(verb, 0.0)
+                - arms[low_arm][name]["chosen_share"].get(verb, 0.0),
+                4,
+            )
+            predicted = round(d_firing * cond_effect, 4)
+            decomposition[name] = {
+                "verb": verb,
+                "arms": [low_arm, high_arm],
+                "delta_firing": d_firing,
+                "conditional_effect": cond_effect,
+                "observed_delta": observed,
+                "predicted_delta": predicted,
+                "fit_ratio": round(observed / predicted, 4) if predicted else None,
+            }
+
+    return {"arms": arms, "stability": stability, "decomposition": decomposition}
+
+
 def synthetic_run(
     policy: str,
     *,
@@ -296,7 +702,20 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "above the natural dearest (22) so the lower-weight scholar drains harder. "
         "A target below 22 is rejected at table build (never silently clamped).",
     )
+    p.add_argument(
+        "--audit",
+        action="append",
+        metavar="MODE[@TARGET]=PATH",
+        help="mechanism audit (ADR 0012 Phase 2): assign a run dir to its economy "
+        "arm, e.g. bal@30=data/econ-stage6-bal30-s42. Repeatable; the report "
+        "carries per-run reconstructions plus the cross-run aggregate.",
+    )
     args = p.parse_args(argv)
+    for spec in args.audit or []:
+        try:
+            parse_audit_spec(spec)
+        except ValueError as exc:
+            p.error(str(exc))
     # Fail fast on meaningless knobs: a non-positive pool or negative regen is
     # never a valid economy and would silently yield a degenerate all-rest sweep.
     if not math.isfinite(args.energy_max) or args.energy_max <= 0:
@@ -358,8 +777,36 @@ def main(argv: list[str]) -> int:
             for pol in ("always-contribute", "uniform-random", "role-biased")
         ]
 
-    if not args.data and not args.synthetic:
-        print("nothing to do: pass --data <dir> and/or --synthetic", file=sys.stderr)
+    if args.audit:
+        audit_runs: list[dict] = []
+        for spec_raw in args.audit:
+            spec = parse_audit_spec(spec_raw)
+            ep = spec.path / "episodic.sqlite"
+            if not ep.exists():
+                print(f"FATAL: {ep} not found", file=sys.stderr)
+                return 2
+            ledger = EnergyLedger.fresh(
+                [n for n, _ in _DEFAULT_ROSTER],
+                max_energy=args.energy_max,
+                regen_per_tick=args.regen,
+                cost_table=build_cost_table(spec.mode, balanced_contribute=spec.target),
+            )
+            audit_runs.append(
+                {
+                    "arm": spec.arm,
+                    "run": spec.path.name,
+                    "report": audit_run(
+                        _audit_trace_from_episodic(ep), ledger=ledger, mode=spec.mode
+                    ),
+                }
+            )
+        report["mechanism_audit"] = {
+            "runs": audit_runs,
+            "aggregate": aggregate_audit(audit_runs),
+        }
+
+    if not args.data and not args.synthetic and not args.audit:
+        print("nothing to do: pass --data <dir>, --synthetic, and/or --audit", file=sys.stderr)
         return 1
     print(json.dumps(report, indent=2, sort_keys=True))
     return 0

--- a/tests/test_economy_audit.py
+++ b/tests/test_economy_audit.py
@@ -226,15 +226,16 @@ def test_audit_low_energy_stratum_splits_hint_absent_turns():
     # Deconfound stratum (audit review): hint-absent turns split into
     # "low" (contribute affordable but within one regen of the threshold:
     # energy < cost + regen) vs "comfortable". Pool 31 at bal@30/regen 8 is
-    # affordable-but-low (31 < 38); pool 100 is comfortable.
+    # affordable-but-low (31 < 38); pool 100 is comfortable. Single-event
+    # traces: the snapshot is pre-deduct, so the regen never lands.
     low = replay_economy.audit_run(
         [_ev(chosen="contribute", executed="rest")],
-        ledger=_ledger({"Cy": 31.0}, regen=0.0),
+        ledger=_ledger({"Cy": 31.0}),
         mode="bal",
     )
     comfy = replay_economy.audit_run(
         [_ev(chosen="contribute", executed="rest")],
-        ledger=_ledger({"Cy": 100.0}, regen=0.0),
+        ledger=_ledger({"Cy": 100.0}),
         mode="bal",
     )
     assert low["agents"]["Cy"]["chosen"]["absent_low"] == {"contribute": 1}
@@ -295,12 +296,14 @@ def test_audit_substitution_agreement_counts_mismatches():
     # An event the reconstruction predicts substituted but the log says was not
     # (or vice versa) must lower the agreement rate — this is the C5 gate that
     # decides whether the reconstruction can carry the audit at all.
+    # Pool pinned at 10 (regen 0, executed rest costs 0) so every event sees
+    # the same affordability state: study (6) affordable, contribute (30) not.
     led = _ledger({"Cy": 10.0}, regen=0.0)
     events = [
-        _ev(chosen="contribute", executed="study", economy_substituted=True),
-        _ev(chosen="contribute", executed="study", economy_substituted=True),
-        _ev(chosen="contribute", executed="contribute", economy_substituted=False),  # mismatch
-        _ev(chosen="study", executed="study", economy_substituted=False),  # affordable: agree
+        _ev(chosen="study", executed="rest", economy_substituted=False),  # affordable: agree
+        _ev(chosen="contribute", executed="rest", economy_substituted=True),  # agree
+        _ev(chosen="contribute", executed="rest", economy_substituted=False),  # mismatch
+        _ev(chosen="study", executed="rest", economy_substituted=False),  # agree
     ]
     report = replay_economy.audit_run(events, ledger=led, mode="bal")
     fid = report["fidelity"]

--- a/tests/test_economy_audit.py
+++ b/tests/test_economy_audit.py
@@ -1,0 +1,446 @@
+"""Mechanism audit for the Stage 6 Gate 9 PASS (ADR 0012 Phase 2 item 2).
+
+The audit must show the scarcity hint is the OPERATIVE channel behind the
+``bal@30`` specialization, not a coincidence: reconstruct per-turn hint state
+offline by replaying the energy ledger over the logged executed-verb stream,
+then read hint firing rates, conditional chosen-verb probabilities, and a
+predicted-vs-logged substitution fidelity check. Zero LLM compute; the
+reconstruction must match ``run.py``'s live hint semantics exactly (parity
+tests below pin it to the live helpers).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from microverse.world.economy import EnergyLedger, build_cost_table
+
+_PATH = Path(__file__).resolve().parents[1] / "scripts" / "replay_economy.py"
+_spec = importlib.util.spec_from_file_location("replay_economy", _PATH)
+assert _spec is not None
+assert _spec.loader is not None
+replay_economy = importlib.util.module_from_spec(_spec)
+sys.modules["replay_economy"] = replay_economy
+_spec.loader.exec_module(replay_economy)
+
+
+def _ledger(
+    levels: dict[str, float] | None = None,
+    *,
+    mode: str = "bal",
+    target: float | None = 30.0,
+    regen: float = 8.0,
+    names: tuple[str, ...] = ("Aki", "Cy"),
+) -> EnergyLedger:
+    led = EnergyLedger.fresh(
+        names,
+        max_energy=100.0,
+        regen_per_tick=regen,
+        cost_table=build_cost_table(mode, balanced_contribute=target if mode == "bal" else None),
+    )
+    for name, level in (levels or {}).items():
+        led._pool[name] = level
+    return led
+
+
+def _ev(
+    actor: str = "Cy",
+    role: str = "scholar",
+    chosen: str = "contribute",
+    executed: str | None = None,
+    **kwargs: object,
+) -> object:
+    return replay_economy.AuditEvent(
+        actor=actor,
+        role=role,
+        chosen=chosen,
+        executed=executed if executed is not None else chosen,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+# --- trace extraction -------------------------------------------------------
+
+
+def _write_episodic(path: Path, rows: list[tuple[str, str, str]]) -> Path:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE events (id INTEGER PRIMARY KEY, actor TEXT, action TEXT, payload_json TEXT)"
+    )
+    conn.executemany("INSERT INTO events (actor, action, payload_json) VALUES (?,?,?)", rows)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_audit_trace_extracts_executed_chosen_and_flags(tmp_path):
+    # The audit trace must carry BOTH verb streams plus the per-event telemetry
+    # flags: executed (the action column), chosen (payload.parsed_verb),
+    # parse_fallback and economy_substituted (gate9 stream parity).
+    ep = _write_episodic(
+        tmp_path / "episodic.sqlite",
+        [
+            (
+                "Cy",
+                "study",
+                '{"role": "scholar", "parsed_verb": "contribute", '
+                '"parse_fallback": false, "economy_substituted": true}',
+            ),
+            ("Aki", "contribute", '{"role": "artisan", "scene_id": "s-1"}'),
+            ("world", "weather.rain", "{}"),
+            ("Cy", "rest", '{"role": "scholar", "parsed_verb": "rest", "parse_fallback": true}'),
+        ],
+    )
+    trace = replay_economy._audit_trace_from_episodic(ep)
+    assert len(trace) == 3  # world event dropped
+    first = trace[0]
+    assert (first.actor, first.role) == ("Cy", "scholar")
+    assert (first.chosen, first.executed) == ("contribute", "study")
+    assert first.economy_substituted is True
+    assert first.parse_fallback is False
+    assert first.forced is False
+    scene = trace[1]
+    assert scene.forced is True
+    assert scene.scene_id == "s-1"
+    fallback = trace[2]
+    assert fallback.parse_fallback is True
+
+
+# --- hint-state parity with the live helpers --------------------------------
+
+
+@pytest.mark.parametrize("mode", ["adv", "bal", "sub"])
+@pytest.mark.parametrize("level", [100.0, 25.0, 10.0, 2.0])
+def test_hint_state_parity_with_run_helpers(monkeypatch, mode: str, level: float):
+    # The offline reconstruction must agree with run.py's live hint helpers
+    # (_compute_energy_hint fires, _energy_hint_verb names) at every pool level
+    # and mode — this test is the drift guard for the audit's validity.
+    from microverse import config, run
+
+    monkeypatch.setattr(config, "ECONOMY_MODE", mode)
+    monkeypatch.setattr(config, "_ECONOMY_SUBSTITUTE", True)
+    led = _ledger({"Cy": level}, mode=mode, target=30.0 if mode == "bal" else None)
+    # Duck-typed stand-in: the live helpers only read .name/.role.
+    agent: Any = SimpleNamespace(name="Cy", role="scholar")
+    fired, easy = replay_economy._hint_state(led, "Cy", "scholar", mode=mode)
+    assert fired == (run._compute_energy_hint(led, agent) != "")
+    assert easy == run._energy_hint_verb(led, agent)
+
+
+def test_hint_state_silent_in_non_substitute_mode():
+    # Mode "throttle" has no prompt hint live (run.py gates on _ECONOMY_SUBSTITUTE);
+    # the reconstruction must stay silent for it too.
+    led = _ledger({"Cy": 2.0}, mode="adv", target=None)
+    assert replay_economy._hint_state(led, "Cy", "scholar", mode="throttle") == (False, None)
+
+
+# --- ledger arithmetic fidelity ---------------------------------------------
+
+
+def test_audit_deducts_logged_executed_verb():
+    # Live deducts the FINAL committed verb (run.py:1222), which can differ from
+    # resolve_executed_verb(chosen) when a later lever (engagement gate)
+    # overrode the economy's output. The audit must follow the log, not re-run
+    # the executor. Here resolve(contribute) at pool 50 would keep contribute
+    # (affordable, cost 30) and leave 28; the log says study was executed (6).
+    led = _ledger({"Cy": 50.0})
+    replay_economy.audit_run([_ev(chosen="contribute", executed="study")], ledger=led, mode="bal")
+    assert led.current("Cy") == pytest.approx(52.0)  # 50 - 6 + regen 8
+
+
+def test_audit_scene_turns_excluded_and_single_regen():
+    # Scene turns are forced contributes: never hint-eligible (run.py forces
+    # energy_hint="" in scenes), excluded from free-turn/conditional streams,
+    # and a whole scene is ONE regen tick (run.py:1127).
+    led = _ledger({"Cy": 10.0})
+    events = [
+        _ev("Aki", "artisan", "contribute", forced=True, scene_id="s1"),
+        _ev("Aki", "artisan", "contribute", forced=True, scene_id="s1"),
+        _ev("Aki", "artisan", "contribute", forced=True, scene_id="s1"),
+    ]
+    report = replay_economy.audit_run(events, ledger=led, mode="bal")
+    assert report["agents"]["Aki"]["free_turns"] == 0
+    assert report["agents"]["Aki"]["chosen"] == {
+        "hint": {},
+        "absent_low": {},
+        "absent_comfortable": {},
+    }
+    assert led.current("Cy") == pytest.approx(18.0)  # one +8, not three
+
+
+# --- hint firing under drain -------------------------------------------------
+
+
+def _drain_trace(n: int) -> list[object]:
+    return [_ev(chosen="contribute", executed="contribute") for _ in range(n)]
+
+
+def test_audit_hint_firing_rate_rises_with_target():
+    # The R2 dose mechanism: a dearer balanced contribute drains the scholar
+    # below affordability sooner, so the reconstructed hint fires more often at
+    # target 30 than at 22 — and never under a generous regen.
+    r30 = replay_economy.audit_run(
+        _drain_trace(12), ledger=_ledger(target=30.0, names=("Cy",)), mode="bal"
+    )
+    r22 = replay_economy.audit_run(
+        _drain_trace(12), ledger=_ledger(target=22.0, names=("Cy",)), mode="bal"
+    )
+    generous = replay_economy.audit_run(
+        _drain_trace(12), ledger=_ledger(target=30.0, regen=50.0, names=("Cy",)), mode="bal"
+    )
+    rate30 = r30["agents"]["Cy"]["hint"]["rate"]
+    rate22 = r22["agents"]["Cy"]["hint"]["rate"]
+    assert rate30 > rate22 > 0.0
+    assert generous["agents"]["Cy"]["hint"]["rate"] == 0.0
+
+
+# --- conditional verb probabilities + obedience ------------------------------
+
+
+def test_audit_conditional_split_and_obedience():
+    # Pool pinned at 10 (regen 0, rest costs 0): contribute(30) is out of reach
+    # every turn, so the hint fires every turn and names study (cheapest
+    # affordable perceived). The agent always chooses study: P(study|hint)=1.0,
+    # obedience 1.0, and the absent strata stay empty.
+    led = _ledger({"Cy": 10.0}, regen=0.0)
+    events = [_ev(chosen="study", executed="rest") for _ in range(10)]
+    report = replay_economy.audit_run(events, ledger=led, mode="bal")
+    cy = report["agents"]["Cy"]
+    assert cy["hint"]["rate"] == 1.0
+    assert cy["hint"]["easy_verbs"] == {"study": 10}
+    assert cy["p_chosen"]["hint"]["study"] == 1.0
+    assert cy["chosen"]["absent_low"] == {}
+    assert cy["chosen"]["absent_comfortable"] == {}
+    assert cy["obedience_rate"] == 1.0
+
+
+def test_audit_low_energy_stratum_splits_hint_absent_turns():
+    # Deconfound stratum (audit review): hint-absent turns split into
+    # "low" (contribute affordable but within one regen of the threshold:
+    # energy < cost + regen) vs "comfortable". Pool 31 at bal@30/regen 8 is
+    # affordable-but-low (31 < 38); pool 100 is comfortable.
+    low = replay_economy.audit_run(
+        [_ev(chosen="contribute", executed="rest")],
+        ledger=_ledger({"Cy": 31.0}, regen=0.0),
+        mode="bal",
+    )
+    comfy = replay_economy.audit_run(
+        [_ev(chosen="contribute", executed="rest")],
+        ledger=_ledger({"Cy": 100.0}, regen=0.0),
+        mode="bal",
+    )
+    assert low["agents"]["Cy"]["chosen"]["absent_low"] == {"contribute": 1}
+    assert low["agents"]["Cy"]["chosen"]["absent_comfortable"] == {}
+    assert comfy["agents"]["Cy"]["chosen"]["absent_comfortable"] == {"contribute": 1}
+    assert comfy["agents"]["Cy"]["chosen"]["absent_low"] == {}
+
+
+def test_audit_parse_fallback_excluded_from_chosen_streams():
+    # gate9 parity: a parse-fallback REST is not a free verb choice; it must not
+    # pollute the conditional chosen streams (but the turn still counts toward
+    # the hint-rate denominator — the hint was computed live regardless).
+    led = _ledger({"Cy": 100.0}, regen=0.0)
+    events = [_ev(chosen="rest", executed="rest", parse_fallback=True)]
+    report = replay_economy.audit_run(events, ledger=led, mode="bal")
+    cy = report["agents"]["Cy"]
+    assert cy["free_turns"] == 1
+    assert cy["chosen"]["absent_comfortable"] == {}
+
+
+# --- energy trace summary -----------------------------------------------------
+
+
+def test_audit_energy_trace_summary():
+    # Pre-deduct snapshots: pool pinned at 10 by regen 0 + rest. The summary
+    # must report min/mean/equilibrium at 10 and contribute unaffordable on
+    # every free turn (10 < 30).
+    led = _ledger({"Cy": 10.0}, regen=0.0)
+    events = [_ev(chosen="study", executed="rest") for _ in range(8)]
+    report = replay_economy.audit_run(events, ledger=led, mode="bal")
+    energy = report["agents"]["Cy"]["energy"]
+    assert energy["min"] == pytest.approx(10.0)
+    assert energy["mean"] == pytest.approx(10.0)
+    assert energy["equilibrium"] == pytest.approx(10.0)
+    assert energy["contribute_unaffordable_rate"] == 1.0
+
+
+# --- predicted-vs-logged substitution fidelity --------------------------------
+
+
+def test_audit_substitution_agreement_perfect():
+    # Drained pool, chosen=contribute: the offline executor predicts a
+    # substitution; the log agrees (economy_substituted=True, executed=study).
+    led = _ledger({"Cy": 10.0}, regen=0.0)
+    events = [
+        _ev(chosen="contribute", executed="study", economy_substituted=True) for _ in range(5)
+    ]
+    report = replay_economy.audit_run(events, ledger=led, mode="bal")
+    fid = report["fidelity"]
+    assert fid["events"] == 5
+    assert fid["rate"] == 1.0
+    assert fid["hint_on"]["events"] == 5
+    assert fid["hint_on"]["rate"] == 1.0
+    assert fid["hint_off"]["events"] == 0
+
+
+def test_audit_substitution_agreement_counts_mismatches():
+    # An event the reconstruction predicts substituted but the log says was not
+    # (or vice versa) must lower the agreement rate — this is the C5 gate that
+    # decides whether the reconstruction can carry the audit at all.
+    led = _ledger({"Cy": 10.0}, regen=0.0)
+    events = [
+        _ev(chosen="contribute", executed="study", economy_substituted=True),
+        _ev(chosen="contribute", executed="study", economy_substituted=True),
+        _ev(chosen="contribute", executed="contribute", economy_substituted=False),  # mismatch
+        _ev(chosen="study", executed="study", economy_substituted=False),  # affordable: agree
+    ]
+    report = replay_economy.audit_run(events, ledger=led, mode="bal")
+    fid = report["fidelity"]
+    assert fid["events"] == 4
+    assert fid["agreements"] == 3
+    assert fid["rate"] == pytest.approx(0.75)
+
+
+def test_audit_deterministic():
+    led1 = _ledger({"Cy": 40.0})
+    led2 = _ledger({"Cy": 40.0})
+    events = _drain_trace(20)
+    r1 = replay_economy.audit_run(events, ledger=led1, mode="bal")
+    r2 = replay_economy.audit_run(events, ledger=led2, mode="bal")
+    assert r1 == r2
+
+
+# --- audit spec parsing --------------------------------------------------------
+
+
+def test_parse_audit_spec_accepts_mode_target_path():
+    spec = replay_economy.parse_audit_spec("bal@30=data/econ-stage6-bal30-s42")
+    assert spec.mode == "bal"
+    assert spec.target == 30.0
+    assert spec.path == Path("data/econ-stage6-bal30-s42")
+    assert spec.arm == "bal@30"
+    plain = replay_economy.parse_audit_spec("adv=data/econ-stage6-adv-s42")
+    assert plain.mode == "adv"
+    assert plain.target is None
+    assert plain.arm == "adv"
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "data/no-equals",  # malformed
+        "warp=data/x",  # unknown mode
+        "adv@30=data/x",  # target only valid for bal
+        "bal@nan=data/x",  # non-finite target
+        "bal@-5=data/x",  # non-positive target
+        "bal@30=",  # empty path
+    ],
+)
+def test_parse_audit_spec_rejects_invalid(spec: str):
+    with pytest.raises(ValueError, match="audit spec"):
+        replay_economy.parse_audit_spec(spec)
+
+
+# --- aggregation ----------------------------------------------------------------
+
+
+def _wrap(arm: str, run: str, report: dict) -> dict:
+    return {"arm": arm, "run": run, "report": report}
+
+
+def test_aggregate_top_verb_stability_and_decomposition():
+    # Two bal arms, one run each. Cy: hint fires more at 30 and study tracks the
+    # hint; Aki: craft dominates everywhere. The aggregate must report per-arm
+    # mean firing rates, per-agent top-verb stability, and the decomposition
+    # (observed delta-study vs delta-firing x conditional effect).
+    led22 = _ledger({"Cy": 100.0, "Aki": 100.0}, target=22.0)
+    led30 = _ledger({"Cy": 100.0, "Aki": 100.0}, target=30.0)
+    mixed22 = [
+        ev
+        for _ in range(15)
+        for ev in (
+            _ev("Cy", "scholar", "contribute", "contribute"),
+            _ev("Aki", "artisan", "craft", "craft"),
+        )
+    ]
+    mixed30 = [
+        ev
+        for _ in range(15)
+        for ev in (
+            _ev("Cy", "scholar", "contribute", "contribute"),
+            _ev("Aki", "artisan", "craft", "craft"),
+        )
+    ]
+    r22 = replay_economy.audit_run(mixed22, ledger=led22, mode="bal")
+    r30 = replay_economy.audit_run(mixed30, ledger=led30, mode="bal")
+    agg = replay_economy.aggregate_audit([_wrap("bal@22", "s42", r22), _wrap("bal@30", "s42", r30)])
+    assert (
+        agg["arms"]["bal@30"]["Cy"]["hint_rate_mean"]
+        >= (agg["arms"]["bal@22"]["Cy"]["hint_rate_mean"])
+    )
+    aki = agg["stability"]["Aki"]
+    assert aki["top_verb_by_run"] == {"bal@22/s42": "craft", "bal@30/s42": "craft"}
+    assert aki["stable"] is True
+    assert "decomposition" in agg
+    assert "Cy" in agg["decomposition"]
+    cy_dec = agg["decomposition"]["Cy"]
+    assert set(cy_dec) >= {"verb", "observed_delta", "predicted_delta", "fit_ratio"}
+
+
+def test_aggregate_single_arm_has_no_decomposition():
+    led = _ledger({"Cy": 100.0}, target=30.0)
+    r = replay_economy.audit_run(_drain_trace(5), ledger=led, mode="bal")
+    agg = replay_economy.aggregate_audit([_wrap("bal@30", "s42", r)])
+    assert agg["decomposition"] == {}
+
+
+# --- CLI wiring -------------------------------------------------------------------
+
+
+def test_main_audit_cli_end_to_end(tmp_path, capsys):
+    # --audit must thread the spec's mode/target into the cost table, replay the
+    # run dir's episodic.sqlite, and emit a mechanism_audit section with per-run
+    # reports and the aggregate.
+    run = tmp_path / "econ-stage6-bal30-s42"
+    run.mkdir()
+    _write_episodic(
+        run / "episodic.sqlite",
+        [
+            (
+                "Cy",
+                "contribute",
+                '{"role": "scholar", "parsed_verb": "contribute", '
+                '"parse_fallback": false, "economy_substituted": false}',
+            )
+            for _ in range(5)
+        ],
+    )
+    rc = replay_economy.main(["--audit", f"bal@30={run}"])
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    audit = report["mechanism_audit"]
+    assert len(audit["runs"]) == 1
+    assert audit["runs"][0]["arm"] == "bal@30"
+    assert audit["runs"][0]["run"] == run.name
+    assert "Cy" in audit["runs"][0]["report"]["agents"]
+    assert "arms" in audit["aggregate"]
+
+
+def test_main_audit_missing_episodic_fails_fast(tmp_path):
+    run = tmp_path / "missing"
+    run.mkdir()
+    rc = replay_economy.main(["--audit", f"bal@30={run}"])
+    assert rc == 2
+
+
+def test_main_rejects_malformed_audit_spec():
+    with pytest.raises(SystemExit):
+        replay_economy.parse_args(["--audit", "warp=data/x"])


### PR DESCRIPTION
## Summary

Implements ADR 0012 Phase 2 item 2: an offline mechanism audit of the Stage 6 Gate 9 PASS (PR #55). Extends `scripts/replay_economy.py` with an `--audit` mode that reconstructs per-turn scarcity-hint state from the frozen Stage 6 runs (zero new LLM compute) and scores it against pre-registered criteria. **Verdict: CONFIRMED — the hint is the operative channel** (ADR 0013).

## Background / Motivation

ADR 0012's PASS read only aggregate verb distributions; the causal middle links (does the hint actually fire more at T=30? does the model obey it per-turn?) were unmeasured. ADR 0012 made this audit the gate before investing in held-out replication (item 3) and roster generality (item 4). The hint text is never persisted, but its state is deterministically reconstructable: replay the EnergyLedger over the LOGGED executed-verb stream (exact live arithmetic, run.py:1222 / run.py:1127) and re-evaluate the live hint predicate pre-deduct (run.py:983). The logged `economy_substituted` flag provides an in-band fidelity check.

## Breaking Changes

- [ ] No breaking changes. `--audit` is additive; the existing Stage-0 replay (`--data`) and Stage-1 synthetic paths are byte-stable (the audit extractor is a sibling, not a modification).

## Changes Made

- `scripts/replay_economy.py`: `AuditEvent`/`AuditSpec`, `_audit_trace_from_episodic` (chosen + executed streams + gate9 telemetry flags), `_hint_state` (offline reimplementation of run.py's hint predicate/selector, mode passed explicitly so one process audits three arms), `audit_run` (pre-deduct snapshots, logged-verb deduction, scene-collapsed regen; emits energy traces, firing rates, conditional chosen-verb strata incl. the `absent_low` deconfound band, obedience, and the predicted-vs-logged fidelity check split by hint-on/off), `aggregate_audit` (per-arm pooled conditionals, top-verb stability, bal-pair decomposition), repeatable `--audit MODE[@TARGET]=PATH` CLI.
- `tests/test_economy_audit.py`: 36 offline tests, including a parity test pinning `_hint_state` to `run._compute_energy_hint`/`_energy_hint_verb` so the reconstruction cannot drift from live semantics.
- `docs/economy-phase2-mechanism-audit.md`: pre-registered criteria (committed BEFORE the instrument read any real event table — see commit 4902662 vs c2a6669), full results, scorecard, findings.
- `docs/adr/0013-action-economy-mechanism-audit.md`: the verdict record.

## Dependencies

None added.

## Test Methodologies and Results

1. `uv run pytest -q -m 'not integration'` → **693 passed** (36 new).
2. `uv run ruff check && uv run ruff format --check && uv run mypy src/microverse && uv run pip-audit && uv build` → all green.
3. The audit itself (read-only on the nine frozen `data/econ-stage6-*` dirs; command in the findings doc Setup section). Headline numbers:
   - **C5 (fidelity) PASS**: hint-off agreement 1.000 in ALL nine runs; hint-on 0.919–0.948 (floor 0.90).
   - **C1 (dose) PASS**: Cy firing adv 0.01–0.04 ≤ bal@22 0.39–0.42 < bal@30 0.66; bal-pair gaps +0.24..+0.27 (floor 0.15).
   - **C2 (conditional shift) PASS**: P(Cy study|hint) 0.56–0.67 vs ≤0.003 absent; contribute suppressed under hint everywhere. Deconfound stratum flat at ~0: the hint TEXT moves the model, not the raw energy level.
   - **C3 (decomposition) PASS**: Cy fit ratio 1.10 (band 0.5–1.5).
   - **C4 FAIL-as-drafted** (criterion mis-specification, scored honestly per pre-registration discipline): `contribute` tops Aki's chosen stream in every arm including adv (pre-Stage-6 fact the drafting missed), and bal moves Aki's own economy too. The underlying no-cross-role-bleed falsification holds cleanly (hint named craft on 100% of Aki's fired turns, study on 100% of Cy's; Aki-study ≤0.02, Cy-craft ≤0.01).

## Design & Reasoning Notes

- **Extension of `replay_economy.py`, not a new script**: the audit needs the exact PR-#55-corrected tick model (scene-collapsed regen); duplicating it would reintroduce the just-patched fidelity-bug class. T20 opt-in and test-loading pattern already exist for this file.
- **Deducts the LOGGED executed verb**, not `resolve(chosen)`: live deducts the committed verb, so the ledger replay is exact arithmetic, unlike the Stage-0 estimator.
- **Conditional probabilities POOLED** (counts summed before dividing) across an (arm, agent) group: stable when hint turns are scarce (adv has 14–40 Cy hint turns per run).
- **Pre-registration honesty**: aggregate Stage 6 verb shifts were already known; the genuinely unseen quantities (firing rates, conditionals, strata, fidelity) are what the criteria bind. C4's literal failure is recorded, not patched away; the corrected criterion is handed to the item 3 pre-registration (ADR 0013 Decision 2).
- Alternative considered and rejected: stamping hint state into the live payload first, then auditing. Rejected because it cannot audit the EXISTING nine runs — and C5 passing proves the reconstruction suffices.

## Impact / Risk Assessment

- Affected: offline tooling + docs only; `src/microverse/` untouched, zero runtime behavior change.
- Risk: a reconstruction bug could mis-state the verdict. Mitigation: the parity test pins the predicate to run.py's helpers; C5 validates against the in-band logged flag per run (hint-off exact in all nine).
- Rollback: revert the PR; no state or schema involved.

## Documentation

- New: `docs/economy-phase2-mechanism-audit.md`, `docs/adr/0013-action-economy-mechanism-audit.md`.
- `README.md` / `CLAUDE.md` / `AGENTS.md` unchanged: no new invariants, commands, or workflows beyond a script flag documented in the script's own docstring and the findings doc.

## Review Focus

- [CRITICAL] `_hint_state` + the pre-deduct snapshot ordering in `audit_run` (scripts/replay_economy.py) — the audit's validity rests on matching live semantics; check against run.py:983/1222/1127.
- [IMPORTANT] Stratum definition (`absent_low` = contribute affordable but energy < cost + regen) — the deconfound band's interpretation.
- [IMPORTANT] `aggregate_audit` decomposition (pooled conditional effect × arm-mean firing delta) — the C3 arithmetic.
- [MINOR] AuditSpec parsing/error messages.

## Post-Merge Recommendations

Next blocking action: **Phase 2 item 3 — held-out replication with T fixed at 30** (fresh seeds + multiple unseeded repeats per condition). Its pre-registration must (a) use the corrected stability criterion from ADR 0013 Decision 2, and (b) decide whether to stamp `energy_hint_fired` into the live payload (ADR 0013 Decision 3) — C5 passed without it, but logging retires the reconstruction caveat for good. Items 4 (roster generality) and 5 (Gate 9 report automation) follow; the audit's `parse_audit_spec`/`aggregate_audit` are importable for item 5 reuse.