### PR TITLE
feat(economy): automate Gate-9 sweep verdict (Phase-2 item 5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ ignore = []
 "scripts/spike_workshop_measure.py" = ["T20"]
 "scripts/verify_kill_drill.py" = ["T20"]
 "scripts/replay_economy.py" = ["T20"]
+"scripts/sweep_report.py" = ["T20"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/scripts/spike_workshop_measure.py
+++ b/scripts/spike_workshop_measure.py
@@ -238,6 +238,11 @@ def _diversity_block(by_agent: dict[str, Counter]) -> dict:
         )
         for a in agents
     }
+    # Full per-agent verb distribution over _VERBS (Layer 2 role-stability /
+    # cross-bleed in sweep_report.py needs every verb's share, not just the top).
+    per_agent_share = {
+        a: {v: round(s, 4) for v, s in _normalize(by_agent[a], _VERBS).items()} for a in agents
+    }
     n = len(agents)
     society_entropy_norm = _entropy_norm(society_counts, k=len(_VERBS))
     entropy_ceiling_norm = _entropy_ceiling_norm(n, k=len(_VERBS))
@@ -256,6 +261,7 @@ def _diversity_block(by_agent: dict[str, Counter]) -> dict:
         "identity_verb_nmi": round(_identity_verb_nmi(by_agent), 4),
         "n_agents": n,
         "per_agent_top_share": per_agent_top,
+        "per_agent_verb_share": per_agent_share,
     }
 
 

--- a/scripts/sweep_report.py
+++ b/scripts/sweep_report.py
@@ -1,0 +1,368 @@
+"""Aggregate an action-economy sweep into one Gate-9 verdict (Phase-2 item 5).
+
+Across ADRs 0014-0018 a "sweep" (3 seeds of a lever) was read into a verdict by
+hand: per seed dir, run ``spike_workshop_measure.py`` (Layer 1) and
+``replay_economy.py --audit`` (instrument fidelity), eyeball Layer 2 role
+stability, then aggregate to the >=2/3-seeds rule. This tool does that read in
+one shot so verdicts are reproducible and traceable, not retyped per ADR.
+
+It IMPLEMENTS the locked pre-registration rules (it does not change them): the
+floors below are named constants citing their runbooks and are echoed into the
+emitted ``sweep-verdict.json`` so every ADR artifact records the criteria it was
+judged against. Changing a floor is a reviewed code change, never a CLI flag.
+
+Usage:
+    uv run python scripts/sweep_report.py \
+        data/econ-r3bal42-s101 data/econ-r3bal42-s202 data/econ-r3bal42-s303 \
+        --roster artisan:Aki:100,scholar:Cy:70,stranger:Vesna:70 \
+        --audit-mode bal@42 [--json-out sweep-verdict.json]
+
+Each dir must hold a ``gate-report.json`` produced by the current
+``spike_workshop_measure.py`` (it must carry ``per_agent_verb_share``; regenerate
+old reports) and an ``episodic.sqlite`` for the fidelity audit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# --- locked criteria (single source of truth; see the cited runbooks) -------
+MEAN_PAIRWISE_FLOOR = 0.25  # Layer 1, ADR 0016 size-invariant divergence
+CROSS_BLEED_FLOOR = 0.05  # Layer 2 role-stability cross-bleed ceiling
+# The ADR 0018 findings adjudicated cross-bleed at 3-dp precision (s202 Aki study
+# 0.050 judged at-floor PASS; the true 4-dp share is 0.0504). Round to that same
+# precision before the <= compare so the tool reproduces the published verdict
+# rather than silently forking it at the knife-edge. See findings doc Layer 2.
+CROSS_BLEED_DECIMALS = 3
+FIDELITY_FLOOR = 0.90  # instrument gate, ADR 0014
+MIN_FIDELITY_EVENTS = 10  # >=10 events/subset (ADR 0014/0018 runbooks)
+MIN_SEEDS_PASS = 2  # sweep verdict = >=2/3 seeds
+# Canonical role->specialty across the whole arc (ADRs 0013-0018). Fixed by
+# design: this is the differentiation the gate measures, not a tunable.
+ROLE_SPECIALTY = {"artisan": "craft", "scholar": "study", "stranger": "travel"}
+CONTRIBUTE = "contribute"
+
+
+# --- roster parsing ---------------------------------------------------------
+def parse_roster(spec: str) -> dict[str, str]:
+    """``name -> role`` from a ``role:name:tokens`` MICROVERSE_ROSTER spec.
+
+    Fail-fast (no silent fallback) on a malformed entry, an unknown role with no
+    defined specialty, or a duplicate name — mirrors ``run.py::_parse_roster_spec``
+    so the report cannot judge an unintended roster.
+    """
+    role_by_name: dict[str, str] = {}
+    for pos, raw in enumerate([e.strip() for e in spec.split(",")], start=1):
+        if not raw:
+            raise ValueError(f"empty roster entry #{pos} in roster spec {spec!r}")
+        parts = [p.strip() for p in raw.split(":")]
+        if len(parts) != 3:
+            raise ValueError(f"roster entry {raw!r} must be 'role:name:tokens'")
+        role, name, _tokens = parts
+        if role not in ROLE_SPECIALTY:
+            raise ValueError(
+                f"role {role!r} in entry {raw!r} has no defined specialty; "
+                f"known: {sorted(ROLE_SPECIALTY)}"
+            )
+        if not name:
+            raise ValueError(f"empty resident name in roster entry {raw!r}")
+        if name in role_by_name:
+            raise ValueError(f"duplicate resident name {name!r} in roster spec {spec!r}")
+        role_by_name[name] = role
+    if not role_by_name:
+        raise ValueError(f"empty roster spec {spec!r}")
+    return role_by_name
+
+
+# --- Layer 2: role stability ------------------------------------------------
+def _top_non_contribute(share: dict[str, float]) -> str | None:
+    candidates = {v: s for v, s in share.items() if v != CONTRIBUTE}
+    if not candidates or max(candidates.values()) <= 0:
+        return None
+    return max(candidates, key=lambda v: candidates[v])
+
+
+def role_stability(
+    per_agent_verb_share: dict[str, dict[str, float]],
+    role_by_name: dict[str, str],
+    *,
+    cross_bleed_floor: float = CROSS_BLEED_FLOOR,
+) -> dict[str, Any]:
+    """Layer 2: every roster-named resident's top non-``contribute`` verb is its
+    specialty AND its cross-bleed is <= ``cross_bleed_floor``. Agents present in
+    the report but not the roster (e.g. Watchdog rehab Strangers) are reported as
+    ``extra_agents``, never gated.
+
+    Cross-bleed is the agent's share of the SINGLE binding other-resident
+    specialty verb (the max over other specialties), matching the ADR 0018
+    findings operationalization ("Aki ``study`` cross-bleed" = the largest single
+    other-specialty share, not the sum across all of them). The binding verb is
+    reported as ``cross_bleed_verb``.
+    """
+    per_resident: dict[str, Any] = {}
+    for name, role in role_by_name.items():
+        specialty = ROLE_SPECIALTY[role]
+        share = per_agent_verb_share.get(name)
+        if share is None:
+            per_resident[name] = {
+                "role": role,
+                "specialty": specialty,
+                "present": False,
+                "top_non_contribute_verb": None,
+                "is_specialty": False,
+                "cross_bleed": None,
+                "cross_bleed_verb": None,
+                "pass": False,
+            }
+            continue
+        # An agent's OWN specialty is never cross-bleed even if a same-role peer
+        # shares it.
+        other_specialties = {ROLE_SPECIALTY[r] for n, r in role_by_name.items() if n != name} - {
+            specialty
+        }
+        top = _top_non_contribute(share)
+        bleed_shares = {v: share.get(v, 0.0) for v in other_specialties}
+        bleed_verb = max(bleed_shares, key=lambda v: bleed_shares[v]) if bleed_shares else None
+        cross_bleed = round(bleed_shares[bleed_verb], 4) if bleed_verb is not None else 0.0
+        is_specialty = top == specialty
+        per_resident[name] = {
+            "role": role,
+            "specialty": specialty,
+            "present": True,
+            "top_non_contribute_verb": top,
+            "is_specialty": is_specialty,
+            "cross_bleed": cross_bleed,
+            "cross_bleed_verb": bleed_verb,
+            "pass": is_specialty and round(cross_bleed, CROSS_BLEED_DECIMALS) <= cross_bleed_floor,
+        }
+    extra = sorted(set(per_agent_verb_share) - set(role_by_name))
+    return {
+        "per_resident": per_resident,
+        "extra_agents": extra,
+        "cross_bleed_floor": cross_bleed_floor,
+        "pass": bool(per_resident) and all(r["pass"] for r in per_resident.values()),
+    }
+
+
+# --- instrument gate: fidelity ----------------------------------------------
+def fidelity_verdict(
+    fidelity: dict[str, Any],
+    *,
+    floor: float = FIDELITY_FLOOR,
+    min_events: int = MIN_FIDELITY_EVENTS,
+) -> dict[str, Any]:
+    """Instrument gate from ``replay_economy.audit_run``'s ``fidelity`` block:
+    ``hint_on``/``hint_off``/``hint_logged`` rates all >= ``floor``, and the
+    hint-on/off subsets each carry >= ``min_events`` (a thin subset can hit a
+    spurious 1.0). ``hint_logged`` is gated on rate only (ground-truth agreement).
+    """
+    subsets: dict[str, Any] = {}
+    ok = True
+    for key in ("hint_on", "hint_off", "hint_logged"):
+        block = fidelity.get(key, {}) or {}
+        rate = block.get("rate")
+        events = block.get("events", 0)
+        enough = events >= min_events if key in ("hint_on", "hint_off") else True
+        passed = rate is not None and rate >= floor and enough
+        subsets[key] = {"rate": rate, "events": events, "pass": passed}
+        ok = ok and passed
+    return {"subsets": subsets, "floor": floor, "min_events": min_events, "pass": ok}
+
+
+# --- per-seed + sweep verdict ----------------------------------------------
+def seed_verdict(
+    seed: str,
+    gate_report: dict[str, Any],
+    fidelity: dict[str, Any],
+    role_by_name: dict[str, str],
+) -> dict[str, Any]:
+    """Combine Layer 1 (``mean_pairwise_jsd``), Layer 2 (role stability), and the
+    instrument gate into one seed verdict. A failed instrument gate yields
+    ``INSTRUMENT-INVALID`` (no behavioral verdict, per the locked runbooks)."""
+    chosen = gate_report["gate_9_verb_diversity"]["chosen"]
+    mpj = chosen["mean_pairwise_jsd"]
+    layer1 = {
+        "mean_pairwise_jsd": mpj,
+        "floor": MEAN_PAIRWISE_FLOOR,
+        "pass": mpj >= MEAN_PAIRWISE_FLOOR,
+    }
+    layer2 = role_stability(chosen["per_agent_verb_share"], role_by_name)
+    fidelity_v = fidelity_verdict(fidelity)
+    instrument_valid = fidelity_v["pass"]
+    behavioral_pass = layer1["pass"] and layer2["pass"]
+    if not instrument_valid:
+        status = "INSTRUMENT-INVALID"
+    elif behavioral_pass:
+        status = "PASS"
+    else:
+        status = "FAIL"
+    return {
+        "seed": seed,
+        "layer1": layer1,
+        "layer2": layer2,
+        "fidelity": fidelity_v,
+        "instrument_valid": instrument_valid,
+        "status": status,
+        "pass": instrument_valid and behavioral_pass,
+    }
+
+
+def sweep_verdict(
+    seed_verdicts: list[dict[str, Any]], *, min_pass: int = MIN_SEEDS_PASS
+) -> dict[str, Any]:
+    n_total = len(seed_verdicts)
+    n_pass = sum(1 for s in seed_verdicts if s["pass"])
+    n_invalid = sum(1 for s in seed_verdicts if not s["instrument_valid"])
+    return {
+        "n_pass": n_pass,
+        "n_total": n_total,
+        "min_pass": min_pass,
+        "n_instrument_invalid": n_invalid,
+        "pass": n_pass >= min_pass,
+    }
+
+
+# --- fidelity audit (reuse replay_economy) ----------------------------------
+def _load_replay_module() -> Any:
+    path = Path(__file__).resolve().parent / "replay_economy.py"
+    spec = importlib.util.spec_from_file_location("replay_economy", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - import plumbing
+        raise ImportError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    # dataclasses in replay_economy need the module registered before exec.
+    sys.modules["replay_economy"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def compute_fidelity(run_dir: Path, audit_mode: str) -> dict[str, Any]:
+    """Run ``replay_economy``'s offline audit on ``run_dir/episodic.sqlite`` and
+    return its ``fidelity`` block — the same instrument read the runbooks use,
+    at the live default energy knobs."""
+    rm = _load_replay_module()
+    spec = rm.parse_audit_spec(f"{audit_mode}={run_dir}")
+    ep = spec.path / "episodic.sqlite"
+    if not ep.exists():
+        raise FileNotFoundError(f"{ep} not found (needed for the fidelity audit)")
+    trace = rm._audit_trace_from_episodic(ep)
+    roster_names = list(dict.fromkeys(ev.actor for ev in trace)) or [
+        n for n, _ in rm._DEFAULT_ROSTER
+    ]
+    ledger = rm.EnergyLedger.fresh(
+        roster_names,
+        max_energy=rm.ENERGY_MAX,
+        regen_per_tick=rm.ENERGY_REGEN_PER_TICK,
+        cost_table=rm.build_cost_table(spec.mode, balanced_contribute=spec.target),
+    )
+    report = rm.audit_run(trace, ledger=ledger, mode=spec.mode)
+    return report["fidelity"]
+
+
+def read_seed(run_dir: Path, audit_mode: str, role_by_name: dict[str, str]) -> dict[str, Any]:
+    gate_report = json.loads((run_dir / "gate-report.json").read_text())
+    chosen = gate_report.get("gate_9_verb_diversity", {}).get("chosen", {})
+    if "per_agent_verb_share" not in chosen:
+        raise ValueError(
+            f"{run_dir}/gate-report.json lacks per_agent_verb_share; regenerate it with the "
+            "current spike_workshop_measure.py (--divergence-metric mean_pairwise_jsd)"
+        )
+    fidelity = compute_fidelity(run_dir, audit_mode)
+    return seed_verdict(run_dir.name, gate_report, fidelity, role_by_name)
+
+
+def build_sweep(run_dirs: list[Path], audit_mode: str, roster_spec: str) -> dict[str, Any]:
+    role_by_name = parse_roster(roster_spec)
+    seeds = [read_seed(d, audit_mode, role_by_name) for d in run_dirs]
+    return {
+        "audit_mode": audit_mode,
+        "roster": roster_spec,
+        "thresholds": {
+            "mean_pairwise_floor": MEAN_PAIRWISE_FLOOR,
+            "cross_bleed_floor": CROSS_BLEED_FLOOR,
+            "cross_bleed_decimals": CROSS_BLEED_DECIMALS,
+            "fidelity_floor": FIDELITY_FLOOR,
+            "min_fidelity_events": MIN_FIDELITY_EVENTS,
+            "min_seeds_pass": MIN_SEEDS_PASS,
+        },
+        "seeds": seeds,
+        "sweep": sweep_verdict(seeds),
+    }
+
+
+# --- rendering --------------------------------------------------------------
+def render_table(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append(f"Sweep: {report['roster']}  (audit {report['audit_mode']})")
+    lines.append(f"{'seed':<22} {'L1 mpjsd':>9} {'L2':>4} {'fidelity':>9} {'status':>18}")
+    lines.append("-" * 66)
+    for s in report["seeds"]:
+        l1 = s["layer1"]
+        l1cell = f"{l1['mean_pairwise_jsd']:.4f}{'*' if l1['pass'] else ' '}"
+        l2cell = "ok" if s["layer2"]["pass"] else "X"
+        fidcell = "ok" if s["fidelity"]["pass"] else "X"
+        lines.append(f"{s['seed']:<22} {l1cell:>9} {l2cell:>4} {fidcell:>9} {s['status']:>18}")
+    sw = report["sweep"]
+    verdict = "PASS" if sw["pass"] else "FAIL"
+    lines.append("-" * 66)
+    lines.append(
+        f"SWEEP {verdict}: {sw['n_pass']}/{sw['n_total']} seeds pass "
+        f"(need >={sw['min_pass']}; {sw['n_instrument_invalid']} instrument-invalid)"
+    )
+    # Per-resident Layer-2 detail (cross-bleed is the usual culprit).
+    for s in report["seeds"]:
+        for name, r in s["layer2"]["per_resident"].items():
+            if not r["pass"]:
+                cb = r["cross_bleed"]
+                cb_s = "n/a" if cb is None else f"{cb:.4f} ({r['cross_bleed_verb']})"
+                lines.append(
+                    f"  L2 {s['seed']} {name}: top={r['top_non_contribute_verb']} "
+                    f"(want {r['specialty']}), cross_bleed={cb_s}, present={r['present']}"
+                )
+        if s["layer2"]["extra_agents"]:
+            extras = s["layer2"]["extra_agents"]
+            lines.append(f"  note {s['seed']}: extra agents (informational): {extras}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "dirs",
+        nargs="+",
+        help="sweep seed dirs (each with gate-report.json + episodic.sqlite)",
+    )
+    p.add_argument(
+        "--roster",
+        required=True,
+        help="MICROVERSE_ROSTER spec, e.g. artisan:Aki:100,scholar:Cy:70,stranger:Vesna:70",
+    )
+    p.add_argument(
+        "--audit-mode",
+        required=True,
+        help="replay_economy audit MODE[@TARGET], e.g. bal@42 (T=42 lever) or bal@30",
+    )
+    p.add_argument(
+        "--json-out",
+        default=None,
+        help="write the machine-readable sweep-verdict JSON to this path",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    report = build_sweep([Path(d) for d in args.dirs], args.audit_mode, args.roster)
+    print(render_table(report))
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2, sort_keys=True))
+        print(f"\nwrote {args.json_out}")
+    return 0 if report["sweep"]["pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_gate9_verb_diversity.py
+++ b/tests/test_gate9_verb_diversity.py
@@ -457,3 +457,32 @@ def test_parse_args_divergence_metric_accepts_mean_pairwise():
 def test_parse_args_divergence_metric_rejects_unknown():
     with pytest.raises(SystemExit):
         swm.parse_args(["--data", "d", "--harvest", "h", "--divergence-metric", "bogus"])
+
+
+# Layer 2 role-stability (sweep_report.py) needs the FULL per-agent verb
+# distribution, not just the top share, to compute cross-bleed. Export it.
+def test_gate9_per_agent_verb_share_full_distribution_sums_to_one():
+    rows = _dist_rows({"Aki": {"craft": 30, "contribute": 10}, "Cy": {"study": 40}})
+    g = swm.gate9_verb_diversity(_events_db(rows))
+    shares = g["chosen"]["per_agent_verb_share"]
+    assert set(shares) == {"Aki", "Cy"}
+    for dist in shares.values():
+        assert set(dist) == set(swm._VERBS)
+        assert sum(dist.values()) == pytest.approx(1.0, abs=1e-6)
+    assert shares["Aki"]["craft"] == pytest.approx(0.75, abs=1e-4)
+    assert shares["Aki"]["contribute"] == pytest.approx(0.25, abs=1e-4)
+    assert shares["Cy"]["study"] == pytest.approx(1.0, abs=1e-4)
+
+
+def test_gate9_per_agent_verb_share_max_matches_top_share():
+    rows = _dist_rows({"Aki": {"craft": 30, "contribute": 10}, "Cy": {"study": 40}})
+    chosen = swm.gate9_verb_diversity(_events_db(rows))["chosen"]
+    for agent, top in chosen["per_agent_top_share"].items():
+        assert max(chosen["per_agent_verb_share"][agent].values()) == pytest.approx(top, abs=1e-4)
+
+
+def test_diversity_block_per_agent_verb_share_zero_count_agent_is_all_zero():
+    from collections import Counter
+
+    block = swm._diversity_block({"Ghost": Counter()})
+    assert block["per_agent_verb_share"]["Ghost"] == dict.fromkeys(swm._VERBS, 0.0)

--- a/tests/test_sweep_report.py
+++ b/tests/test_sweep_report.py
@@ -1,0 +1,294 @@
+"""sweep_report: aggregate per-seed Gate-9 + fidelity reads into one sweep verdict.
+
+Unit-tests the pure verdict functions on synthetic dicts and a CLI smoke test
+that monkeypatches the heavy fidelity audit (which needs an episodic.sqlite).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parent.parent / "scripts" / "sweep_report.py"
+_spec = importlib.util.spec_from_file_location("sweep_report", _PATH)
+sr = importlib.util.module_from_spec(_spec)
+sys.modules["sweep_report"] = sr
+_spec.loader.exec_module(sr)
+
+_VERBS = ("speak", "craft", "study", "rest", "travel", "contribute")
+_ROLES = {"Aki": "artisan", "Cy": "scholar", "Vesna": "stranger"}
+
+
+def _share(**verbs: float) -> dict[str, float]:
+    base: dict[str, float] = dict.fromkeys(_VERBS, 0.0)
+    base.update(verbs)
+    return base
+
+
+_PASS_SHARES = {"Aki": _share(craft=1.0), "Cy": _share(study=1.0), "Vesna": _share(travel=1.0)}
+
+
+def _fid(
+    on: float | None = 0.95,
+    off: float | None = 0.97,
+    logged: float | None = 0.96,
+    on_ev: int = 50,
+    off_ev: int = 50,
+    logged_ev: int = 50,
+) -> dict:
+    return {
+        "rate": 0.96,
+        "events": on_ev + off_ev,
+        "agreements": 0,
+        "hint_on": {"events": on_ev, "agreements": 0, "rate": on},
+        "hint_off": {"events": off_ev, "agreements": 0, "rate": off},
+        "hint_logged": {"events": logged_ev, "agreements": 0, "rate": logged},
+    }
+
+
+def _gate_report(mpj: float, shares: dict) -> dict:
+    return {
+        "gate_9_verb_diversity": {
+            "chosen": {"mean_pairwise_jsd": mpj, "per_agent_verb_share": shares}
+        }
+    }
+
+
+# --- parse_roster ----------------------------------------------------------
+def test_parse_roster_maps_name_to_role():
+    r = sr.parse_roster("artisan:Aki:100,scholar:Cy:70,stranger:Vesna:70")
+    assert r == {"Aki": "artisan", "Cy": "scholar", "Vesna": "stranger"}
+
+
+def test_parse_roster_rejects_unknown_role():
+    with pytest.raises(ValueError, match="no defined specialty"):
+        sr.parse_roster("elder:Mara:50")
+
+
+def test_parse_roster_rejects_malformed_entry():
+    with pytest.raises(ValueError, match="role:name:tokens"):
+        sr.parse_roster("artisan:Aki")
+
+
+def test_parse_roster_rejects_duplicate_name():
+    with pytest.raises(ValueError, match="duplicate"):
+        sr.parse_roster("artisan:Aki:100,scholar:Aki:70")
+
+
+# --- role_stability (Layer 2) ---------------------------------------------
+def test_role_stability_disjoint_specialists_pass():
+    shares = {"Aki": _share(craft=1.0), "Cy": _share(study=1.0), "Vesna": _share(travel=1.0)}
+    out = sr.role_stability(shares, _ROLES)
+    assert out["pass"] is True
+    assert out["per_resident"]["Aki"]["top_non_contribute_verb"] == "craft"
+    assert out["per_resident"]["Aki"]["cross_bleed"] == 0.0
+
+
+def test_role_stability_contribute_dominant_but_specialty_topped_passes():
+    shares = {
+        "Aki": _share(contribute=0.6, craft=0.4),
+        "Cy": _share(contribute=0.6, study=0.4),
+        "Vesna": _share(contribute=0.6, travel=0.4),
+    }
+    out = sr.role_stability(shares, _ROLES)
+    assert out["pass"] is True
+    assert out["per_resident"]["Aki"]["is_specialty"] is True
+
+
+def test_role_stability_cross_bleed_above_floor_fails():
+    shares = {
+        "Aki": _share(contribute=0.5, craft=0.42, study=0.08),
+        "Cy": _share(study=1.0),
+        "Vesna": _share(travel=1.0),
+    }
+    out = sr.role_stability(shares, _ROLES)
+    assert out["per_resident"]["Aki"]["is_specialty"] is True
+    assert out["per_resident"]["Aki"]["cross_bleed"] == pytest.approx(0.08)
+    assert out["per_resident"]["Aki"]["pass"] is False
+    assert out["pass"] is False
+
+
+def test_role_stability_wrong_top_verb_fails():
+    shares = {
+        "Aki": _share(craft=1.0),
+        "Cy": _share(study=1.0),
+        "Vesna": _share(contribute=0.5, speak=0.4, travel=0.1),
+    }
+    out = sr.role_stability(shares, _ROLES)
+    assert out["per_resident"]["Vesna"]["top_non_contribute_verb"] == "speak"
+    assert out["per_resident"]["Vesna"]["is_specialty"] is False
+    assert out["pass"] is False
+
+
+def test_role_stability_reports_extra_agents_separately():
+    shares = {
+        "Aki": _share(craft=1.0),
+        "Cy": _share(study=1.0),
+        "Vesna": _share(travel=1.0),
+        "Wanderer": _share(travel=1.0),  # watchdog rehab stranger, not in roster
+    }
+    out = sr.role_stability(shares, _ROLES)
+    assert out["extra_agents"] == ["Wanderer"]
+    assert "Wanderer" not in out["per_resident"]
+    assert out["pass"] is True  # extras are informational, never gate
+
+
+def test_role_stability_missing_resident_fails():
+    shares = {"Aki": _share(craft=1.0), "Cy": _share(study=1.0)}  # Vesna absent
+    out = sr.role_stability(shares, _ROLES)
+    assert out["per_resident"]["Vesna"]["present"] is False
+    assert out["per_resident"]["Vesna"]["pass"] is False
+    assert out["pass"] is False
+
+
+def test_role_stability_cross_bleed_is_max_not_sum_of_other_specialties():
+    # Aki bleeds study 0.04 AND travel 0.04: sum=0.08 (>floor) but the binding
+    # single verb is 0.04 (<=floor). The locked rule (ADR 0018) is per-verb max,
+    # so this PASSES — guards against a regression to summing.
+    shares = {
+        "Aki": _share(contribute=0.5, craft=0.42, study=0.04, travel=0.04),
+        "Cy": _share(study=1.0),
+        "Vesna": _share(travel=1.0),
+    }
+    out = sr.role_stability(shares, _ROLES)
+    assert out["per_resident"]["Aki"]["cross_bleed"] == pytest.approx(0.04)
+    assert out["per_resident"]["Aki"]["pass"] is True
+    assert out["pass"] is True
+
+
+def test_role_stability_cross_bleed_at_floor_to_3dp_passes():
+    # ADR 0018 s202 boundary: raw 0.0504 rounds to 0.050 == floor -> PASS, matching
+    # the published adjudication precision (CROSS_BLEED_DECIMALS).
+    shares = {
+        "Aki": _share(contribute=0.5, craft=0.45, study=0.0504),
+        "Cy": _share(study=1.0),
+        "Vesna": _share(travel=1.0),
+    }
+    out = sr.role_stability(shares, _ROLES)
+    assert out["per_resident"]["Aki"]["cross_bleed"] == pytest.approx(0.0504)
+    assert out["per_resident"]["Aki"]["pass"] is True
+
+
+def test_role_stability_own_specialty_never_counts_as_cross_bleed():
+    # Two artisans share craft; an agent's OWN specialty must not be bled.
+    roles = {"Aki": "artisan", "Bo": "artisan", "Cy": "scholar"}
+    shares = {"Aki": _share(craft=1.0), "Bo": _share(craft=1.0), "Cy": _share(study=1.0)}
+    out = sr.role_stability(shares, roles)
+    assert out["per_resident"]["Aki"]["cross_bleed"] == 0.0
+    assert out["pass"] is True
+
+
+# --- fidelity_verdict ------------------------------------------------------
+def test_fidelity_verdict_pass():
+    assert sr.fidelity_verdict(_fid())["pass"] is True
+
+
+def test_fidelity_verdict_low_rate_fails():
+    out = sr.fidelity_verdict(_fid(on=0.80))
+    assert out["pass"] is False
+    assert out["subsets"]["hint_on"]["pass"] is False
+
+
+def test_fidelity_verdict_too_few_events_fails():
+    assert sr.fidelity_verdict(_fid(on_ev=3))["pass"] is False
+
+
+def test_fidelity_verdict_none_rate_fails():
+    assert sr.fidelity_verdict(_fid(on=None, on_ev=0))["pass"] is False
+
+
+# --- seed_verdict / sweep_verdict -----------------------------------------
+def test_seed_verdict_all_pass():
+    sv = sr.seed_verdict("s101", _gate_report(0.31, _PASS_SHARES), _fid(), _ROLES)
+    assert sv["pass"] is True
+    assert sv["layer1"]["pass"] is True
+    assert sv["status"] == "PASS"
+
+
+def test_seed_verdict_layer1_below_floor_fails():
+    sv = sr.seed_verdict("s101", _gate_report(0.20, _PASS_SHARES), _fid(), _ROLES)
+    assert sv["layer1"]["pass"] is False
+    assert sv["pass"] is False
+    assert sv["status"] == "FAIL"
+
+
+def test_seed_verdict_instrument_invalid_blocks_behavioral():
+    sv = sr.seed_verdict("s101", _gate_report(0.31, _PASS_SHARES), _fid(on=0.5), _ROLES)
+    assert sv["instrument_valid"] is False
+    assert sv["pass"] is False
+    assert sv["status"] == "INSTRUMENT-INVALID"
+
+
+def test_sweep_verdict_two_of_three_passes():
+    seeds = [
+        sr.seed_verdict("s101", _gate_report(0.31, _PASS_SHARES), _fid(), _ROLES),
+        sr.seed_verdict("s202", _gate_report(0.29, _PASS_SHARES), _fid(), _ROLES),
+        sr.seed_verdict("s303", _gate_report(0.20, _PASS_SHARES), _fid(), _ROLES),
+    ]
+    out = sr.sweep_verdict(seeds)
+    assert out["n_pass"] == 2
+    assert out["n_total"] == 3
+    assert out["pass"] is True
+
+
+def test_sweep_verdict_one_of_three_fails():
+    seeds = [
+        sr.seed_verdict("s101", _gate_report(0.31, _PASS_SHARES), _fid(), _ROLES),
+        sr.seed_verdict("s202", _gate_report(0.20, _PASS_SHARES), _fid(), _ROLES),
+        sr.seed_verdict("s303", _gate_report(0.20, _PASS_SHARES), _fid(), _ROLES),
+    ]
+    out = sr.sweep_verdict(seeds)
+    assert out["n_pass"] == 1
+    assert out["pass"] is False
+
+
+def test_thresholds_are_emitted_for_traceability():
+    sv = sr.seed_verdict("s101", _gate_report(0.31, _PASS_SHARES), _fid(), _ROLES)
+    assert sv["layer1"]["floor"] == sr.MEAN_PAIRWISE_FLOOR
+    assert sv["fidelity"]["floor"] == sr.FIDELITY_FLOOR
+
+
+# --- read_seed guard + CLI smoke ------------------------------------------
+def test_read_seed_raises_on_legacy_report_without_per_agent_share(tmp_path, monkeypatch):
+    (tmp_path / "gate-report.json").write_text(
+        json.dumps({"gate_9_verb_diversity": {"chosen": {"mean_pairwise_jsd": 0.31}}})
+    )
+    monkeypatch.setattr(sr, "compute_fidelity", lambda *a, **k: _fid())
+    with pytest.raises(ValueError, match="per_agent_verb_share"):
+        sr.read_seed(tmp_path, "bal@42", _ROLES)
+
+
+def test_main_smoke_writes_json_and_returns_zero(tmp_path, monkeypatch, capsys):
+    for seed, mpj in (("s101", 0.31), ("s202", 0.29), ("s303", 0.20)):
+        d = tmp_path / f"econ-x-{seed}"
+        d.mkdir()
+        (d / "gate-report.json").write_text(json.dumps(_gate_report(mpj, _PASS_SHARES)))
+    # Avoid the episodic.sqlite audit entirely.
+    monkeypatch.setattr(sr, "compute_fidelity", lambda *a, **k: _fid())
+    out_json = tmp_path / "sweep-verdict.json"
+    rc = sr.main(
+        [
+            str(tmp_path / "econ-x-s101"),
+            str(tmp_path / "econ-x-s202"),
+            str(tmp_path / "econ-x-s303"),
+            "--roster",
+            "artisan:Aki:100,scholar:Cy:70,stranger:Vesna:70",
+            "--audit-mode",
+            "bal@42",
+            "--json-out",
+            str(out_json),
+        ]
+    )
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert "PASS" in captured
+    obj = json.loads(out_json.read_text())
+    assert obj["sweep"]["pass"] is True
+    assert obj["sweep"]["n_pass"] == 2
+    # Anti-fork traceability: thresholds + audit mode recorded in the artifact.
+    assert obj["thresholds"]["mean_pairwise_floor"] == sr.MEAN_PAIRWISE_FLOOR
+    assert obj["audit_mode"] == "bal@42"


### PR DESCRIPTION
## Summary

Adds `scripts/sweep_report.py`, a one-shot tool that turns a sweep (N seed dirs of a lever) into a single Gate-9 verdict, replacing the manual per-sweep read repeated by hand across ADRs 0014-0018. This is the last open item (#5) on the action-economy Phase-2 tracker.

For each seed dir it reads `gate-report.json` (Layer 1 `mean_pairwise_jsd` + Layer 2 role stability) and runs the `replay_economy` fidelity audit, then aggregates to the locked ≥2/3-seeds rule and emits a human table **and** a `sweep-verdict.json` from one internal object.

```
Sweep: artisan:Aki:100,scholar:Cy:70,stranger:Vesna:70  (audit bal@42)
seed                    L1 mpjsd   L2  fidelity             status
------------------------------------------------------------------
econ-r3bal42-s101        0.3053*    X        ok               FAIL
econ-r3bal42-s202        0.2990*   ok        ok               PASS
econ-r3bal42-s303        0.3261*   ok        ok               PASS
------------------------------------------------------------------
SWEEP PASS: 2/3 seeds pass (need >=2; 0 instrument-invalid)
  L2 econ-r3bal42-s101 Aki: top=craft (want craft), cross_bleed=0.0702 (study), present=True
```

## Background / Motivation

Reading a sweep into a PASS/FAIL verdict was a manual ritual: run `spike_workshop_measure.py` per dir (Layer 1), run `replay_economy.py --audit` per dir (instrument fidelity), eyeball Layer 2 role stability (each resident's top non-`contribute` verb == its specialty, cross-bleed ≤ 0.05), then hand-aggregate to ≥2/3 seeds. Error-prone and not reproducible. Item 5 asked to automate it so verdicts are traceable, not retyped per ADR.

**Verified gap:** today's `gate-report.json` exported `per_agent_top_share` (top share only), not the full per-agent verb distribution Layer 2 cross-bleed needs. So the report had to be extended before a pure aggregator could compute Layer 2.

## What changed

- **`scripts/spike_workshop_measure.py`** — `_diversity_block` now also emits `per_agent_verb_share` (full normalized per-agent verb distribution, reusing `_normalize`). Additive, backward-compatible.
- **`scripts/sweep_report.py`** (new) — pure, unit-tested functions (`parse_roster`, `role_stability`, `fidelity_verdict`, `seed_verdict`, `sweep_verdict`) + a thin CLI. Reuses `replay_economy`'s `parse_audit_spec` / `_audit_trace_from_episodic` / `audit_run` for the fidelity read (no duplication, live default energy knobs).
- **`pyproject.toml`** — `sweep_report.py` added to the explicit per-file T20 (print) allowlist, consistent with the other operator scripts.

## Design & Reasoning Notes

- **Approach A (Codex-confirmed):** extend the authoritative measure script + add a thin aggregator, rather than a second metrics source of truth.
- **Anti-fork:** the locked floors (`MEAN_PAIRWISE_FLOOR=0.25` ADR 0016, `CROSS_BLEED_FLOOR=0.05`, `FIDELITY_FLOOR=0.90` ADR 0014, `MIN_SEEDS_PASS=2`) are named constants citing their runbooks and are echoed into `sweep-verdict.json` so every artifact records the criteria it was judged against. The tool *implements* the locked rules; it does not change them.
- **Cross-bleed = single binding other-specialty verb (per-verb MAX, not sum)**, adjudicated at 3-dp precision to match the ADR 0018 findings (s202 Aki `study` raw 0.0504 → 0.050, judged at-floor PASS). This was caught by the real-data positive control: an initial sum-based implementation forked the published verdict (1/3); the per-verb-max + 3-dp reading reproduces it (2/3). A discriminating unit test pins the definition.
- **Layer 2 covers roster-named residents only;** Watchdog rehab Strangers are reported as `extra_agents` (informational), matching the hand read.

## Testing

- New `tests/test_sweep_report.py` (25 cases): each pure function on synthetic dicts (disjoint specialists, contribute-dominant-but-specialty-topped, cross-bleed above/at floor, wrong top verb, extra agents, missing resident, own-specialty exclusion, sum-vs-max, 2/3 vs 1/3 sweep) + a CLI smoke test (monkeypatched audit) asserting table output + JSON thresholds traceability.
- Extended `tests/test_gate9_verb_diversity.py` for `per_agent_verb_share`.
- **Real-data validation** against local sweeps: `bal@42` → PASS 2/3 (matches ADR 0018), `roster-r3` baseline → FAIL 0/3 with L1 0.207/0.206/0.223 (matches ADR 0015/0016).
- Full offline gate green: ruff, ruff format, mypy (`src/microverse`), pip-audit, **770 pytest passed**, `uv build`.

## Documentation

The tool's module docstring documents usage and contracts. README/AGENTS don't document the sibling sweep scripts (`spike_workshop_measure`, `replay_economy`) either — they rely on docstrings — so a docstring is the consistent home; adding a README section for one script would be inconsistent. No ADR: this is tooling/DX, not a measurement decision (it implements existing locked rules).

## Post-Merge Recommendations

- Future sweeps can write `sweep-verdict.json` straight into the run/ADR artifacts via `--json-out`.
- If a future ADR tightens Layer 2 (e.g. the structural Aki `study` cross-bleed at the floor), update `CROSS_BLEED_FLOOR`/`CROSS_BLEED_DECIMALS` as a reviewed code+docs change, never a CLI flag.