### PR TITLE
feat(economy): hint ground-truth logging + pre-registered T=30 replication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ soak-*.log
 soak-*.pid
 soak-status*/
 smoke-*.log
+econ-*-sweep.log
 
 # OS noise
 .DS_Store

--- a/docs/adr/0014-action-economy-replication.md
+++ b/docs/adr/0014-action-economy-replication.md
@@ -1,0 +1,92 @@
+# ADR 0014: Action-economy held-out replication — the `bal@30` Gate 9 PASS is stable
+
+**Status:** Accepted (measurement record) — records the held-out replication sweep (ADR 0012
+Phase 2 item 3) of the Stage 6 Gate 9 PASS. **Verdict: REPLICATED.** The instrument gate, Layer 1
+(gate replication), and Layer 2 (role stability) all pass in full at all three fresh seeds, against
+the two-layer rule locked before the sweep's first tick, with no post-hoc amendment.
+
+**Date:** 2026-06-14
+
+## Context
+
+ADR 0012 lifted the arc's HALT on the first Gate 9 PASS (`bal@30`, seeds {42, 38, 7}); ADR 0013
+confirmed the scarcity hint as the operative channel. Both records scoped the claim deliberately as
+"first locked pass, to be replicated" — a single sweep at three seeds cannot tell a stable effect
+from a lucky draw of `gemma4:26b`'s unseeded sampling. Phase 2 item 3 tests stability: hold the
+balanced contribute target fixed at **T = 30** (re-tune nothing), draw fresh seeds {101, 202, 303}
+disjoint from every prior economy read, and re-read Gate 9 against a pre-registered rule.
+
+ADR 0013 handed this PR two obligations: **Decision 2** (the replication pre-registration must use
+the corrected stability criterion — Aki's top NON-contribute chosen verb, not the mis-drafted C4
+that tested a `craft`-tops baseline which never existed) and **Decision 3** (stamp ground-truth
+hint state into the live payload to retire the reconstruction caveat). Both are discharged here.
+
+## Method
+
+One sweep, `{bal@22 in-sweep control, bal@30}` × seeds `{101, 202, 303}` × 3000 ticks,
+seed-outer / arm-inner, `gemma4:26b`, energy knobs at the live defaults (max 100, regen 8). Run
+detached 2026-06-12 → 2026-06-14 (~6.3 h / ~4540 events per run). The control is in-sweep `bal@22`,
+not Stage 6's archived control, because model/runtime behavior can drift between sweeps separated by
+days; the only causally clean comparator is a `bal@22` paired temporally adjacent to its `bal@30`.
+
+The two-layer pass rule, instrument gate, verdict mapping, and secondary/advisory metrics were
+committed to git (`docs/economy-phase2-replication-runbook.md`, commit `2d4ef8b`) **before** the
+sweep's first tick. The ground-truth hint logging (`energy_hint_fired` / `energy_hint_verb`,
+observation-only, pinned by unit tests and a byte-identical re-read of a Stage 6 dir) and the
+audit's `fidelity.hint_logged` block shipped in the same PR.
+
+## Results (summary — full tables in the findings doc)
+
+- **Instrument gate PASS (all six runs).** Substitution fidelity hint-off 1.000, hint-on
+  0.924–0.939 (floor 0.90); `hint_logged` reconstruction-vs-logged agreement 0.9992–1.000 (the
+  reconstruction matches live truth almost exactly, so the mechanism reads stand on logged ground
+  truth); coverage 1499–2569 events per block (floor 10).
+- **Layer 1 PASS (gate replication).** `bal@30` chosen `jsd_norm` 0.337 / 0.372 / 0.387 at seeds
+  101 / 202 / 303 (floor 0.25), `entropy_norm` 0.623 / 0.634 / 0.635 (floor 0.35), each beating its
+  matched `bal@22` control (0.271 / 0.249 / 0.258) by 0.066–0.129 — past the pre-registered 0.02
+  noise margin at every seed. The fresh-seed values bracket and slightly exceed Stage 6's
+  0.307 / 0.344 / 0.376.
+- **Layer 2 PASS (role stability).** At all three `bal@30` seeds Aki's top non-contribute chosen
+  verb is `craft` and Cy's is `study`; cross-role bleed ≤ 0.027 (floor 0.05). No identity collapse.
+- **Secondary attribution (reported, confirmatory).** Cy contribute drop 0.114–0.159 (≥ 0.10 every
+  seed); mean Cy study rise 0.125 across seeds (floor 0.05), no seed below 0.116.
+- **Advisory mechanism diagnostics (directional).** Cy hint firing rises 0.43–0.48 → 0.65–0.67
+  bal@22→bal@30; `P(Cy study | hint)` 0.62–0.65 vs ≤ 0.003 absent, with the `absent_low` deconfound
+  flat at ≤ 0.007; Cy obedience 0.62–0.65 (floor 0.30); the hint names `craft` for Aki and `study`
+  for Cy at every seed.
+- **R3 scene-collapse watch clears.** scene_completed 318–360 across all runs, `bal@30` ≈ `bal@22`;
+  `json_fallback_rest` ≤ 2.
+
+## Decision
+
+1. **The Stage 6 Gate 9 PASS is upgraded from "first locked pass" to "replicated."** The claim's
+   scope moves from "the tuned economy produced divergence at three seeds" to "the divergence is
+   stable across fresh unseeded sampling draws at held-out seeds, with T fixed at 30." The
+   ADR 0012/0013 causal narrative survives unchanged on new data.
+2. **Phase 2 item 4 (roster generality) is now the live frontier.** Replication is settled for the
+   two-resident roster; the open question is whether the effect generalizes across more residents,
+   different soul-token weights, and different role pairings.
+3. **The ground-truth hint logging stays in the live loop.** It retired the ADR 0013 reconstruction
+   caveat (hint_logged ≥ 0.9992 everywhere) and is observation-only, so it carries forward as the
+   audit's truth source for item 4 with no comparability cost.
+4. **The pre-registration discipline is recorded as a pass, not a patch.** Unlike ADR 0013's C4,
+   every layer here scored as drafted; the verdict needed no amendment. The corrected Decision-2
+   criterion (top non-contribute verb) held cleanly on held-out data, validating the ADR 0013
+   diagnosis of the C4 mis-drafting.
+
+## Scope and limitations
+
+- Two-resident roster, single model (`gemma4:26b`), T fixed at 30, three fresh seeds. The seed
+  controls weather/scheduler RNG only; `gemma4:26b` sampling is unseeded, so this supports "stable
+  across fresh stochastic runs" but does NOT decompose seed effects vs sampling noise (fixed-seed
+  repeats would, out of scope).
+- Roster generality (item 4) is untouched by this sweep.
+- No mid-run restarts; the instrument gate was re-checked on logged ground truth and passes.
+
+## Reproduction
+
+Findings: `docs/economy-phase2-replication-findings.md`. Pre-registration:
+`docs/economy-phase2-replication-runbook.md` (locked `2d4ef8b`). Sweep driver:
+`scripts/run_rep30_sweep.sh`. Audit:
+`scripts/replay_economy.py --audit bal=data/econ-rep30-bal22-s<seed> --audit bal@30=data/econ-rep30-bal30-s<seed>`.
+Run dirs `data/econ-rep30-*` (untracked, kept locally).

--- a/docs/economy-phase2-replication-findings.md
+++ b/docs/economy-phase2-replication-findings.md
@@ -1,0 +1,186 @@
+# Action-economy Phase 2 item 3 findings — held-out replication of the `bal@30` Gate 9 PASS
+
+Operator note recording the live held-out replication sweep that feeds **ADR 0014**. This is the
+sweep pre-registered in `docs/economy-phase2-replication-runbook.md` (locked at commit `2d4ef8b`,
+before the sweep's first tick). It tests whether the Stage 6 Gate 9 PASS (ADR 0012, seeds
+{42, 38, 7}) is **stable under replication**: the balanced contribute target stays fixed at
+**T = 30** (nothing is re-tuned), only the seeds are fresh ({101, 202, 303}, disjoint from every
+prior economy read) and each run is a new unseeded sampling draw of `gemma4:26b`.
+
+**Headline: REPLICATED.** Instrument gate PASS, Layer 1 (gate replication) PASS, Layer 2 (role
+stability) PASS — all three at every fresh seed, against the locked two-layer rule, with no
+post-hoc amendment. The arc's first Gate 9 PASS holds on held-out seeds.
+
+## Setup
+
+- Matrix `{bal@22 in-sweep control, bal@30}` × seeds `{101, 202, 303}` × 3000 ticks, one sweep,
+  seed-outer / arm-inner. Model `gemma4:26b`, energy knobs at the live defaults (max 100,
+  regen 8). State dirs `data/econ-rep30-<arm>-s<seed>`.
+
+  ```bash
+  env MICROVERSE_ECONOMY=bal [MICROVERSE_BAL_CONTRIBUTE=30] \
+    MICROVERSE_DATA=data/econ-rep30-<arm>-s<seed> \
+    MICROVERSE_HARVEST=harvest/econ-rep30-<arm>-s<seed> \
+    uv run python -m microverse.run --ticks 3000 --tempo 0 --seed <seed>
+  ```
+
+- Arms: `bal@22` (`bal` at the natural dearest contribute cost 22, `MICROVERSE_BAL_CONTRIBUTE`
+  unset — the **in-sweep control**, isolating the raised target from unseeded sampling drift);
+  `bal@30` (the replicated arm, `MICROVERSE_BAL_CONTRIBUTE=30`, T fixed not re-tuned). No `adv`
+  arm: its Stage-6 role (reproducing the one-sided Stage-4/5 mechanism) is settled and re-running
+  it buys nothing for the replication claim.
+- Run detached 2026-06-12 20:38 → 2026-06-14 11:02 JST (pid 59409), ~6.3 h / ~4540 agent events
+  per run, dead-steady pacing. Each seed's `bal@22` control is paired temporally adjacent to its
+  `bal@30`, so the archived Stage-6 control is a reference only, not the comparator.
+- Metric: `gate9_verb_diversity` (`scripts/spike_workshop_measure.py`), **chosen** (`parsed_verb`)
+  stream, exactly as Stage 6. Gate 9 PASS = chosen `entropy_norm ≥ 0.35` AND chosen
+  `jsd_norm ≥ 0.25`. Mechanism audit via `scripts/replay_economy.py --audit MODE[@TARGET]=PATH`
+  over all six dirs.
+
+## What was new in the instrument (and why it does not break comparability)
+
+ADR 0013 Decision 3: this PR stamps the live scarcity-hint state into each free-turn payload —
+`energy_hint_fired` and `energy_hint_verb` — computed once per free turn and threaded to the
+prompt, the R4 conflict counter, and the payload so they cannot diverge. The audit's new
+`fidelity.hint_logged` block compares its offline reconstruction against this logged ground truth,
+retiring the ADR 0013 reconstruction caveat. The keys are observation-only (pinned by
+`tests/test_run_economy.py` and by the audit re-read of `data/econ-stage6-bal30-s42`, numerically
+identical to the PR #56 report except for the added null `hint_logged` block); Gate 9 filters
+only `parsed_verb` / `scene_id` / `parse_fallback` / `economy_substituted`, so it is inert to the
+new keys. The replication runs therefore remain comparable to Stage 6.
+
+## Instrument gate (checked before any behavioral verdict)
+
+Per run: substitution fidelity (the audit's C5) ≥ 0.90 on both the hint-off and hint-on subsets;
+`hint_logged` agreement ≥ 0.90; coverage ≥ 10 events on the hint-on and `hint_logged` blocks.
+
+| run | hint-off | hint-on | hint-on n | hint_logged | hint_logged n |
+|-----|---------:|--------:|----------:|------------:|--------------:|
+| `bal@22`-s101 | 1.000 | 0.924 | 1499 | 1.000 | 2569 |
+| `bal@30`-s101 | 1.000 | 0.939 | 1974 | 1.000 | 2560 |
+| `bal@22`-s202 | 1.000 | 0.924 | 1519 | 1.000 | 2561 |
+| `bal@30`-s202 | 1.000 | 0.934 | 1959 | 1.000 | 2564 |
+| `bal@22`-s303 | 1.000 | 0.932 | 1528 | 0.9992 | 2516 |
+| `bal@30`-s303 | 1.000 | 0.935 | 1955 | 1.000 | 2529 |
+
+**Instrument gate PASS.** Hint-off exact in all six runs (no phantom scarcity); hint-on
+0.924–0.939 (floor 0.90); `hint_logged` 0.9992–1.000 — the offline reconstruction matches the
+live ground truth almost exactly, so the audit's mechanism reads below stand on logged truth, not
+reconstruction. Coverage is two-to-three orders of magnitude above the 10-event floor.
+
+## Layer 1 — gate replication (hard)
+
+At all three fresh seeds: `bal@30` chosen `entropy_norm ≥ 0.35` AND `jsd_norm ≥ 0.25`; AND
+`jsd_norm(bal@30) > jsd_norm(bal@22) + 0.02` at every matched seed.
+
+| seed | jsd `bal@22` | jsd `bal@30` | margin | > +0.02 | entropy `bal@30` | ≥ 0.35 | jsd ≥ 0.25 |
+|------|-------------:|-------------:|-------:|:-------:|-----------------:|:------:|:----------:|
+| 101 | 0.2714 | 0.3369 | 0.0655 | ✅ | 0.6226 | ✅ | ✅ |
+| 202 | 0.2488 | 0.3715 | 0.1227 | ✅ | 0.6342 | ✅ | ✅ |
+| 303 | 0.2583 | 0.3873 | 0.1290 | ✅ | 0.6354 | ✅ | ✅ |
+
+**Layer 1 PASS.** Every `bal@30` seed clears both floors with margin, and beats its matched
+`bal@22` control by 0.066–0.129 (well past the 0.02 noise margin). The fresh-seed `bal@30` jsd
+values (0.337 / 0.372 / 0.387) bracket and slightly exceed the Stage 6 results
+(0.307 / 0.344 / 0.376 at seeds 42 / 38 / 7) — replication is not a marginal re-pass. The matched
+`bal@22` controls sit at 0.249–0.271, below or at the 0.25 floor, exactly the near-miss Stage 6
+diagnosed as residual R2.
+
+## Layer 2 — role stability (hard, the ADR 0013 Decision 2 corrected criterion)
+
+At all three `bal@30` seeds: Aki's top NON-contribute chosen verb is `craft` AND Cy's is `study`;
+no cross-role bleed (Aki chosen-`study` ≤ 0.05 AND Cy chosen-`craft` ≤ 0.05). Phrased on the top
+non-contribute verb because `contribute` tops both agents' raw chosen streams by design (the
+ADR 0013 C4 lesson).
+
+| seed | Aki top non-contrib | Aki `study` | Cy top non-contrib | Cy `craft` |
+|------|--------------------:|------------:|-------------------:|-----------:|
+| 101 | `craft` | 0.0213 | `study` | 0.0189 |
+| 202 | `craft` | 0.0167 | `study` | 0.0198 |
+| 303 | `craft` | 0.0108 | `study` | 0.0267 |
+
+**Layer 2 PASS.** The specialization is the same one Stage 6 produced: the artisan keeps `craft`,
+the scholar keeps `study`, and neither drifts toward the other's specialty (max cross-bleed 0.027,
+floor 0.05). No identity collapse at fresh seeds.
+
+## Verdict
+
+**REPLICATED.** Instrument gate PASS, Layer 1 PASS, Layer 2 PASS, all in full at every fresh seed.
+By the locked rule (REPLICATED iff Layer 1 AND Layer 2 hold, given the instrument gate passed),
+the Stage 6 Gate 9 PASS is stable under replication on held-out seeds with T fixed at 30.
+
+## Secondary attribution metrics (reported, NOT gating)
+
+Per matched seed vs the in-sweep `bal@22` control. Stage 6's conditions 2/4, demoted to
+confirmatory because the lever attribution was already established in ADR 0013; replication tests
+stability, not attribution.
+
+| seed | Cy contribute `bal@22`→`bal@30` | drop | ≥ 0.10 | Cy study `bal@22`→`bal@30` | rise |
+|------|--------------------------------:|-----:|:------:|---------------------------:|-----:|
+| 101 | 0.656 → 0.497 | 0.159 | ✅ | 0.276 → 0.417 | 0.141 |
+| 202 | 0.613 → 0.499 | 0.114 | ✅ | 0.303 → 0.419 | 0.116 |
+| 303 | 0.599 → 0.471 | 0.128 | ✅ | 0.319 → 0.438 | 0.119 |
+
+Cy contribute drops ≥ 0.10 at every seed; mean Cy study rise across the three fresh seeds is
+**0.125** (floor 0.05), with no seed below 0.116 — the aggregate does not hide a zero-rise seed.
+The scholar reallocates from contribute to study under the raised target, the same substitution
+Stage 6 measured.
+
+## Advisory mechanism diagnostics (directional, deliberately no numeric bands)
+
+From `--audit` over the six dirs (the audit now stands on logged hint ground truth):
+
+- **Cy hint firing materially higher in `bal@30`** than its matched `bal@22` at every seed:
+  0.433 → 0.672 (s101), 0.465 → 0.647 (s202), 0.477 → 0.674 (s303). Same dose direction Stage 6
+  and ADR 0013 reported.
+- **`P(Cy study | hint fired) > P(Cy study | hint absent)`** at every `bal@30` seed: 0.619 / 0.647
+  / 0.649 conditional on the hint, vs ≤ 0.003 absent. The `absent_low` deconfound stratum
+  (hint-absent turns energetically adjacent to the threshold) stays flat at ≤ 0.007 — the hint
+  TEXT moves the model, not the bare energy level, replicating ADR 0013's C2.
+- **Cy obedience to the named verb ≥ 0.30** (advisory floor): 0.619 / 0.647 / 0.649 across seeds.
+- **Per-agent specialty hint targeting persists:** Aki's fired turns name `craft`, Cy's name
+  `study`, at all three seeds (Aki firing itself rises 0.689 → 0.842, 0.688 → 0.848, 0.703 → 0.843
+  — `bal` raises the artisan's own contribute cost too, the same self-economy ADR 0013 noted).
+
+## Quality counters (reported MAX across runs, R3 scene-collapse watch)
+
+| run | scene_completed | scene_aborted | novelty_energy_hint_conflict | json_fallback_rest |
+|-----|----------------:|--------------:|-----------------------------:|-------------------:|
+| `bal@22`-s101 | 325 | 106 | 455 | 1 |
+| `bal@30`-s101 | 324 | 116 | 706 | 2 |
+| `bal@22`-s202 | 334 | 105 | 504 | 1 |
+| `bal@30`-s202 | 318 | 118 | 685 | 2 |
+| `bal@22`-s303 | 360 | 124 | 505 | 2 |
+| `bal@30`-s303 | 338 | 133 | 706 | 0 |
+
+**Scenes do not collapse at fresh seeds (R3 clears):** scene_completed is 318–360 across all six
+runs, `bal@30` ≈ `bal@22` (no scene attrition from the raised target). `json_fallback_rest` is
+0–2 (parse health intact). `novelty_energy_hint_conflict` is higher in `bal@30`
+(685–706 vs 455–505) — expected, since the hint fires more often, so the novelty/scarcity
+co-fire opportunity rises; the conflict resolver favors the scarcity hint by design and the Layer 2
+role stability shows no resulting drift.
+
+## Honesty note
+
+The Stage 6 results at seeds {42, 38, 7} were known. Everything this sweep measures — all six
+fresh-seed runs — was genuinely unseen at pre-registration time, and the two-layer rule, instrument
+gate, and verdict mapping were committed to git (`2d4ef8b`) before the sweep's first tick. No
+criterion was amended after the read.
+
+## Scope and limitations
+
+- Two-resident roster, single model (`gemma4:26b`), T fixed at 30. Replication is over fresh
+  unseeded sampling draws at three new seeds; the seed controls weather/scheduler RNG only, so
+  this design supports "stable across fresh stochastic runs" but does NOT decompose seed effects
+  vs sampling noise (that needs fixed-seed repeats, out of scope).
+- Roster generality (more residents, different weights/pairings) remains Phase 2 item 4 — this
+  sweep does not speak to it.
+- No mid-run restarts; the instrument gate was re-checked on logged ground truth and passes.
+
+## Reproduction
+
+Runbook: `docs/economy-phase2-replication-runbook.md` (pre-registration, locked `2d4ef8b`). Sweep
+driver: `scripts/run_rep30_sweep.sh`. Per-run gate reports:
+`data/econ-rep30-<arm>-s<seed>/gate-report.json`. Audit:
+`uv run python scripts/replay_economy.py --audit bal=data/econ-rep30-bal22-s<seed> --audit bal@30=data/econ-rep30-bal30-s<seed>`
+(run dirs untracked, kept locally).

--- a/docs/economy-phase2-replication-runbook.md
+++ b/docs/economy-phase2-replication-runbook.md
@@ -64,9 +64,11 @@ Model `gemma4:26b`, energy knobs at the live defaults (max 100, regen 8). State 
 nohup ./scripts/run_rep30_sweep.sh > econ-rep30-sweep.log 2>&1 &
 ```
 
-(The script writes each run's Gate 1–9 report to `data/econ-rep30-<tag>/gate-report.json` and
-refuses to append to a partial run dir — a crashed run is re-run fresh, never restarted, because a
-mid-run restart would both weaken the audit reconstruction and make the run non-comparable.)
+(The script writes each run's Gate 1–9 report to `data/econ-rep30-<arm>-s<seed>/gate-report.json`
+and refuses to append to a partial run dir — a crashed run is re-run fresh, never restarted,
+because a mid-run restart would both weaken the audit reconstruction and make the run
+non-comparable. Path template corrected post-launch — a doubled-prefix typo flagged in review;
+no criterion touched.)
 
 ### Instrument gate (checked before any behavioral verdict is read)
 

--- a/docs/economy-phase2-replication-runbook.md
+++ b/docs/economy-phase2-replication-runbook.md
@@ -1,0 +1,142 @@
+# Phase 2 item 3 runbook — held-out replication of the `bal@30` Gate 9 PASS (T fixed at 30)
+
+Operator handoff + **pre-registration** for the ADR 0012 Phase 2 item 3 replication sweep.
+Stage 6 (ADR 0012) produced the arc's first Gate 9 PASS at `bal@30`, seeds {42, 38, 7}; the
+mechanism audit (ADR 0013) confirmed the scarcity hint as the operative channel. Both records
+scope the claim as "first locked pass, to be replicated." This sweep tests whether the PASS is
+**stable under replication**: the target stays fixed at T = 30 (nothing is re-tuned), only the
+seeds are fresh and the runs are new draws of `gemma4:26b`'s unseeded sampling.
+
+This PR ships the **ground-truth hint logging + the audit's logged-hint fidelity check + this
+pre-registration**; the sweep launches right after the pre-registration commit and the findings +
+ADR 0014 land in the same PR after the read (~38 h of live compute later).
+
+## What is new in the instrument (and why it does not break comparability)
+
+ADR 0013 Decision 3: the replication runs stamp the live scarcity-hint state into each free-turn
+payload — `energy_hint_fired` (was the hint in the prompt this turn) and `energy_hint_verb` (the
+verb it named, `null` when it named none). This retires the mechanism audit's reconstruction
+caveat: the audit now compares its offline reconstruction against logged ground truth
+(`fidelity.hint_logged`).
+
+**Instrument-inertness clause (pre-registered):** the new keys are observation-only. The values
+are the very ones already computed for the prompt and the R4 conflict counter (run.py threads one
+computation to all three consumers); nothing about prompts, scheduling, energy arithmetic, or
+action selection changes. Pinned by unit tests (`tests/test_run_economy.py`: stamped-when-drained,
+false-when-ample, absent-when-off) and by the audit re-read of `data/econ-stage6-bal30-s42`, which
+is numerically identical to the PR #56 report except for the new (null) `hint_logged` block. Gate 9
+is inert to unknown payload keys (it filters only `parsed_verb` / `scene_id` / `parse_fallback` /
+`economy_substituted`). The replication runs therefore remain comparable to Stage 6.
+
+## Design notes (why this matrix)
+
+- **In-sweep `bal@22` control, not Stage 6's archived control.** Model/runtime behavior can drift
+  between sweeps separated by days; the only causally clean comparator for `bal@30` is a paired
+  `bal@22` run in the same sweep (same reasoning as Stage 6, reaffirmed by external design review).
+- **No `adv` arm.** Its role in Stage 6 was reproducing the one-sided Stage-4/5 mechanism; that
+  is settled and re-running it buys nothing for the replication claim (~12.6 h saved).
+- **Fresh seeds {101, 202, 303}**, disjoint from every prior economy read ({42, 38, 7}). The seed
+  controls weather/scheduler RNG only; `gemma4:26b` sampling is unseeded, so each run is also an
+  independent sampling draw. This design supports "stable across fresh stochastic runs"; it does
+  NOT decompose seed effects vs sampling noise (that would need fixed-seed repeats, out of scope).
+- **Known C4 lesson applied:** every role-stability criterion below is phrased on the top
+  NON-contribute verb, because `contribute` tops BOTH agents' raw chosen streams by design in all
+  nine Stage 6 runs (ADR 0013 Decision 2).
+
+---
+
+## ===== DO NOT EDIT BELOW AFTER THE SWEEP LAUNCHES (pre-registered) =====
+
+### Matrix — 6 runs
+
+| arm | mode | `MICROVERSE_BAL_CONTRIBUTE` | role |
+|-----|------|----------------------------|------|
+| `bal@22` | `bal` | unset (→ natural dearest 22) | in-sweep control |
+| `bal@30` | `bal` | `30` | the replicated arm (T fixed, not re-tuned) |
+
+`{bal@22, bal@30}` × seeds `{101, 202, 303}` × 3000 ticks, one sweep, seed-outer/arm-inner.
+Model `gemma4:26b`, energy knobs at the live defaults (max 100, regen 8). State dirs
+`data/econ-rep30-<arm>-s<seed>`, harvest `harvest/econ-rep30-<arm>-s<seed>`.
+
+### Run
+
+```bash
+nohup ./scripts/run_rep30_sweep.sh > econ-rep30-sweep.log 2>&1 &
+```
+
+(The script writes each run's Gate 1–9 report to `data/econ-rep30-<tag>/gate-report.json` and
+refuses to append to a partial run dir — a crashed run is re-run fresh, never restarted, because a
+mid-run restart would both weaken the audit reconstruction and make the run non-comparable.)
+
+### Instrument gate (checked before any behavioral verdict is read)
+
+Per run, from `scripts/replay_economy.py --audit bal=PATH` / `bal@30=PATH`:
+
+- `fidelity` (predicted-vs-logged substitution, the audit's C5) ≥ 0.90 on both the hint-on and
+  hint-off subsets (Stage 6 landed hint-on 0.92–0.95; a value in 0.90–0.91 satisfies the gate but
+  is flagged as borderline in the findings);
+- `fidelity.hint_logged` (reconstruction vs logged ground truth, full `(fired, verb)` agreement)
+  ≥ 0.90;
+- coverage: the hint-on fidelity subset and the `hint_logged` block each have ≥ 10 events per run
+  (fewer means the rate is too unstable to gate on → INSTRUMENT-INVALID).
+
+If any run fails the instrument gate, the verdict is **INSTRUMENT-INVALID**: no behavioral verdict
+is read, and the instrument fault is diagnosed before any re-run.
+
+### Pass rule (locked)
+
+Measured on the **chosen** (`parsed_verb`) stream via `scripts/spike_workshop_measure.py`
+`gate9_verb_diversity`, exactly as Stage 6.
+
+- **Layer 1 — gate replication (hard):** at ALL three fresh seeds, `bal@30` has
+  `entropy_norm ≥ 0.35` AND `jsd_norm ≥ 0.25`; AND
+  `jsd_norm(bal@30) > jsd_norm(bal@22) + 0.02` at every matched seed (the margin excludes a
+  noise-level ordering win; Stage 6's per-seed gaps were 0.055–0.156, so the margin is
+  conservative against the published facts).
+- **Layer 2 — role stability (hard, the ADR 0013 Decision 2 corrected criterion):** at ALL three
+  `bal@30` seeds, Aki's top NON-contribute chosen verb is `craft` AND Cy's top NON-contribute
+  chosen verb is `study`; and no cross-role bleed: Aki chosen-`study` share ≤ 0.05 AND Cy
+  chosen-`craft` share ≤ 0.05.
+
+**Verdict rule: REPLICATED iff Layer 1 AND Layer 2 hold in full (given the instrument gate
+passed); otherwise NOT REPLICATED.** No partial credit, no post-hoc amendment: a Layer that fails
+as drafted is reported as drafted (the ADR 0013 C4 lesson is why the layers above are phrased
+against the published Stage 6 facts).
+
+### Secondary attribution metrics (reported, NOT gating)
+
+Per matched seed vs in-sweep `bal@22`: Cy chosen-`contribute` drop ≥ 0.10; Cy chosen-`study` rise
+≥ 0.05 on the mean across the three fresh seeds (per-seed values reported individually so the
+aggregate cannot hide a zero-rise seed). These are Stage 6's conditions 2/4, demoted to
+confirmatory because lever attribution was already established there; replication tests
+stability, not attribution.
+
+### Advisory mechanism diagnostics (directional, deliberately no numeric bands)
+
+From `--audit` over the six dirs (numeric bands are avoided because firing/obedience rates vary
+with seed weather and opportunity mix for boring reasons; direction is the claim):
+
+- Cy hint firing rate materially higher in `bal@30` than its matched `bal@22`;
+- P(Cy `study` | hint fired) > P(Cy `study` | hint absent), with the `absent_low` deconfound
+  stratum flat as in ADR 0013;
+- Cy obedience to the named verb ≥ 0.30 (the audit's advisory floor);
+- per-agent specialty hint targeting persists (Aki's fired turns name `craft`, Cy's name `study`).
+
+### Quality counters (report, `MAX` not `SUM`)
+
+`novelty_energy_hint_conflict`, `artisan_empty_craft_coerced`, `parse_fallback`,
+`scene_completed` (the R3 watch: confirm scenes do not collapse at fresh seeds).
+
+### Honesty note
+
+The Stage 6 results at seeds {42, 38, 7} are known. Everything this sweep measures — all six
+fresh-seed runs — is genuinely unseen at pre-registration time. This rule is committed to git
+before the sweep's first tick.
+
+---
+
+After the read: `docs/economy-phase2-replication-findings.md` with the per-seed table and the
+REPLICATED / NOT REPLICATED / INSTRUMENT-INVALID verdict, plus `docs/adr/0014-*` recording it,
+appended to this PR. If NOT REPLICATED, the arc's claim reverts to ADR 0012's bounded "first
+locked pass" framing and Phase 2 item 4 (roster generality) is re-scoped in light of which layer
+failed.

--- a/scripts/replay_economy.py
+++ b/scripts/replay_economy.py
@@ -218,7 +218,12 @@ _SUBSTITUTE_MODES = frozenset({"1", "flat", "sub", "adv", "bal"})
 
 @dataclass(frozen=True)
 class AuditEvent:
-    """One committed agent action with both verb streams + telemetry flags."""
+    """One committed agent action with both verb streams + telemetry flags.
+
+    ``hint_fired_logged`` / ``hint_verb_logged`` carry the ground-truth hint
+    state stamped live by replication runs (Phase 2 item 3, ADR 0013 D3);
+    ``None`` (fired) means the run predates hint logging and there is no
+    ground truth to check against."""
 
     actor: str
     role: str
@@ -228,6 +233,8 @@ class AuditEvent:
     scene_id: str | None = None
     parse_fallback: bool = False
     economy_substituted: bool = False
+    hint_fired_logged: bool | None = None
+    hint_verb_logged: str | None = None
 
 
 @dataclass(frozen=True)
@@ -317,6 +324,8 @@ def _audit_trace_from_episodic(path: Path) -> list[AuditEvent]:
         if chosen not in _VERBS:
             chosen = action
         scene_id = payload.get("scene_id")
+        hint_fired = payload.get("energy_hint_fired")
+        hint_verb = payload.get("energy_hint_verb")
         out.append(
             AuditEvent(
                 actor=actor,
@@ -327,6 +336,8 @@ def _audit_trace_from_episodic(path: Path) -> list[AuditEvent]:
                 scene_id=scene_id,
                 parse_fallback=bool(payload.get("parse_fallback")),
                 economy_substituted=bool(payload.get("economy_substituted")),
+                hint_fired_logged=None if hint_fired is None else bool(hint_fired),
+                hint_verb_logged=str(hint_verb) if hint_verb is not None else None,
             )
         )
     return out
@@ -375,12 +386,21 @@ def audit_run(events: Sequence[AuditEvent], *, ledger: EnergyLedger, mode: str) 
 
     acc: dict[str, dict] = {}
     fid = {"hint_on": [0, 0], "hint_off": [0, 0]}  # [events, agreements]
+    hint_logged = [0, 0]  # [events with ground truth, full (fired, verb) agreements]
     ev_list = list(events)
     for idx, ev in enumerate(ev_list):
         st = acc.setdefault(ev.actor, _new_acc(ev.role))
         if not ev.forced:
             energy = ledger.current(ev.actor)
             fired, easy = _hint_state(ledger, ev.actor, ev.role, mode=mode)
+            # Ground-truth check (Phase 2 item 3): live stamps the hint state on
+            # every free commit in substitution modes, parse_fallback included
+            # (the hint preceded think()), so this comparison sits OUTSIDE the
+            # parse-fallback guard below — unlike the chosen-stream conditionals.
+            if ev.hint_fired_logged is not None:
+                hint_logged[0] += 1
+                if fired == ev.hint_fired_logged and easy == ev.hint_verb_logged:
+                    hint_logged[1] += 1
             contribute_cost = ledger.cost(ev.role, "contribute")
             st["free"] += 1
             st["energies"].append(energy)
@@ -464,6 +484,7 @@ def audit_run(events: Sequence[AuditEvent], *, ledger: EnergyLedger, mode: str) 
             **_fid_block(on_n + off_n, on_a + off_a),
             "hint_on": _fid_block(on_n, on_a),
             "hint_off": _fid_block(off_n, off_a),
+            "hint_logged": _fid_block(hint_logged[0], hint_logged[1]),
         },
     }
 

--- a/scripts/run_rep30_sweep.sh
+++ b/scripts/run_rep30_sweep.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Phase 2 item 3 (ADR 0012/0013): held-out replication sweep, T fixed at 30.
+# Matrix: {bal@22 in-sweep control, bal@30} x fresh seeds {101, 202, 303},
+# seed-outer / arm-inner so each seed's pair runs adjacently in time.
+# Pre-registration: docs/economy-phase2-replication-runbook.md (locked before launch).
+#
+# Launch detached from the repo root:
+#   nohup ./scripts/run_rep30_sweep.sh > econ-rep30-sweep.log 2>&1 &
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+for SEED in 101 202 303; do
+  for ARM in bal22 bal30; do
+    case "$ARM" in
+      bal22) BAL="" ;; # unset target -> natural dearest contribute (22)
+      bal30) BAL=30 ;;
+    esac
+    TAG="econ-rep30-${ARM}-s${SEED}"
+    if [ -f "data/${TAG}/gate-report.json" ]; then
+      echo "=== skip ${TAG}: gate-report.json already present ==="
+      continue
+    fi
+    if [ -d "data/${TAG}" ]; then
+      # A data dir without a gate report is a partial (crashed/killed) run.
+      # Appending to it would violate the runbook's no-restart fidelity caveat;
+      # move it aside and relaunch the sweep instead.
+      echo "ERROR ${TAG}: partial run dir exists — move data/${TAG} aside first" >&2
+      exit 1
+    fi
+    echo "=== $(date '+%F %T') start ${TAG} ==="
+    MICROVERSE_ECONOMY=bal MICROVERSE_BAL_CONTRIBUTE="$BAL" \
+    MICROVERSE_DATA="data/${TAG}" \
+    MICROVERSE_HARVEST="harvest/${TAG}" \
+      uv run python -m microverse.run --ticks 3000 --tempo 0 --seed "$SEED"
+    uv run python scripts/spike_workshop_measure.py \
+      --data "data/${TAG}" --harvest "harvest/${TAG}" \
+      > "data/${TAG}/gate-report.json"
+    echo "=== $(date '+%F %T') done ${TAG} ==="
+  done
+done
+echo "=== $(date '+%F %T') sweep complete ==="

--- a/scripts/run_rep30_sweep.sh
+++ b/scripts/run_rep30_sweep.sh
@@ -12,7 +12,7 @@ cd "$(dirname "$0")/.."
 for SEED in 101 202 303; do
   for ARM in bal22 bal30; do
     case "$ARM" in
-      bal22) BAL="" ;; # unset target -> natural dearest contribute (22)
+      bal22) BAL="" ;; # no target -> natural dearest contribute (22)
       bal30) BAL=30 ;;
     esac
     TAG="econ-rep30-${ARM}-s${SEED}"
@@ -28,13 +28,25 @@ for SEED in 101 202 303; do
       exit 1
     fi
     echo "=== $(date '+%F %T') start ${TAG} ==="
-    MICROVERSE_ECONOMY=bal MICROVERSE_BAL_CONTRIBUTE="$BAL" \
-    MICROVERSE_DATA="data/${TAG}" \
-    MICROVERSE_HARVEST="harvest/${TAG}" \
+    # Truly omit MICROVERSE_BAL_CONTRIBUTE for the control arm rather than
+    # exporting "" (the parser treats both as unset, but the env should state
+    # the intent exactly — Gemini/CodeRabbit review).
+    ENV_ARGS=(
+      MICROVERSE_ECONOMY=bal
+      MICROVERSE_DATA="data/${TAG}"
+      MICROVERSE_HARVEST="harvest/${TAG}"
+    )
+    if [ -n "$BAL" ]; then
+      ENV_ARGS+=(MICROVERSE_BAL_CONTRIBUTE="$BAL")
+    fi
+    env "${ENV_ARGS[@]}" \
       uv run python -m microverse.run --ticks 3000 --tempo 0 --seed "$SEED"
+    # Atomic gate-report write: a crash mid-measure must not leave a partial
+    # file that the skip guard above would mistake for a completed run.
     uv run python scripts/spike_workshop_measure.py \
       --data "data/${TAG}" --harvest "harvest/${TAG}" \
-      > "data/${TAG}/gate-report.json"
+      > "data/${TAG}/gate-report.json.tmp"
+    mv "data/${TAG}/gate-report.json.tmp" "data/${TAG}/gate-report.json"
     echo "=== $(date '+%F %T') done ${TAG} ==="
   done
 done

--- a/src/microverse/run.py
+++ b/src/microverse/run.py
@@ -969,6 +969,11 @@ def run(
             # does not see all weather/world events since process
             # start on their first tick.
             agent_last_ts = last_tick_ts.setdefault(agent.name, time.time())
+            # Compute the scarcity hint ONCE and thread the same values into the
+            # prompt (via world_base), the R4 conflict counter, and the payload
+            # ground truth (Phase 2 item 3) so the three can never diverge.
+            energy_hint = _compute_energy_hint(energy, agent)
+            energy_hint_verb = _energy_hint_verb(energy, agent)
             world_base = _build_per_tick_world_base(
                 episodic=episodic,
                 agent=agent,
@@ -980,7 +985,7 @@ def run(
                 novelty_hint=novelty_hint,
                 novelty_dominant_verb=novelty_dominant_verb,
                 novelty_suggested_verb=novelty_suggested_verb,
-                energy_hint=_compute_energy_hint(energy, agent),
+                energy_hint=energy_hint,
                 self_view=_build_self_view(
                     episodic,
                     agent,
@@ -1197,7 +1202,7 @@ def run(
             # never sees the energy hint in a scene, so the two levers cannot fight
             # there (CodeRabbit review). High counts mean the levers fight on the
             # ticks that matter, capping specialization; the Stage-4 read inspects it.
-            if _hints_conflict(_energy_hint_verb(energy, agent), novelty_dominant_verb):
+            if _hints_conflict(energy_hint_verb, novelty_dominant_verb):
                 metrics.bump("novelty_energy_hint_conflict", agent=agent.name)
             try:
                 action = agent.think(world)
@@ -1212,8 +1217,15 @@ def run(
             # ADR 0008 spike: stamp the model's pre-economy verb so Gate 9 can
             # compare CHOSEN vs EXECUTED. Stamped ONLY in substitution-enabled
             # modes, so a flag-off run writes a byte-identical payload.
+            # Phase 2 item 3 (ADR 0013 Decision 3): also stamp the hint ground
+            # truth the prompt carried this turn — observation-only, so the
+            # mechanism audit can drop the reconstruction caveat.
             extra_payload = (
-                dict(agent._verb_trace)
+                {
+                    **agent._verb_trace,
+                    "energy_hint_fired": bool(energy_hint),
+                    "energy_hint_verb": energy_hint_verb,
+                }
                 if (energy is not None and config._ECONOMY_SUBSTITUTE)
                 else None
             )

--- a/tests/test_economy_audit.py
+++ b/tests/test_economy_audit.py
@@ -312,6 +312,85 @@ def test_audit_substitution_agreement_counts_mismatches():
     assert fid["rate"] == pytest.approx(0.75)
 
 
+# --- logged ground-truth hint fidelity (Phase 2 item 3) -----------------------
+# Replication runs stamp energy_hint_fired/energy_hint_verb into the payload
+# (ADR 0013 Decision 3). The audit must compare its reconstruction against that
+# ground truth where present, and report zero coverage (not fabricated
+# agreement) for pre-replication runs like the Stage 6 dirs.
+
+
+def test_audit_trace_carries_logged_hint_state(tmp_path):
+    ep = _write_episodic(
+        tmp_path / "episodic.sqlite",
+        [
+            (
+                "Cy",
+                "study",
+                '{"role": "scholar", "parsed_verb": "study", '
+                '"energy_hint_fired": true, "energy_hint_verb": "study"}',
+            ),
+            (
+                "Cy",
+                "rest",
+                '{"role": "scholar", "parsed_verb": "rest", '
+                '"energy_hint_fired": false, "energy_hint_verb": null}',
+            ),
+            ("Cy", "rest", '{"role": "scholar", "parsed_verb": "rest"}'),  # pre-replication
+        ],
+    )
+    trace = replay_economy._audit_trace_from_episodic(ep)
+    assert trace[0].hint_fired_logged is True
+    assert trace[0].hint_verb_logged == "study"
+    assert trace[1].hint_fired_logged is False
+    assert trace[1].hint_verb_logged is None
+    assert trace[2].hint_fired_logged is None  # unlogged run: no ground truth
+    assert trace[2].hint_verb_logged is None
+
+
+def test_audit_hint_logged_fidelity_agreement():
+    # Pool pinned at 10 (regen 0, rest costs 0): the reconstruction says
+    # fired=True / easy=study every turn; the logged ground truth agrees.
+    led = _ledger({"Cy": 10.0}, regen=0.0)
+    events = [
+        _ev(chosen="study", executed="rest", hint_fired_logged=True, hint_verb_logged="study")
+        for _ in range(4)
+    ]
+    report = replay_economy.audit_run(events, ledger=led, mode="bal")
+    hl = report["fidelity"]["hint_logged"]
+    assert hl["events"] == 4
+    assert hl["agreements"] == 4
+    assert hl["rate"] == 1.0
+
+
+def test_audit_hint_logged_fidelity_counts_mismatches():
+    # A fired-flag mismatch and a named-verb mismatch both count as
+    # disagreements: the replication's instrument gate reads this rate.
+    led = _ledger({"Cy": 10.0}, regen=0.0)
+    events = [
+        _ev(chosen="study", executed="rest", hint_fired_logged=True, hint_verb_logged="study"),
+        _ev(chosen="study", executed="rest", hint_fired_logged=False, hint_verb_logged=None),
+        _ev(chosen="study", executed="rest", hint_fired_logged=True, hint_verb_logged="speak"),
+        _ev(chosen="study", executed="rest", hint_fired_logged=True, hint_verb_logged="study"),
+    ]
+    report = replay_economy.audit_run(events, ledger=led, mode="bal")
+    hl = report["fidelity"]["hint_logged"]
+    assert hl["events"] == 4
+    assert hl["agreements"] == 2
+    assert hl["rate"] == pytest.approx(0.5)
+
+
+def test_audit_hint_logged_null_for_unlogged_runs():
+    # Stage 6 dirs predate hint logging: zero coverage, null rate — the
+    # existing reconstruction-only read stays valid and unchanged.
+    led = _ledger({"Cy": 10.0}, regen=0.0)
+    events = [_ev(chosen="study", executed="rest") for _ in range(3)]
+    report = replay_economy.audit_run(events, ledger=led, mode="bal")
+    hl = report["fidelity"]["hint_logged"]
+    assert hl["events"] == 0
+    assert hl["agreements"] == 0
+    assert hl["rate"] is None
+
+
 def test_audit_deterministic():
     led1 = _ledger({"Cy": 40.0})
     led2 = _ledger({"Cy": 40.0})

--- a/tests/test_run_economy.py
+++ b/tests/test_run_economy.py
@@ -474,6 +474,62 @@ def test_bal_contribute_knob_parses_from_env_cold_import():
     assert json.loads(result.stdout.strip().splitlines()[-1]) is None
 
 
+# --- ground-truth hint logging (ADR 0013 Decision 3, Phase 2 item 3) ---
+# The replication runs stamp the live hint state into the per-event payload so
+# the mechanism read no longer depends on offline reconstruction. Observation-
+# only: same gating as the existing verb-trace telemetry (substitution modes),
+# so a flag-off run stays byte-identical, and gate9 is inert to the new keys
+# (it filters only parsed_verb/scene_id/parse_fallback/economy_substituted).
+
+
+def test_hint_payload_stamped_when_drained(tmp_path: Path):
+    """Mirror of test_economy_on_substitutes_when_drained: a draining solo
+    artisan writes payloads carrying the hint ground truth, with at least one
+    fired=True turn once the pool falls below a productive cost, and fired
+    turns are the only ones that may name an easy verb."""
+    data_dir = tmp_path / "data"
+    with (
+        _economy("1", energy_max=30.0),
+        patch("microverse.agents.artisan.DIVERSITY_SUBSTITUTE_PROB", 0.0),
+        patch("microverse.agents.artisan.chat", return_value=_study_only()),
+    ):
+        run(ticks=40, seed=1, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h", solo=True)
+    payloads = [p for p in _payloads(data_dir) if "parsed_verb" in p]
+    assert payloads, "no telemetry payloads written"
+    assert all("energy_hint_fired" in p and "energy_hint_verb" in p for p in payloads)
+    assert any(p["energy_hint_fired"] is True for p in payloads), "hint never fired while drained"
+    for p in payloads:
+        if p["energy_hint_fired"] is False:
+            assert p["energy_hint_verb"] is None  # no hint -> no named verb
+
+
+def test_hint_payload_false_when_ample(tmp_path: Path):
+    """With full reserves every productive verb is affordable, so the stamped
+    ground truth must say the hint did not fire and named nothing."""
+    data_dir = tmp_path / "data"
+    with (
+        _economy("adv"),
+        patch("microverse.agents.artisan.DIVERSITY_SUBSTITUTE_PROB", 0.0),
+        patch("microverse.agents.artisan.chat", return_value=_study_only()),
+    ):
+        run(ticks=6, seed=1, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h", solo=True)
+    payloads = [p for p in _payloads(data_dir) if "parsed_verb" in p]
+    assert payloads, "no telemetry payloads written"
+    assert all(p.get("energy_hint_fired") is False for p in payloads)
+    assert all(p.get("energy_hint_verb") is None for p in payloads)
+
+
+def test_hint_payload_absent_when_economy_off(tmp_path: Path):
+    """Economy off must stay byte-identical to pre-spike payloads: no hint
+    keys, exactly like the parsed_verb gating (Stage 6 comparability)."""
+    data_dir = tmp_path / "data"
+    with patch("microverse.agents.artisan.chat", return_value=_study_only()):
+        run(ticks=6, seed=1, tempo=0, data_dir=data_dir, harvest_dir=tmp_path / "h", solo=True)
+    assert all(
+        "energy_hint_fired" not in p and "energy_hint_verb" not in p for p in _payloads(data_dir)
+    )
+
+
 def test_invalid_economy_mode_fails_fast(tmp_path: Path):
     """A typo'd MICROVERSE_ECONOMY must raise, not silently run an unlabeled
     no-op arm (ECONOMY_ENABLED but neither gate nor substitution)."""


### PR DESCRIPTION
## Summary

Phase 2 item 3 of the action-economy arc (ADR 0012 / ADR 0013): the held-out replication of the `bal@30` Gate 9 PASS. This PR ships the instrument and the locked pre-registration; the 6-run live sweep is already running detached, and the findings + ADR 0014 will be appended to this PR after the read (~38 h of compute).

- `run.py` stamps the live scarcity-hint state (`energy_hint_fired` / `energy_hint_verb`) into the per-event payload (ADR 0013 Decision 3), retiring the mechanism audit's reconstruction caveat.
- `replay_economy.py --audit` gains a `fidelity.hint_logged` block: full `(fired, verb)` agreement between the offline reconstruction and the logged ground truth.
- `docs/economy-phase2-replication-runbook.md` pre-registers the sweep: matrix, two-layer hard pass rule, instrument gate, verdict rule — committed before the sweep's first tick.

## Background / Motivation

ADR 0012 recorded the arc's first Gate 9 PASS (`bal@30`, seeds 42/38/7) as "first locked pass, to be replicated." ADR 0013 (PR #56) confirmed the scarcity hint is the operative channel and handed two obligations to this PR: Decision 2 (the replication pre-registration must use the corrected role-stability criterion, not the mis-drafted C4) and Decision 3 (decide on live hint logging — done here). The replication moves the claim toward "stable under replication" with fresh seeds {101, 202, 303}, T fixed at 30 (nothing re-tuned), and an in-sweep `bal@22` control.

## Breaking Changes

- [ ] No breaking changes.

The new payload keys are observation-only and additive. Gate 9 is inert to them (it filters only `parsed_verb` / `scene_id` / `parse_fallback` / `economy_substituted`), and economy-off runs write byte-identical payloads (pinned by test). Old run dirs remain fully readable: the audit reports a null `hint_logged` block for them.

## Changes Made

- `src/microverse/run.py`: the scarcity hint is computed once per free turn and threaded to its three consumers — the prompt, the R4 conflict counter, and now the payload — so they can never diverge. Stamped only in substitution-enabled economy modes, same gating as the existing verb-trace telemetry.
- `scripts/replay_economy.py`: `AuditEvent` carries `hint_fired_logged` / `hint_verb_logged`; `_audit_trace_from_episodic` extracts them; `audit_run` emits `fidelity.hint_logged` (compared outside the parse-fallback guard, because live stamps regardless of how think() parsed).
- `docs/economy-phase2-replication-runbook.md` (new): locked pre-registration. Layer 1 (gate replication: entropy ≥ 0.35, jsd ≥ 0.25 at all three fresh seeds, jsd(bal@30) > jsd(bal@22) + 0.02 per matched seed) + Layer 2 (ADR 0013 D2 corrected stability: top NON-contribute verbs craft/study, cross-bleed ≤ 0.05) are hard; Stage 6's attribution conditions are demoted to reported-only; mechanism diagnostics are advisory and directional (no numeric bands). Verdict maps every outcome to exactly one of REPLICATED / NOT REPLICATED / INSTRUMENT-INVALID.
- `scripts/run_rep30_sweep.sh` (new): the sweep loop, `{bal@22, bal@30} × {101, 202, 303}` × 3000 ticks, seed-outer/arm-inner; refuses to append to a partial run dir (no-restart fidelity caveat); writes per-run `gate-report.json`.
- Tests: 4 new in `tests/test_run_economy.py` (stamped-when-drained, false-when-ample, absent-when-off), 4 new in `tests/test_economy_audit.py` (trace extraction, agreement, mismatch counting, null coverage for unlogged runs). Red committed before green.

## Dependencies

None added or changed.

## Test Methodologies and Results

1. `uv run pytest -q -m 'not integration'` → **700 passed** (8 new).
2. Full gauntlet: `ruff check` + `ruff format --check` + `mypy src/microverse` + `pip-audit` + `uv build` → all green.
3. Backward compatibility on frozen Stage 6 data: `uv run python scripts/replay_economy.py --audit bal@30=data/econ-stage6-bal30-s42` is numerically identical to the merged PR #56 report, plus the new null `hint_logged` block (`events: 0, rate: null`).
4. Live validation on the first completed replication run (`econ-rep30-bal22-s101`, 4538 events): `hint_logged` agreement **1.000 over all 2569 ground-truth events** — the reconstruction exactly matches the logged hint state; substitution fidelity hint-off 1.000 / hint-on 0.924, Cy firing 0.43 — all inside the Stage 6 bands. The instrument gate passes on real data.

## Design & Reasoning Notes

- **One computation, three consumers**: the hint values stamped into the payload are the very objects the prompt rendered, not a recomputation, so payload/prompt divergence is structurally impossible.
- **Two-layer pass rule instead of Stage 6's four-condition rule verbatim**: re-registering the attribution conditions as hard gates would re-test what ADR 0012/0013 already established and re-create C4-style fragility; replication tests stability. Every role criterion is phrased on the top NON-contribute verb (the C4 lesson — contribute tops both agents' raw streams by design). External design review (Codex consult) recommended this structure, the +0.02 jsd ordering margin, the ≥10-event coverage floor, and the in-sweep control over the archived Stage 6 control.
- **No `adv` arm**: its Stage 6 role (reproducing the one-sided mechanism) is settled; dropping it saves ~12.6 h.
- **Advisory mechanism diagnostics carry no numeric bands**: firing/obedience rates vary with seed weather and opportunity mix for boring reasons; direction is the claim.
- **Sweep state**: launched 2026-06-12 20:38 JST from this branch after the pre-registration commit (`2d4ef8b`). Run 1/6 done, run 2/6 in flight. **Do not merge until the sweep completes** — the detached process runs from this working tree, and findings + ADR 0014 land here.

## Impact / Risk Assessment

- Affected: per-event payloads in substitution-mode economy runs only; the audit instrument.
- Risk: a payload-schema consumer surprised by new keys — none exists beyond gate9 (verified inert) and the audit (updated here).
- Rollback: revert the run.py hunk; old payloads were never altered. The pre-registration doc is a measurement record and carries no runtime risk.

## Documentation

- `docs/economy-phase2-replication-runbook.md` (new) — the pre-registration, following the Stage 6 runbook pattern.
- README/AGENTS/CLAUDE.md unchanged: no commands, invariants, or workflows changed (the hint-logging behavior is documented in the runbook and will be folded into ADR 0014 with the read).

## Review Focus

- [CRITICAL] The locked pass rule (`docs/economy-phase2-replication-runbook.md`, below the DO-NOT-EDIT line) — internal consistency and no criterion contradicting published Stage 6 facts; this is exactly where C4 went wrong last time.
- [IMPORTANT] `src/microverse/run.py` hint threading — confirm the ledger cannot change between hint computation and commit (deduct/regen land after commit; scenes exit the path earlier).
- [IMPORTANT] `audit_run`'s `hint_logged` comparison sitting outside the parse-fallback guard (intentional: live stamps regardless of parse outcome).
- [MINOR] `scripts/run_rep30_sweep.sh` shell hygiene.

## Post-Merge Recommendations

Merge happens only after the sweep read lands in this PR. Then, rooted in the verdict: if **REPLICATED**, proceed to Phase 2 item 4 (roster generality — more residents, alternate weights, a different scholar/artisan pairing), the limitation most likely to bound the claim. If **NOT REPLICATED**, the claim reverts to ADR 0012's bounded "first locked pass" framing and item 4 is re-scoped around whichever layer failed. If **INSTRUMENT-INVALID**, diagnose the instrument before any re-run.